### PR TITLE
Update MATCHES operators descriptions to mention 'regex'

### DIFF
--- a/src/main/java/com/czertainly/api/model/core/search/FilterConditionOperator.java
+++ b/src/main/java/com/czertainly/api/model/core/search/FilterConditionOperator.java
@@ -28,13 +28,7 @@ public enum FilterConditionOperator implements IPlatformEnum {
     COUNT_EQUAL("COUNT_EQUAL", "count equals", "ce"),
     COUNT_NOT_EQUAL("COUNT_NOT_EQUAL", "count not equals", "cne"),
     COUNT_GREATER_THAN("COUNT_GREATER_THAN", "count greater than", "cge"),
-    COUNT_LESS_THAN("COUNT_LESS_THAN", "count less than", "cle"),
-    // TODO: remove following
-    SUCCESS("SUCCESS", "success", "success"),
-    FAILED("FAILED", "failed", "failed"),
-    UNKNOWN("UNKNOWN", "unknown", "unknown"),
-    NOT_CHECKED("NOT_CHECKED", "not checked", "notchecked"),
-    ;
+    COUNT_LESS_THAN("COUNT_LESS_THAN", "count less than", "cle");
 
     private static final FilterConditionOperator[] VALUES;
 
@@ -48,7 +42,7 @@ public enum FilterConditionOperator implements IPlatformEnum {
     private final String queryCode;
 
     FilterConditionOperator(String code, String label, String queryCode) {
-        this(code, label,null, queryCode);
+        this(code, label, null, queryCode);
     }
 
     FilterConditionOperator(String code, String label, String description, String queryCode) {


### PR DESCRIPTION
Changed the descriptions for MATCHES and NOT_MATCHES operators to clarify that they refer to regex matching instead of generic matching.