### PR TITLE
feat: add SaaS support with message queue proxy and extended APIs

### DIFF
--- a/src/main/java/com/czertainly/api/clients/ApiClientConnectorInfo.java
+++ b/src/main/java/com/czertainly/api/clients/ApiClientConnectorInfo.java
@@ -3,6 +3,7 @@ package com.czertainly.api.clients;
 import com.czertainly.api.model.client.attribute.ResponseAttribute;
 import com.czertainly.api.model.core.connector.AuthType;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 
 import java.io.Serializable;
 import java.util.List;
@@ -20,5 +21,7 @@ public interface ApiClientConnectorInfo extends Serializable {
     AuthType getAuthType();
 
     List<ResponseAttribute> getAuthAttributes();
+
+    ProxyDto getProxy();
 
 }

--- a/src/main/java/com/czertainly/api/clients/AttributeApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/AttributeApiClient.java
@@ -1,12 +1,12 @@
 package com.czertainly.api.clients;
 
+import com.czertainly.api.interfaces.client.v1.AttributeSyncApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.common.attribute.common.callback.AttributeCallback;
 import com.czertainly.api.model.common.attribute.common.callback.RequestAttributeCallback;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class AttributeApiClient extends BaseApiClient {
+public class AttributeApiClient extends BaseApiClient implements AttributeSyncApiClient {
 
     private static final String ATTRIBUTE_BASE_CONTEXT = "/v1/{functionGroup}/{kind}/attributes";
     private static final String ATTRIBUTE_VALIDATION_CONTEXT = ATTRIBUTE_BASE_CONTEXT + "/validate";
@@ -35,7 +35,7 @@ public class AttributeApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<BaseAttribute> listAttributeDefinitions(ConnectorDto connector, FunctionGroupCode functionGroupCode, String kind) throws ConnectorException {
+    public List<BaseAttribute> listAttributeDefinitions(ApiClientConnectorInfo connector, FunctionGroupCode functionGroupCode, String kind) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 
         return processRequest(r -> r
@@ -47,7 +47,7 @@ public class AttributeApiClient extends BaseApiClient {
                 connector);
     }
 
-    public Void validateAttributes(ConnectorDto connector, FunctionGroupCode functionGroupCode, List<RequestAttribute> attributes, String functionGroupType) throws ValidationException, ConnectorException {
+    public Void validateAttributes(ApiClientConnectorInfo connector, FunctionGroupCode functionGroupCode, List<RequestAttribute> attributes, String functionGroupType) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -60,7 +60,7 @@ public class AttributeApiClient extends BaseApiClient {
                 connector);
     }
 
-    public Object attributeCallback(ConnectorDto connector, AttributeCallback callback, RequestAttributeCallback callbackRequest) throws ConnectorException {
+    public Object attributeCallback(ApiClientConnectorInfo connector, AttributeCallback callback, RequestAttributeCallback callbackRequest) throws ConnectorException {
         HttpMethod method = HttpMethod.valueOf(callback.getCallbackMethod());
 
         URI uri;

--- a/src/main/java/com/czertainly/api/clients/AuthorityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/AuthorityInstanceApiClient.java
@@ -4,24 +4,24 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
-import com.czertainly.api.model.common.attribute.v2.BaseAttributeV2;
 import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceDto;
 import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceRequestDto;
 import com.czertainly.api.model.connector.authority.CertificateRevocationListRequestDto;
 import com.czertainly.api.model.connector.authority.CertificateRevocationListResponseDto;
 import com.czertainly.api.model.connector.authority.CaCertificatesRequestDto;
 import com.czertainly.api.model.connector.authority.CaCertificatesResponseDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import com.czertainly.api.interfaces.client.v1.AuthorityInstanceSyncApiClient;
+
 import javax.net.ssl.TrustManager;
 import java.util.List;
 import java.util.Objects;
 
-public class AuthorityInstanceApiClient extends BaseApiClient {
+public class AuthorityInstanceApiClient extends BaseApiClient implements AuthorityInstanceSyncApiClient {
 
     private static final String AUTHORITY_INSTANCE_BASE_CONTEXT = "/v1/authorityProvider/authorities";
     private static final String AUTHORITY_INSTANCE_IDENTIFIED_CONTEXT = AUTHORITY_INSTANCE_BASE_CONTEXT + "/{uuid}";
@@ -38,7 +38,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<AuthorityProviderInstanceDto> listAuthorityInstances(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public List<AuthorityProviderInstanceDto> listAuthorityInstances(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -50,7 +51,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public AuthorityProviderInstanceDto getAuthorityInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public AuthorityProviderInstanceDto getAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -62,7 +64,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public AuthorityProviderInstanceDto createAuthorityInstance(ConnectorDto connector, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public AuthorityProviderInstanceDto createAuthorityInstance(ApiClientConnectorInfo connector, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -76,7 +79,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
 
-    public AuthorityProviderInstanceDto updateAuthorityInstance(ConnectorDto connector, String uuid, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public AuthorityProviderInstanceDto updateAuthorityInstance(ApiClientConnectorInfo connector, String uuid, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -89,7 +93,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void removeAuthorityInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public void removeAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
@@ -102,7 +107,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
 
-    public List<BaseAttribute> listRAProfileAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listRAProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -114,7 +120,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public Boolean validateRAProfileAttributes(ConnectorDto connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public Boolean validateRAProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -127,7 +134,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public CertificateRevocationListResponseDto getCrl(ConnectorDto connector, String uuid, CertificateRevocationListRequestDto requestDto) throws ConnectorException {
+    @Override
+    public CertificateRevocationListResponseDto getCrl(ApiClientConnectorInfo connector, String uuid, CertificateRevocationListRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> Objects.requireNonNull(r
@@ -140,7 +148,8 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public CaCertificatesResponseDto getCaCertificates(ConnectorDto connector, String uuid, CaCertificatesRequestDto requestDto) throws ValidationException, ConnectorException {
+    @Override
+    public CaCertificatesResponseDto getCaCertificates(ApiClientConnectorInfo connector, String uuid, CaCertificatesRequestDto requestDto) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> Objects.requireNonNull(r

--- a/src/main/java/com/czertainly/api/clients/BaseApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/BaseApiClient.java
@@ -5,7 +5,6 @@ import com.czertainly.api.model.client.attribute.ResponseAttribute;
 import com.czertainly.api.model.common.attribute.common.AttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.FileAttributeContentV2;
 import com.czertainly.api.model.common.error.ProblemDetailExtended;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.KeyStoreUtils;

--- a/src/main/java/com/czertainly/api/clients/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/CertificateApiClient.java
@@ -1,17 +1,17 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.CertificateSyncApiClient;
 import com.czertainly.api.model.core.authority.CertRevocationDto;
 import com.czertainly.api.model.core.authority.CertificateSignRequestDto;
 import com.czertainly.api.model.core.authority.CertificateSignResponseDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import javax.net.ssl.TrustManager;
 
-public class CertificateApiClient extends BaseApiClient {
+public class CertificateApiClient extends BaseApiClient implements CertificateSyncApiClient {
 
     private static final String CERTIFICATE_BASE_CONTEXT = "/v1/authorityProvider/authorities/{uuid}/endEntityProfiles/{endEntityProfileName}/certificates";
     private static final String CERTIFICATE_ISSUE_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/issue";
@@ -22,7 +22,8 @@ public class CertificateApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public CertificateSignResponseDto issueCertificate(ConnectorDto connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) throws ConnectorException {
+    @Override
+    public CertificateSignResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -35,7 +36,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void revokeCertificate(ConnectorDto connector, String authorityUuid, String endEntityProfileName, CertRevocationDto requestDto) throws ConnectorException {
+    @Override
+    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertRevocationDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/ComplianceApiClient.java
@@ -1,11 +1,11 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.ComplianceSyncApiClient;
 import com.czertainly.api.model.connector.compliance.ComplianceGroupsResponseDto;
 import com.czertainly.api.model.connector.compliance.ComplianceRequestDto;
 import com.czertainly.api.model.connector.compliance.ComplianceResponseDto;
 import com.czertainly.api.model.connector.compliance.ComplianceRulesResponseDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
@@ -16,7 +16,7 @@ import javax.net.ssl.TrustManager;
 import java.net.URI;
 import java.util.List;
 
-public class ComplianceApiClient extends BaseApiClient {
+public class ComplianceApiClient extends BaseApiClient implements ComplianceSyncApiClient {
 
     private static final String COMPLIANCE_BASE_CONTEXT = "/v1/complianceProvider/{kind}";
     private static final String COMPLIANCE_RULE_GET_CONTEXT = COMPLIANCE_BASE_CONTEXT + "/rules";
@@ -32,7 +32,8 @@ public class ComplianceApiClient extends BaseApiClient {
     }
 
 
-    public List<ComplianceRulesResponseDto> getComplianceRules(ConnectorDto connector, String kind, List<String> certificateType) throws ConnectorException {
+    @Override
+    public List<ComplianceRulesResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, List<String> certificateType) throws ConnectorException {
         URI uri;
         UriBuilder uriBuilder = UriComponentsBuilder.fromUriString(connector.getUrl());
         uriBuilder.path(COMPLIANCE_RULE_GET_CONTEXT.replace("{kind}", kind));
@@ -54,7 +55,8 @@ public class ComplianceApiClient extends BaseApiClient {
     }
 
 
-    public List<ComplianceGroupsResponseDto> getComplianceGroups(ConnectorDto connector, String kind) throws ConnectorException {
+    @Override
+    public List<ComplianceGroupsResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -67,7 +69,8 @@ public class ComplianceApiClient extends BaseApiClient {
     }
 
 
-    public List<ComplianceRulesResponseDto> getComplianceGroupRules(ConnectorDto connector, String kind, String uuid) throws ConnectorException {
+    @Override
+    public List<ComplianceRulesResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -79,7 +82,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public ComplianceResponseDto checkCompliance(ConnectorDto connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/ConnectorApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/ConnectorApiClient.java
@@ -1,5 +1,6 @@
 package com.czertainly.api.clients;
 
+import com.czertainly.api.interfaces.client.v1.ConnectorSyncApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.model.client.connector.InfoResponse;
 import org.springframework.core.ParameterizedTypeReference;
@@ -9,7 +10,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class ConnectorApiClient extends BaseApiClient {
+public class ConnectorApiClient extends BaseApiClient implements ConnectorSyncApiClient {
 
     private static final String CONNECTOR_BASE_CONTEXT = "/v1";
 
@@ -21,6 +22,7 @@ public class ConnectorApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
+    @Override
     public List<InfoResponse> listSupportedFunctions(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 

--- a/src/main/java/com/czertainly/api/clients/DiscoveryApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/DiscoveryApiClient.java
@@ -1,17 +1,17 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.DiscoverySyncApiClient;
 import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
 import com.czertainly.api.model.connector.discovery.DiscoveryProviderDto;
 import com.czertainly.api.model.connector.discovery.DiscoveryRequestDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import javax.net.ssl.TrustManager;
 
-public class DiscoveryApiClient extends BaseApiClient {
+public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncApiClient {
 
     private static final String DISCOVERY_BASE_CONTEXT = "/v1/discoveryProvider/discover";
     private static final String DISCOVERY_GET_CONTEXT = DISCOVERY_BASE_CONTEXT + "/{uuid}";
@@ -22,7 +22,8 @@ public class DiscoveryApiClient extends BaseApiClient {
     }
 
 
-    public DiscoveryProviderDto discoverCertificates(ConnectorDto connector, DiscoveryRequestDto requestDto) throws ConnectorException {
+    @Override
+    public DiscoveryProviderDto discoverCertificates(ApiClientConnectorInfo connector, DiscoveryRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -35,7 +36,8 @@ public class DiscoveryApiClient extends BaseApiClient {
                 connector);
     }
 
-    public DiscoveryProviderDto getDiscoveryData(ConnectorDto connector, DiscoveryDataRequestDto requestDto, String uuid) throws ConnectorException {
+    @Override
+    public DiscoveryProviderDto getDiscoveryData(ApiClientConnectorInfo connector, DiscoveryDataRequestDto requestDto, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -48,7 +50,8 @@ public class DiscoveryApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void removeDiscovery(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public void removeDiscovery(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/EndEntityApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EndEntityApiClient.java
@@ -1,10 +1,10 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.EndEntitySyncApiClient;
 import com.czertainly.api.model.core.authority.AddEndEntityRequestDto;
 import com.czertainly.api.model.core.authority.EditEndEntityRequestDto;
 import com.czertainly.api.model.core.authority.EndEntityDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class EndEntityApiClient extends BaseApiClient {
+public class EndEntityApiClient extends BaseApiClient implements EndEntitySyncApiClient {
 
     private static final String END_ENTITY_BASE_CONTEXT = "/v1/authorityProvider/authorities/{uuid}/endEntityProfiles/{endEntityProfileName}/endEntities";
     private static final String END_ENTITY_IDENTIFIED_CONTEXT = END_ENTITY_BASE_CONTEXT + "/{endEntityName}";
@@ -23,7 +23,8 @@ public class EndEntityApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<EndEntityDto> listEntities(ConnectorDto connector, String authorityUuid, String endEntityProfileName) throws ConnectorException {
+    @Override
+    public List<EndEntityDto> listEntities(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -35,7 +36,8 @@ public class EndEntityApiClient extends BaseApiClient {
                 connector);
     }
 
-    public EndEntityDto getEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+    @Override
+    public EndEntityDto getEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -47,7 +49,8 @@ public class EndEntityApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void createEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, AddEndEntityRequestDto requestDto) throws ConnectorException {
+    @Override
+    public void createEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, AddEndEntityRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -60,7 +63,8 @@ public class EndEntityApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void updateEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName, EditEndEntityRequestDto requestDto) throws ConnectorException {
+    @Override
+    public void updateEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName, EditEndEntityRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -73,7 +77,8 @@ public class EndEntityApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void revokeAndDeleteEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+    @Override
+    public void revokeAndDeleteEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
@@ -85,7 +90,8 @@ public class EndEntityApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void resetPassword(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+    @Override
+    public void resetPassword(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/EndEntityProfileApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EndEntityProfileApiClient.java
@@ -1,15 +1,15 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.EndEntityProfileSyncApiClient;
 import com.czertainly.api.model.common.NameAndIdDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class EndEntityProfileApiClient extends BaseApiClient {
+public class EndEntityProfileApiClient extends BaseApiClient implements EndEntityProfileSyncApiClient {
 
     private static final String END_ENTITY_PROFILE_BASE_CONTEXT = "/v1/authorityProvider/authorities/{uuid}/endEntityProfiles";
     private static final String END_ENTITY_PROFILE_IDENTIFIED_CONTEXT = END_ENTITY_PROFILE_BASE_CONTEXT + "/{endEntityProfileId}";
@@ -21,7 +21,8 @@ public class EndEntityProfileApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<NameAndIdDto> listEndEntityProfiles(ConnectorDto connector, String authorityUuid) throws ConnectorException {
+    @Override
+    public List<NameAndIdDto> listEndEntityProfiles(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -33,7 +34,8 @@ public class EndEntityProfileApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<NameAndIdDto> listCertificateProfiles(ConnectorDto connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
+    @Override
+    public List<NameAndIdDto> listCertificateProfiles(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -45,7 +47,8 @@ public class EndEntityProfileApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<NameAndIdDto> listCAsInProfile(ConnectorDto connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
+    @Override
+    public List<NameAndIdDto> listCAsInProfile(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/EntityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EntityInstanceApiClient.java
@@ -4,19 +4,19 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
-import com.czertainly.api.model.common.attribute.v2.BaseAttributeV2;
 import com.czertainly.api.model.connector.entity.EntityInstanceDto;
 import com.czertainly.api.model.connector.entity.EntityInstanceRequestDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import com.czertainly.api.interfaces.client.v1.EntityInstanceSyncApiClient;
+
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class EntityInstanceApiClient extends BaseApiClient {
+public class EntityInstanceApiClient extends BaseApiClient implements EntityInstanceSyncApiClient {
 
     private static final String ENTITY_INSTANCE_BASE_CONTEXT = "/v1/entityProvider/entities";
     private static final String ENTITY_INSTANCE_IDENTIFIED_CONTEXT = ENTITY_INSTANCE_BASE_CONTEXT + "/{entityUuid}";
@@ -31,7 +31,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<EntityInstanceDto> listEntityInstances(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public List<EntityInstanceDto> listEntityInstances(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -43,7 +44,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public EntityInstanceDto getEntityInstance(ConnectorDto connector, String entityUuid) throws ConnectorException {
+    @Override
+    public EntityInstanceDto getEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -55,7 +57,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public EntityInstanceDto createEntityInstance(ConnectorDto connector, EntityInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public EntityInstanceDto createEntityInstance(ApiClientConnectorInfo connector, EntityInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -68,7 +71,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public EntityInstanceDto updateEntityInstance(ConnectorDto connector, String entityUuid, EntityInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public EntityInstanceDto updateEntityInstance(ApiClientConnectorInfo connector, String entityUuid, EntityInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector, true);
 
         return processRequest(r -> r
@@ -81,7 +85,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void removeEntityInstance(ConnectorDto connector, String entityUuid) throws ConnectorException {
+    @Override
+    public void removeEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
@@ -94,7 +99,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
 
-    public List<BaseAttribute> listLocationAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listLocationAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -106,7 +112,8 @@ public class EntityInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateLocationAttributes(ConnectorDto connector, String entityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateLocationAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/HealthApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/HealthApiClient.java
@@ -1,5 +1,6 @@
 package com.czertainly.api.clients;
 
+import com.czertainly.api.interfaces.client.v1.HealthSyncApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.model.common.HealthDto;
 import org.springframework.http.HttpMethod;
@@ -7,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.TrustManager;
 
-public class HealthApiClient extends BaseApiClient {
+public class HealthApiClient extends BaseApiClient implements HealthSyncApiClient {
 
     private static final String HEALTH_BASE_CONTEXT = "/v1/health";
 
@@ -16,6 +17,7 @@ public class HealthApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
+    @Override
     public HealthDto checkHealth(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 

--- a/src/main/java/com/czertainly/api/clients/LocationApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/LocationApiClient.java
@@ -4,16 +4,17 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.entity.*;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import com.czertainly.api.interfaces.client.v1.LocationSyncApiClient;
+
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class LocationApiClient extends BaseApiClient {
+public class LocationApiClient extends BaseApiClient implements LocationSyncApiClient {
 
     private static final String LOCATION_BASE_CONTEXT = "/v1/entityProvider/entities/{entityUuid}/locations";
     private static final String LOCATION_PUSH_CONTEXT = LOCATION_BASE_CONTEXT + "/push";
@@ -32,7 +33,8 @@ public class LocationApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public LocationDetailResponseDto getLocationDetail(ConnectorDto connector, String entityUuid, LocationDetailRequestDto requestDto) throws ConnectorException {
+    @Override
+    public LocationDetailResponseDto getLocationDetail(ApiClientConnectorInfo connector, String entityUuid, LocationDetailRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -45,7 +47,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public PushCertificateResponseDto pushCertificateToLocation(ConnectorDto connector, String entityUuid, PushCertificateRequestDto requestDto) throws ConnectorException {
+    @Override
+    public PushCertificateResponseDto pushCertificateToLocation(ApiClientConnectorInfo connector, String entityUuid, PushCertificateRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -58,7 +61,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listPushCertificateAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listPushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -70,7 +74,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validatePushCertificateAttributes(ConnectorDto connector, String entityUuid, List<RequestAttribute>pushAttributes) throws ConnectorException {
+    @Override
+    public void validatePushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -83,7 +88,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public RemoveCertificateResponseDto removeCertificateFromLocation(ConnectorDto connector, String entityUuid, RemoveCertificateRequestDto requestDto) throws ConnectorException {
+    @Override
+    public RemoveCertificateResponseDto removeCertificateFromLocation(ApiClientConnectorInfo connector, String entityUuid, RemoveCertificateRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -96,7 +102,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public GenerateCsrResponseDto generateCsrLocation(ConnectorDto connector, String entityUuid, GenerateCsrRequestDto requestDto) throws ConnectorException {
+    @Override
+    public GenerateCsrResponseDto generateCsrLocation(ApiClientConnectorInfo connector, String entityUuid, GenerateCsrRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -109,7 +116,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listGenerateCsrAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -121,7 +129,8 @@ public class LocationApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateGenerateCsrAttributes(ConnectorDto connector, String entityUuid, List<RequestAttribute>pushAttributes) throws ConnectorException {
+    @Override
+    public void validateGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/NotificationInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/NotificationInstanceApiClient.java
@@ -1,11 +1,11 @@
 package com.czertainly.api.clients;
 
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.NotificationInstanceSyncApiClient;
 import com.czertainly.api.model.common.attribute.common.DataAttribute;
 import com.czertainly.api.model.connector.notification.NotificationProviderInstanceDto;
 import com.czertainly.api.model.connector.notification.NotificationProviderInstanceRequestDto;
 import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,7 +15,7 @@ import javax.net.ssl.TrustManager;
 import java.util.List;
 import java.util.Objects;
 
-public class NotificationInstanceApiClient extends BaseApiClient {
+public class NotificationInstanceApiClient extends BaseApiClient implements NotificationInstanceSyncApiClient {
 
     private static final String NOTIFICATION_INSTANCE_BASE_CONTEXT = "/v1/notificationProvider/notifications";
     private static final String NOTIFICATION_INSTANCE_IDENTIFIED_CONTEXT = NOTIFICATION_INSTANCE_BASE_CONTEXT + "/{uuid}";
@@ -28,7 +28,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<NotificationProviderInstanceDto> listNotificationInstances(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public List<NotificationProviderInstanceDto> listNotificationInstances(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_BASE_CONTEXT)
@@ -38,7 +39,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
                 .getBody(), request, connector);
     }
 
-    public NotificationProviderInstanceDto getNotificationInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public NotificationProviderInstanceDto getNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -48,7 +50,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
                 .getBody(), request, connector);
     }
 
-    public NotificationProviderInstanceDto createNotificationInstance(ConnectorDto connector, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public NotificationProviderInstanceDto createNotificationInstance(ApiClientConnectorInfo connector, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_BASE_CONTEXT)
@@ -60,7 +63,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
     }
 
 
-    public NotificationProviderInstanceDto updateNotificationInstance(ConnectorDto connector, String uuid, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public NotificationProviderInstanceDto updateNotificationInstance(ApiClientConnectorInfo connector, String uuid, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector, true);
 
         return processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -71,7 +75,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
                 .getBody(), request, connector);
     }
 
-    public void removeNotificationInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public void removeNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -82,7 +87,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
     }
 
 
-    public void sendNotification(ConnectorDto connector, String uuid, NotificationProviderNotifyRequestDto requestDto) throws ConnectorException {
+    @Override
+    public void sendNotification(ApiClientConnectorInfo connector, String uuid, NotificationProviderNotifyRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_IDENTIFIED_SEND_CONTEXT, uuid)
@@ -93,7 +99,8 @@ public class NotificationInstanceApiClient extends BaseApiClient {
                 .getBody(), request, connector);
     }
 
-    public List<DataAttribute> listMappingAttributes(ConnectorDto connector, String kind) throws ConnectorException {
+    @Override
+    public List<DataAttribute> listMappingAttributes(ApiClientConnectorInfo connector, String kind) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> Objects.requireNonNull(r.uri(connector.getUrl() + NOTIFICATION_INSTANCE_MAPPING_ATTRIBUTES_CONTEXT, kind)

--- a/src/main/java/com/czertainly/api/clients/cryptography/CryptographicOperationsApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/cryptography/CryptographicOperationsApiClient.java
@@ -1,12 +1,13 @@
 package com.czertainly.api.clients.cryptography;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.CryptographicOperationsSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.cryptography.operations.*;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,7 +16,7 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class CryptographicOperationsApiClient extends BaseApiClient {
+public class CryptographicOperationsApiClient extends BaseApiClient implements CryptographicOperationsSyncApiClient {
 
     private static final String CRYPTOP_BASE_CONTEXT = "/v1/cryptographyProvider/tokens/{uuid}/keys";
     private static final String CRYPTOP_ENCRYPT_CONTEXT = CRYPTOP_BASE_CONTEXT + "/{keyUuid}/encrypt";
@@ -34,7 +35,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public EncryptDataResponseDto encryptData(ConnectorDto connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
+    @Override
+    public EncryptDataResponseDto encryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -47,7 +49,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
                 connector);
     }
 
-    public DecryptDataResponseDto decryptData(ConnectorDto connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
+    @Override
+    public DecryptDataResponseDto decryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -61,7 +64,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
     }
 
 
-    public SignDataResponseDto signData(ConnectorDto connector, String uuid, String keyUuid, SignDataRequestDto requestDto) throws ConnectorException {
+    @Override
+    public SignDataResponseDto signData(ApiClientConnectorInfo connector, String uuid, String keyUuid, SignDataRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -74,7 +78,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
                 connector);
     }
 
-    public VerifyDataResponseDto verifyData(ConnectorDto connector, String uuid, String keyUuid, VerifyDataRequestDto requestDto) throws ConnectorException {
+    @Override
+    public VerifyDataResponseDto verifyData(ApiClientConnectorInfo connector, String uuid, String keyUuid, VerifyDataRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -87,7 +92,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listRandomAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listRandomAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -99,7 +105,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateRandomAttributes(ConnectorDto connector, String uuid, List<RequestAttribute>attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateRandomAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -112,7 +119,8 @@ public class CryptographicOperationsApiClient extends BaseApiClient {
                 connector);
     }
 
-    public RandomDataResponseDto randomData(ConnectorDto connector, String uuid, RandomDataRequestDto requestDto) throws ConnectorException {
+    @Override
+    public RandomDataResponseDto randomData(ApiClientConnectorInfo connector, String uuid, RandomDataRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/cryptography/KeyManagementApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/cryptography/KeyManagementApiClient.java
@@ -1,14 +1,15 @@
 package com.czertainly.api.clients.cryptography;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.KeyManagementSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
 import com.czertainly.api.model.connector.cryptography.key.KeyDataResponseDto;
 import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -17,7 +18,7 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class KeyManagementApiClient extends BaseApiClient {
+public class KeyManagementApiClient extends BaseApiClient implements KeyManagementSyncApiClient {
 
     private static final String KEY_BASE_CONTEXT = "/v1/cryptographyProvider/tokens/{uuid}/keys";
     private static final String KEY_CREATE_SECRET_KEY_CONTEXT = KEY_BASE_CONTEXT + "/secret";
@@ -37,7 +38,8 @@ public class KeyManagementApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<BaseAttribute> listCreateSecretKeyAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -49,7 +51,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateCreateSecretKeyAttributes(ConnectorDto connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -62,7 +65,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public KeyDataResponseDto createSecretKey(ConnectorDto connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
+    @Override
+    public KeyDataResponseDto createSecretKey(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -75,7 +79,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listCreateKeyPairAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -87,7 +92,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateCreateKeyPairAttributes(ConnectorDto connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -100,7 +106,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public KeyPairDataResponseDto createKeyPair(ConnectorDto connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
+    @Override
+    public KeyPairDataResponseDto createKeyPair(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -113,7 +120,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<KeyDataResponseDto> listKeys(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<KeyDataResponseDto> listKeys(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -125,7 +133,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public KeyDataResponseDto getKey(ConnectorDto connector, String uuid, String keyUuid) throws ConnectorException {
+    @Override
+    public KeyDataResponseDto getKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -137,7 +146,8 @@ public class KeyManagementApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void destroyKey(ConnectorDto connector, String uuid, String keyUuid) throws ConnectorException {
+    @Override
+    public void destroyKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/cryptography/TokenInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/cryptography/TokenInstanceApiClient.java
@@ -1,14 +1,15 @@
 package com.czertainly.api.clients.cryptography;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.TokenInstanceSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.cryptography.token.TokenInstanceDto;
 import com.czertainly.api.model.connector.cryptography.token.TokenInstanceRequestDto;
 import com.czertainly.api.model.connector.cryptography.token.TokenInstanceStatusDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -17,7 +18,7 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class TokenInstanceApiClient extends BaseApiClient {
+public class TokenInstanceApiClient extends BaseApiClient implements TokenInstanceSyncApiClient {
 
     private static final String TOKEN_INSTANCE_BASE_CONTEXT = "/v1/cryptographyProvider/tokens";
     private static final String TOKEN_INSTANCE_IDENTIFIED_CONTEXT = TOKEN_INSTANCE_BASE_CONTEXT + "/{uuid}";
@@ -37,7 +38,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<TokenInstanceDto> listTokenInstances(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public List<TokenInstanceDto> listTokenInstances(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -49,7 +51,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public TokenInstanceDto getTokenInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public TokenInstanceDto getTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -61,7 +64,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public TokenInstanceDto createTokenInstance(ConnectorDto connector, TokenInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public TokenInstanceDto createTokenInstance(ApiClientConnectorInfo connector, TokenInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -75,7 +79,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
     }
 
 
-    public TokenInstanceDto updateTokenInstance(ConnectorDto connector, String uuid, TokenInstanceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public TokenInstanceDto updateTokenInstance(ApiClientConnectorInfo connector, String uuid, TokenInstanceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -88,7 +93,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void removeTokenInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public void removeTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
@@ -100,7 +106,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public TokenInstanceStatusDto getTokenInstanceStatus(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public TokenInstanceStatusDto getTokenInstanceStatus(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -112,7 +119,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listTokenProfileAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -124,7 +132,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateTokenProfileAttributes(ConnectorDto connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -137,7 +146,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listTokenInstanceActivationAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -149,7 +159,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void validateTokenInstanceActivationAttributes(ConnectorDto connector, String uuid, List<RequestAttribute>attributes) throws ValidationException, ConnectorException {
+    @Override
+    public void validateTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -162,7 +173,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void activateTokenInstance(ConnectorDto connector, String uuid, List<RequestAttribute>attributes) throws ConnectorException {
+    @Override
+    public void activateTokenInstance(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PATCH, connector, true);
 
         processRequest(r -> r
@@ -175,7 +187,8 @@ public class TokenInstanceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void deactivateTokenInstance(ConnectorDto connector, String uuid) throws ConnectorException {
+    @Override
+    public void deactivateTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PATCH, connector, true);
 
         processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/mq/AttributeApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/AttributeApiClient.java
@@ -1,0 +1,287 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.interfaces.client.v1.AttributeSyncApiClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.common.attribute.common.callback.AttributeCallback;
+import com.czertainly.api.model.common.attribute.common.callback.RequestAttributeCallback;
+import com.czertainly.api.model.core.connector.FunctionGroupCode;
+
+import java.io.Serializable;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Message queue based attribute API client.
+ * Uses ProxyClient to send requests via message queue instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based AttributeApiClient
+ * to ensure compatibility with existing code.</p>
+ */
+public class AttributeApiClient implements AttributeSyncApiClient {
+
+    private static final String ATTRIBUTE_BASE_CONTEXT = "/v1/{functionGroup}/{kind}/attributes";
+    private static final String ATTRIBUTE_VALIDATION_CONTEXT = ATTRIBUTE_BASE_CONTEXT + "/validate";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public AttributeApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    /**
+     * List attribute definitions for a connector.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @param functionGroupCode Function group code
+     * @param kind Connector kind
+     * @return List of base attributes
+     * @throws ConnectorException If request fails
+     */
+    @Override
+    public List<BaseAttribute> listAttributeDefinitions(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) throws ConnectorException {
+
+        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    /**
+     * List attribute definitions (alternative with BaseAttribute return type).
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @param functionGroupCode Function group code
+     * @param kind Connector kind
+     * @return List of abstract base attributes
+     * @throws ConnectorException If request fails
+     */
+    @Override
+    public List<BaseAttribute> listAttributeDefinitions1(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) throws ConnectorException {
+
+        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    /**
+     * Validate attributes.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @param functionGroupCode Function group code
+     * @param attributes Attributes to validate
+     * @param functionGroupType Function group type (kind)
+     * @return null on success
+     * @throws ValidationException If validation fails
+     * @throws ConnectorException If request fails
+     */
+    @Override
+    public Void validateAttributes(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            List<RequestAttribute> attributes,
+            String functionGroupType) throws ValidationException, ConnectorException {
+
+        String path = buildPath(ATTRIBUTE_VALIDATION_CONTEXT, functionGroupCode.getCode(), functionGroupType);
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                attributes,
+                Void.class
+        );
+    }
+
+    /**
+     * Execute attribute callback.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @param callback Callback configuration with method and context
+     * @param callbackRequest Request with path variables, query params, and body
+     * @return Callback response object
+     * @throws ConnectorException If request fails
+     */
+    @Override
+    public Object attributeCallback(
+            ApiClientConnectorInfo connector,
+            AttributeCallback callback,
+            RequestAttributeCallback callbackRequest) throws ConnectorException {
+
+        String path = buildCallbackPath(callback, callbackRequest);
+        String method = callback.getCallbackMethod();
+        Object body = callbackRequest.getBody();
+
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                method,
+                body,
+                Object.class
+        );
+    }
+
+    // ==================== Async variants ====================
+
+    /**
+     * Async version of listAttributeDefinitions.
+     */
+    public CompletableFuture<List<BaseAttribute>> listAttributeDefinitionsAsync(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) {
+
+        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        ).thenApply(Arrays::asList);
+    }
+
+    /**
+     * Async version of listAttributeDefinitions1.
+     */
+    public CompletableFuture<List<BaseAttribute>> listAttributeDefinitions1Async(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) {
+
+        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        ).thenApply(Arrays::asList);
+    }
+
+    /**
+     * Async version of validateAttributes.
+     */
+    public CompletableFuture<Void> validateAttributesAsync(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            List<RequestAttribute> attributes,
+            String functionGroupType) {
+
+        String path = buildPath(ATTRIBUTE_VALIDATION_CONTEXT, functionGroupCode.getCode(), functionGroupType);
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                attributes,
+                Void.class
+        );
+    }
+
+    /**
+     * Async version of attributeCallback.
+     */
+    public CompletableFuture<Object> attributeCallbackAsync(
+            ApiClientConnectorInfo connector,
+            AttributeCallback callback,
+            RequestAttributeCallback callbackRequest) {
+
+        String path = buildCallbackPath(callback, callbackRequest);
+        String method = callback.getCallbackMethod();
+        Object body = callbackRequest.getBody();
+
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                method,
+                body,
+                Object.class
+        );
+    }
+
+    // ==================== Helper methods ====================
+
+    /**
+     * Build path by substituting path variables in template.
+     */
+    private String buildPath(String template, String functionGroup, String kind) {
+        return template
+                .replace("{functionGroup}", functionGroup)
+                .replace("{kind}", kind);
+    }
+
+    /**
+     * Build callback path with path variables and query parameters.
+     */
+    private String buildCallbackPath(AttributeCallback callback, RequestAttributeCallback callbackRequest) {
+        String path = callback.getCallbackContext();
+
+        // Substitute path variables
+        if (callbackRequest.getPathVariable() != null) {
+            for (Map.Entry<String, Serializable> entry : callbackRequest.getPathVariable().entrySet()) {
+                String value = extractValue(entry.getValue());
+                path = path.replace("{" + entry.getKey() + "}", value);
+            }
+        }
+
+        // Append query parameters
+        if (callbackRequest.getRequestParameter() != null) {
+            String queryString = callbackRequest.getRequestParameter().entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .map(e -> encodeParam(e.getKey()) + "=" + encodeParam(extractValue(e.getValue())))
+                    .collect(Collectors.joining("&"));
+
+            if (!queryString.isEmpty()) {
+                path = path + "?" + queryString;
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * Extract value from object, handling Map wrapper case.
+     * Some attributes come wrapped in a Map with "value" key.
+     */
+    @SuppressWarnings("unchecked")
+    private String extractValue(Object value) {
+        if (value instanceof Map) {
+            Object mapValue = ((Map<?, ?>) value).get("value");
+            return mapValue != null ? mapValue.toString() : "";
+        }
+        return value != null ? value.toString() : "";
+    }
+
+    /**
+     * URL encode a parameter.
+     */
+    private String encodeParam(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/AttributeApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/AttributeApiClient.java
@@ -66,32 +66,6 @@ public class AttributeApiClient implements AttributeSyncApiClient {
     }
 
     /**
-     * List attribute definitions (alternative with BaseAttribute return type).
-     *
-     * @param connector Connector configuration (must have proxyId set)
-     * @param functionGroupCode Function group code
-     * @param kind Connector kind
-     * @return List of abstract base attributes
-     * @throws ConnectorException If request fails
-     */
-    @Override
-    public List<BaseAttribute> listAttributeDefinitions1(
-            ApiClientConnectorInfo connector,
-            FunctionGroupCode functionGroupCode,
-            String kind) throws ConnectorException {
-
-        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
-        BaseAttribute[] result = proxyClient.sendRequest(
-                connector,
-                path,
-                HTTP_METHOD_GET,
-                null,
-                BaseAttribute[].class
-        );
-        return Arrays.asList(result);
-    }
-
-    /**
      * Validate attributes.
      *
      * @param connector Connector configuration (must have proxyId set)
@@ -153,24 +127,6 @@ public class AttributeApiClient implements AttributeSyncApiClient {
      * Async version of listAttributeDefinitions.
      */
     public CompletableFuture<List<BaseAttribute>> listAttributeDefinitionsAsync(
-            ApiClientConnectorInfo connector,
-            FunctionGroupCode functionGroupCode,
-            String kind) {
-
-        String path = buildPath(ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind);
-        return proxyClient.sendRequestAsync(
-                connector,
-                path,
-                HTTP_METHOD_GET,
-                null,
-                BaseAttribute[].class
-        ).thenApply(Arrays::asList);
-    }
-
-    /**
-     * Async version of listAttributeDefinitions1.
-     */
-    public CompletableFuture<List<BaseAttribute>> listAttributeDefinitions1Async(
             ApiClientConnectorInfo connector,
             FunctionGroupCode functionGroupCode,
             String kind) {

--- a/src/main/java/com/czertainly/api/clients/mq/AuthorityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/AuthorityInstanceApiClient.java
@@ -1,0 +1,167 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.AuthorityInstanceSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceDto;
+import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceRequestDto;
+import com.czertainly.api.model.connector.authority.CaCertificatesRequestDto;
+import com.czertainly.api.model.connector.authority.CaCertificatesResponseDto;
+import com.czertainly.api.model.connector.authority.CertificateRevocationListRequestDto;
+import com.czertainly.api.model.connector.authority.CertificateRevocationListResponseDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based Authority Instance API client for connectors.
+ * Uses ProxyClient to send authority instance requests via message queue
+ * instead of direct REST calls.
+ */
+public class AuthorityInstanceApiClient implements AuthorityInstanceSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/authorityProvider/authorities";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    public AuthorityInstanceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<AuthorityProviderInstanceDto> listAuthorityInstances(ApiClientConnectorInfo connector) throws ConnectorException {
+        AuthorityProviderInstanceDto[] result = proxyClient.sendRequest(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_GET,
+                null,
+                AuthorityProviderInstanceDto[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public AuthorityProviderInstanceDto getAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                AuthorityProviderInstanceDto.class
+        );
+    }
+
+    @Override
+    public AuthorityProviderInstanceDto createAuthorityInstance(ApiClientConnectorInfo connector, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
+        return proxyClient.sendRequest(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_POST,
+                requestDto,
+                AuthorityProviderInstanceDto.class
+        );
+    }
+
+    @Override
+    public AuthorityProviderInstanceDto updateAuthorityInstance(ApiClientConnectorInfo connector, String uuid, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                AuthorityProviderInstanceDto.class
+        );
+    }
+
+    @Override
+    public void removeAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_DELETE,
+                null,
+                Void.class
+        );
+    }
+
+    @Override
+    public List<BaseAttribute> listRAProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/raProfile/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public Boolean validateRAProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/raProfile/attributes/validate";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                attributes,
+                Boolean.class
+        );
+    }
+
+    @Override
+    public CertificateRevocationListResponseDto getCrl(ApiClientConnectorInfo connector, String uuid, CertificateRevocationListRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/crl";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                CertificateRevocationListResponseDto.class
+        );
+    }
+
+    @Override
+    public CaCertificatesResponseDto getCaCertificates(ApiClientConnectorInfo connector, String uuid, CaCertificatesRequestDto requestDto) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/caCertificates";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                CaCertificatesResponseDto.class
+        );
+    }
+
+    // Async variants for key methods
+    public CompletableFuture<List<AuthorityProviderInstanceDto>> listAuthorityInstancesAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_GET,
+                null,
+                AuthorityProviderInstanceDto[].class
+        ).thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<AuthorityProviderInstanceDto> getAuthorityInstanceAsync(ApiClientConnectorInfo connector, String uuid) {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                AuthorityProviderInstanceDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/CertificateApiClient.java
@@ -1,0 +1,82 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.CertificateSyncApiClient;
+import com.czertainly.api.model.core.authority.CertRevocationDto;
+import com.czertainly.api.model.core.authority.CertificateSignRequestDto;
+import com.czertainly.api.model.core.authority.CertificateSignResponseDto;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based certificate API client for connectors.
+ * Uses ProxyClient to send certificate requests via message queue
+ * instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based CertificateApiClient
+ * to ensure compatibility with existing code.</p>
+ *
+ * <p>Usage: Inject this client when the connector has a proxyId set.
+ * For connectors without proxyId, use the REST-based CertificateApiClient.</p>
+ */
+public class CertificateApiClient implements CertificateSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/authorityProvider/authorities";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    /**
+     * Constructor for MQ-based CertificateApiClient.
+     *
+     * @param proxyClient The proxy client to use for communication
+     */
+    public CertificateApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public CertificateSignResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/certificates/issue";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                CertificateSignResponseDto.class
+        );
+    }
+
+    @Override
+    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertRevocationDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/certificates/revoke";
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                Void.class
+        );
+    }
+
+    /**
+     * Async version of issueCertificate.
+     *
+     * @param connector            Connector configuration (must have proxyId set)
+     * @param authorityUuid        Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param requestDto           Certificate sign request
+     * @return CompletableFuture that completes with CertificateSignResponseDto
+     */
+    public CompletableFuture<CertificateSignResponseDto> issueCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/certificates/issue";
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                CertificateSignResponseDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/ComplianceApiClient.java
@@ -1,0 +1,72 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.ComplianceSyncApiClient;
+import com.czertainly.api.model.connector.compliance.ComplianceGroupsResponseDto;
+import com.czertainly.api.model.connector.compliance.ComplianceRequestDto;
+import com.czertainly.api.model.connector.compliance.ComplianceResponseDto;
+import com.czertainly.api.model.connector.compliance.ComplianceRulesResponseDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * MQ-based implementation of v1 Compliance API client.
+ */
+public class ComplianceApiClient implements ComplianceSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/complianceProvider";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public ComplianceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<ComplianceRulesResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, List<String> certificateType) throws ConnectorException {
+        StringBuilder pathBuilder = new StringBuilder(BASE_PATH).append("/").append(kind).append("/rules");
+        if (certificateType != null && !certificateType.isEmpty()) {
+            String queryParams = certificateType.stream()
+                    .filter(q -> q != null)
+                    .map(q -> "certificateType=" + q)
+                    .collect(Collectors.joining("&"));
+            if (!queryParams.isEmpty()) {
+                pathBuilder.append("?").append(queryParams);
+            }
+        }
+        ComplianceRulesResponseDto[] result = proxyClient.sendRequest(connector, pathBuilder.toString(), HTTP_METHOD_GET, null, ComplianceRulesResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public List<ComplianceGroupsResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/groups";
+        ComplianceGroupsResponseDto[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, ComplianceGroupsResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public List<ComplianceRulesResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/groups/" + uuid;
+        ComplianceRulesResponseDto[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, ComplianceRulesResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/compliance";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, ComplianceResponseDto.class);
+    }
+
+    // Async variant
+    public CompletableFuture<ComplianceResponseDto> checkComplianceAsync(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) {
+        String path = BASE_PATH + "/" + kind + "/compliance";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, ComplianceResponseDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/ComplianceApiClient.java
@@ -8,6 +8,8 @@ import com.czertainly.api.model.connector.compliance.ComplianceRequestDto;
 import com.czertainly.api.model.connector.compliance.ComplianceResponseDto;
 import com.czertainly.api.model.connector.compliance.ComplianceRulesResponseDto;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +36,7 @@ public class ComplianceApiClient implements ComplianceSyncApiClient {
         if (certificateType != null && !certificateType.isEmpty()) {
             String queryParams = certificateType.stream()
                     .filter(q -> q != null)
-                    .map(q -> "certificateType=" + q)
+                    .map(q -> "certificateType=" + URLEncoder.encode(q, StandardCharsets.UTF_8))
                     .collect(Collectors.joining("&"));
             if (!queryParams.isEmpty()) {
                 pathBuilder.append("?").append(queryParams);

--- a/src/main/java/com/czertainly/api/clients/mq/ConnectorApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/ConnectorApiClient.java
@@ -1,0 +1,64 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.interfaces.client.v1.ConnectorSyncApiClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.connector.InfoResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based connector API client.
+ * Uses ProxyClient to send requests via message queue instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based ConnectorApiClient
+ * to ensure compatibility with existing code.</p>
+ */
+public class ConnectorApiClient implements ConnectorSyncApiClient {
+
+    private static final String CONNECTOR_BASE_CONTEXT = "/v1";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    public ConnectorApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    /**
+     * List supported functions of a connector via proxy message queue.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @return List of supported functions
+     * @throws ConnectorException If request fails
+     */
+    @Override
+    public List<InfoResponse> listSupportedFunctions(ApiClientConnectorInfo connector) throws ConnectorException {
+        InfoResponse[] result = proxyClient.sendRequest(
+                connector,
+                CONNECTOR_BASE_CONTEXT,
+                HTTP_METHOD_GET,
+                null,
+                InfoResponse[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    /**
+     * Async version of listSupportedFunctions.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @return CompletableFuture that completes with list of supported functions
+     */
+    public CompletableFuture<List<InfoResponse>> listSupportedFunctionsAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                CONNECTOR_BASE_CONTEXT,
+                HTTP_METHOD_GET,
+                null,
+                InfoResponse[].class
+        ).thenApply(Arrays::asList);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/CryptographicOperationsApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/CryptographicOperationsApiClient.java
@@ -1,0 +1,90 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.CryptographicOperationsSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.operations.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class CryptographicOperationsApiClient implements CryptographicOperationsSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/cryptographyProvider/tokens";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public CryptographicOperationsApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public EncryptDataResponseDto encryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/encrypt";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, EncryptDataResponseDto.class);
+    }
+
+    @Override
+    public DecryptDataResponseDto decryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/decrypt";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, DecryptDataResponseDto.class);
+    }
+
+    @Override
+    public SignDataResponseDto signData(ApiClientConnectorInfo connector, String uuid, String keyUuid, SignDataRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/sign";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, SignDataResponseDto.class);
+    }
+
+    @Override
+    public VerifyDataResponseDto verifyData(ApiClientConnectorInfo connector, String uuid, String keyUuid, VerifyDataRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/verify";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, VerifyDataResponseDto.class);
+    }
+
+    @Override
+    public List<BaseAttribute> listRandomAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/random/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateRandomAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/random/attributes/validate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Void.class);
+    }
+
+    @Override
+    public RandomDataResponseDto randomData(ApiClientConnectorInfo connector, String uuid, RandomDataRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/random";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, RandomDataResponseDto.class);
+    }
+
+    // Async variants
+    public CompletableFuture<EncryptDataResponseDto> encryptDataAsync(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/encrypt";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, EncryptDataResponseDto.class);
+    }
+
+    public CompletableFuture<DecryptDataResponseDto> decryptDataAsync(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/decrypt";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, DecryptDataResponseDto.class);
+    }
+
+    public CompletableFuture<SignDataResponseDto> signDataAsync(ApiClientConnectorInfo connector, String uuid, String keyUuid, SignDataRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/sign";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, SignDataResponseDto.class);
+    }
+
+    public CompletableFuture<VerifyDataResponseDto> verifyDataAsync(ApiClientConnectorInfo connector, String uuid, String keyUuid, VerifyDataRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid + "/verify";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, VerifyDataResponseDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/DiscoveryApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/DiscoveryApiClient.java
@@ -1,0 +1,110 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.DiscoverySyncApiClient;
+import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
+import com.czertainly.api.model.connector.discovery.DiscoveryProviderDto;
+import com.czertainly.api.model.connector.discovery.DiscoveryRequestDto;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based discovery API client for connectors.
+ * Uses ProxyClient to send discovery requests via message queue
+ * instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based DiscoveryApiClient
+ * to ensure compatibility with existing code.</p>
+ *
+ * <p>Usage: Inject this client when the connector has a proxyId set.
+ * For connectors without proxyId, use the REST-based DiscoveryApiClient.</p>
+ */
+public class DiscoveryApiClient implements DiscoverySyncApiClient {
+
+    private static final String DISCOVERY_BASE_PATH = "/v1/discoveryProvider/discover";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    /**
+     * Constructor for MQ-based DiscoveryApiClient.
+     *
+     * @param proxyClient The proxy client to use for communication
+     */
+    public DiscoveryApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public DiscoveryProviderDto discoverCertificates(ApiClientConnectorInfo connector, DiscoveryRequestDto requestDto) throws ConnectorException {
+        return proxyClient.sendRequest(
+                connector,
+                DISCOVERY_BASE_PATH,
+                HTTP_METHOD_POST,
+                requestDto,
+                DiscoveryProviderDto.class
+        );
+    }
+
+    @Override
+    public DiscoveryProviderDto getDiscoveryData(ApiClientConnectorInfo connector, DiscoveryDataRequestDto requestDto, String uuid) throws ConnectorException {
+        String path = DISCOVERY_BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                DiscoveryProviderDto.class
+        );
+    }
+
+    @Override
+    public void removeDiscovery(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = DISCOVERY_BASE_PATH + "/" + uuid;
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_DELETE,
+                null,
+                Void.class
+        );
+    }
+
+    /**
+     * Async version of discoverCertificates.
+     *
+     * @param connector  Connector configuration (must have proxyId set)
+     * @param requestDto Discovery request parameters
+     * @return CompletableFuture that completes with DiscoveryProviderDto
+     */
+    public CompletableFuture<DiscoveryProviderDto> discoverCertificatesAsync(ApiClientConnectorInfo connector, DiscoveryRequestDto requestDto) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                DISCOVERY_BASE_PATH,
+                HTTP_METHOD_POST,
+                requestDto,
+                DiscoveryProviderDto.class
+        );
+    }
+
+    /**
+     * Async version of getDiscoveryData.
+     *
+     * @param connector  Connector configuration (must have proxyId set)
+     * @param requestDto Discovery data request with pagination
+     * @param uuid       Discovery UUID at the connector
+     * @return CompletableFuture that completes with DiscoveryProviderDto
+     */
+    public CompletableFuture<DiscoveryProviderDto> getDiscoveryDataAsync(ApiClientConnectorInfo connector, DiscoveryDataRequestDto requestDto, String uuid) {
+        String path = DISCOVERY_BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                DiscoveryProviderDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/EndEntityApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/EndEntityApiClient.java
@@ -1,0 +1,79 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.EndEntitySyncApiClient;
+import com.czertainly.api.model.core.authority.AddEndEntityRequestDto;
+import com.czertainly.api.model.core.authority.EditEndEntityRequestDto;
+import com.czertainly.api.model.core.authority.EndEntityDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of End Entity API client.
+ */
+public class EndEntityApiClient implements EndEntitySyncApiClient {
+
+    private static final String BASE_PATH = "/v1/authorityProvider/authorities";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_PUT = "PUT";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    public EndEntityApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<EndEntityDto> listEntities(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities";
+        EndEntityDto[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, EndEntityDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public EndEntityDto getEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities/" + endEntityName;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, EndEntityDto.class);
+    }
+
+    @Override
+    public void createEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, AddEndEntityRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public void updateEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName, EditEndEntityRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities/" + endEntityName;
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public void revokeAndDeleteEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities/" + endEntityName;
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_DELETE, null, Void.class);
+    }
+
+    @Override
+    public void resetPassword(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities/" + endEntityName + "/resetPassword";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_PUT, null, Void.class);
+    }
+
+    // Async variants
+    public CompletableFuture<List<EndEntityDto>> listEntitiesAsync(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName) {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_GET, null, EndEntityDto[].class)
+                .thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<EndEntityDto> getEndEntityAsync(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileName + "/endEntities/" + endEntityName;
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_GET, null, EndEntityDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/EndEntityProfileApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/EndEntityProfileApiClient.java
@@ -1,0 +1,94 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.EndEntityProfileSyncApiClient;
+import com.czertainly.api.model.common.NameAndIdDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based end entity profile API client for connectors.
+ * Uses ProxyClient to send requests via message queue instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based EndEntityProfileApiClient
+ * to ensure compatibility with existing code.</p>
+ *
+ * <p>Usage: Inject this client when the connector has a proxyId set.
+ * For connectors without proxyId, use the REST-based EndEntityProfileApiClient.</p>
+ */
+public class EndEntityProfileApiClient implements EndEntityProfileSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/authorityProvider/authorities";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    /**
+     * Constructor for MQ-based EndEntityProfileApiClient.
+     *
+     * @param proxyClient The proxy client to use for communication
+     */
+    public EndEntityProfileApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<NameAndIdDto> listEndEntityProfiles(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles";
+        NameAndIdDto[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                NameAndIdDto[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public List<NameAndIdDto> listCertificateProfiles(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileId + "/certificateprofiles";
+        NameAndIdDto[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                NameAndIdDto[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public List<NameAndIdDto> listCAsInProfile(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles/" + endEntityProfileId + "/cas";
+        NameAndIdDto[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                NameAndIdDto[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    /**
+     * Async version of listEndEntityProfiles.
+     *
+     * @param connector     Connector configuration (must have proxyId set)
+     * @param authorityUuid Authority instance UUID
+     * @return CompletableFuture that completes with list of end entity profiles
+     */
+    public CompletableFuture<List<NameAndIdDto>> listEndEntityProfilesAsync(ApiClientConnectorInfo connector, String authorityUuid) {
+        String path = BASE_PATH + "/" + authorityUuid + "/endEntityProfiles";
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                NameAndIdDto[].class
+        ).thenApply(Arrays::asList);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/EntityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/EntityInstanceApiClient.java
@@ -1,0 +1,140 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.EntityInstanceSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.entity.EntityInstanceDto;
+import com.czertainly.api.model.connector.entity.EntityInstanceRequestDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based Entity Instance API client for connectors.
+ * Uses ProxyClient to send entity instance requests via message queue
+ * instead of direct REST calls.
+ */
+public class EntityInstanceApiClient implements EntityInstanceSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/entityProvider/entities";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_PUT = "PUT";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    public EntityInstanceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<EntityInstanceDto> listEntityInstances(ApiClientConnectorInfo connector) throws ConnectorException {
+        EntityInstanceDto[] result = proxyClient.sendRequest(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_GET,
+                null,
+                EntityInstanceDto[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public EntityInstanceDto getEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid;
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                EntityInstanceDto.class
+        );
+    }
+
+    @Override
+    public EntityInstanceDto createEntityInstance(ApiClientConnectorInfo connector, EntityInstanceRequestDto requestDto) throws ConnectorException {
+        return proxyClient.sendRequest(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_POST,
+                requestDto,
+                EntityInstanceDto.class
+        );
+    }
+
+    @Override
+    public EntityInstanceDto updateEntityInstance(ApiClientConnectorInfo connector, String entityUuid, EntityInstanceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid;
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_PUT,
+                requestDto,
+                EntityInstanceDto.class
+        );
+    }
+
+    @Override
+    public void removeEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid;
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_DELETE,
+                null,
+                Void.class
+        );
+    }
+
+    @Override
+    public List<BaseAttribute> listLocationAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/location/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateLocationAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/location/attributes/validate";
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                attributes,
+                Void.class
+        );
+    }
+
+    // Async variants
+    public CompletableFuture<List<EntityInstanceDto>> listEntityInstancesAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                BASE_PATH,
+                HTTP_METHOD_GET,
+                null,
+                EntityInstanceDto[].class
+        ).thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<EntityInstanceDto> getEntityInstanceAsync(ApiClientConnectorInfo connector, String entityUuid) {
+        String path = BASE_PATH + "/" + entityUuid;
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                EntityInstanceDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/HealthApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/HealthApiClient.java
@@ -1,0 +1,72 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.interfaces.client.v1.HealthSyncApiClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.common.HealthDto;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based health API client for connectors.
+ * Uses ProxyClient to send health check requests via message queue
+ * instead of direct REST calls.
+ *
+ * <p>This client maintains the same signature as the REST-based HealthApiClient
+ * to ensure compatibility with existing code.</p>
+ *
+ * <p>Usage: Inject this client when the connector has a proxyId set.
+ * For connectors without proxyId, use the REST-based HealthApiClient.</p>
+ */
+public class HealthApiClient implements HealthSyncApiClient {
+
+    private static final String HEALTH_PATH = "/v1/health";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    /**
+     * Constructor for MQ-based HealthApiClient.
+     *
+     * @param proxyClient The proxy client to use for communication
+     */
+    public HealthApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    /**
+     * Check health of a connector via proxy message queue.
+     * Maintains same signature as REST-based HealthApiClient.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @return HealthDto containing connector health status
+     * @throws ConnectorException If health check fails
+     * @throws IllegalArgumentException If connector.proxyId is null
+     */
+    @Override
+    public HealthDto checkHealth(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(
+                connector,
+                HEALTH_PATH,
+                HTTP_METHOD_GET,
+                null,  // No request body for GET
+                HealthDto.class
+        );
+    }
+
+    /**
+     * Async version of health check.
+     *
+     * @param connector Connector configuration (must have proxyId set)
+     * @return CompletableFuture that completes with HealthDto
+     */
+    public CompletableFuture<HealthDto> checkHealthAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                HEALTH_PATH,
+                HTTP_METHOD_GET,
+                null,
+                HealthDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/KeyManagementApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/KeyManagementApiClient.java
@@ -1,0 +1,98 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.KeyManagementSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class KeyManagementApiClient implements KeyManagementSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/cryptographyProvider/tokens";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    public KeyManagementApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<BaseAttribute> listCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/secret/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/secret/attributes/validate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Void.class);
+    }
+
+    @Override
+    public KeyDataResponseDto createSecretKey(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/secret";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, KeyDataResponseDto.class);
+    }
+
+    @Override
+    public List<BaseAttribute> listCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/pair/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/pair/attributes/validate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Void.class);
+    }
+
+    @Override
+    public KeyPairDataResponseDto createKeyPair(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/pair";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, KeyPairDataResponseDto.class);
+    }
+
+    @Override
+    public List<KeyDataResponseDto> listKeys(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys";
+        KeyDataResponseDto[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, KeyDataResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public KeyDataResponseDto getKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, KeyDataResponseDto.class);
+    }
+
+    @Override
+    public void destroyKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/keys/" + keyUuid;
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_DELETE, null, Void.class);
+    }
+
+    // Async variants
+    public CompletableFuture<List<KeyDataResponseDto>> listKeysAsync(ApiClientConnectorInfo connector, String uuid) {
+        String path = BASE_PATH + "/" + uuid + "/keys";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_GET, null, KeyDataResponseDto[].class)
+                .thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<KeyPairDataResponseDto> createKeyPairAsync(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/keys/pair";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, KeyPairDataResponseDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/LocationApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/LocationApiClient.java
@@ -1,0 +1,158 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.LocationSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.entity.GenerateCsrRequestDto;
+import com.czertainly.api.model.connector.entity.GenerateCsrResponseDto;
+import com.czertainly.api.model.connector.entity.LocationDetailRequestDto;
+import com.czertainly.api.model.connector.entity.LocationDetailResponseDto;
+import com.czertainly.api.model.connector.entity.PushCertificateRequestDto;
+import com.czertainly.api.model.connector.entity.PushCertificateResponseDto;
+import com.czertainly.api.model.connector.entity.RemoveCertificateRequestDto;
+import com.czertainly.api.model.connector.entity.RemoveCertificateResponseDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Message queue based Location API client for connectors.
+ * Uses ProxyClient to send location requests via message queue
+ * instead of direct REST calls.
+ */
+public class LocationApiClient implements LocationSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/entityProvider/entities";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public LocationApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public LocationDetailResponseDto getLocationDetail(ApiClientConnectorInfo connector, String entityUuid, LocationDetailRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                LocationDetailResponseDto.class
+        );
+    }
+
+    @Override
+    public PushCertificateResponseDto pushCertificateToLocation(ApiClientConnectorInfo connector, String entityUuid, PushCertificateRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/push";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                PushCertificateResponseDto.class
+        );
+    }
+
+    @Override
+    public List<BaseAttribute> listPushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/push/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validatePushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/push/attributes/validate";
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                pushAttributes,
+                Void.class
+        );
+    }
+
+    @Override
+    public RemoveCertificateResponseDto removeCertificateFromLocation(ApiClientConnectorInfo connector, String entityUuid, RemoveCertificateRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/remove";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                RemoveCertificateResponseDto.class
+        );
+    }
+
+    @Override
+    public GenerateCsrResponseDto generateCsrLocation(ApiClientConnectorInfo connector, String entityUuid, GenerateCsrRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/csr";
+        return proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                GenerateCsrResponseDto.class
+        );
+    }
+
+    @Override
+    public List<BaseAttribute> listGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/csr/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/csr/attributes/validate";
+        proxyClient.sendRequest(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                pushAttributes,
+                Void.class
+        );
+    }
+
+    // Async variants
+    public CompletableFuture<LocationDetailResponseDto> getLocationDetailAsync(ApiClientConnectorInfo connector, String entityUuid, LocationDetailRequestDto requestDto) {
+        String path = BASE_PATH + "/" + entityUuid + "/locations";
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                LocationDetailResponseDto.class
+        );
+    }
+
+    public CompletableFuture<PushCertificateResponseDto> pushCertificateToLocationAsync(ApiClientConnectorInfo connector, String entityUuid, PushCertificateRequestDto requestDto) {
+        String path = BASE_PATH + "/" + entityUuid + "/locations/push";
+        return proxyClient.sendRequestAsync(
+                connector,
+                path,
+                HTTP_METHOD_POST,
+                requestDto,
+                PushCertificateResponseDto.class
+        );
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/NotificationInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/NotificationInstanceApiClient.java
@@ -1,0 +1,89 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.NotificationInstanceSyncApiClient;
+import com.czertainly.api.model.common.attribute.common.DataAttribute;
+import com.czertainly.api.model.connector.notification.NotificationProviderInstanceDto;
+import com.czertainly.api.model.connector.notification.NotificationProviderInstanceRequestDto;
+import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of Notification Instance API client.
+ */
+public class NotificationInstanceApiClient implements NotificationInstanceSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/notificationProvider/notifications";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_PUT = "PUT";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+
+    private final ProxyClient proxyClient;
+
+    public NotificationInstanceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<NotificationProviderInstanceDto> listNotificationInstances(ApiClientConnectorInfo connector) throws ConnectorException {
+        NotificationProviderInstanceDto[] result = proxyClient.sendRequest(connector, BASE_PATH, HTTP_METHOD_GET, null, NotificationProviderInstanceDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public NotificationProviderInstanceDto getNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, NotificationProviderInstanceDto.class);
+    }
+
+    @Override
+    public NotificationProviderInstanceDto createNotificationInstance(ApiClientConnectorInfo connector, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
+        return proxyClient.sendRequest(connector, BASE_PATH, HTTP_METHOD_POST, requestDto, NotificationProviderInstanceDto.class);
+    }
+
+    @Override
+    public NotificationProviderInstanceDto updateNotificationInstance(ApiClientConnectorInfo connector, String uuid, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_PUT, requestDto, NotificationProviderInstanceDto.class);
+    }
+
+    @Override
+    public void removeNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_DELETE, null, Void.class);
+    }
+
+    @Override
+    public void sendNotification(ApiClientConnectorInfo connector, String uuid, NotificationProviderNotifyRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/notify";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public List<DataAttribute> listMappingAttributes(ApiClientConnectorInfo connector, String kind) throws ConnectorException {
+        String path = "/v1/notificationProvider/" + kind + "/attributes/mapping";
+        DataAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, DataAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    // Async variants
+    public CompletableFuture<List<NotificationProviderInstanceDto>> listNotificationInstancesAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, BASE_PATH, HTTP_METHOD_GET, null, NotificationProviderInstanceDto[].class)
+                .thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<NotificationProviderInstanceDto> getNotificationInstanceAsync(ApiClientConnectorInfo connector, String uuid) {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_GET, null, NotificationProviderInstanceDto.class);
+    }
+
+    public CompletableFuture<Void> sendNotificationAsync(ApiClientConnectorInfo connector, String uuid, NotificationProviderNotifyRequestDto requestDto) {
+        String path = BASE_PATH + "/" + uuid + "/notify";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/ProxyClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/ProxyClient.java
@@ -1,0 +1,195 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client interface for communicating with connectors via message queue proxy.
+ * Provides both synchronous and asynchronous methods for connector communication.
+ *
+ * <p>The ProxyClient sends requests to a message queue topic where a proxy service
+ * forwards them to the actual connector via HTTP. Responses are received through
+ * a response queue and correlated using correlation IDs.</p>
+ *
+ * <p>Synchronous methods block until a response is received or timeout occurs.
+ * Asynchronous methods return CompletableFuture that completes when response arrives.</p>
+ */
+public interface ProxyClient {
+
+    /**
+     * Send a request to the connector and wait for response synchronously.
+     * Uses the default configured timeout.
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param <T>          Response type
+     * @return Deserialized response object
+     * @throws ConnectorException If request fails or times out
+     */
+    <T> T sendRequest(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType
+    ) throws ConnectorException;
+
+    /**
+     * Send a request to the connector and wait for response synchronously with custom timeout.
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param timeout      Custom timeout duration
+     * @param <T>          Response type
+     * @return Deserialized response object
+     * @throws ConnectorException If request fails or times out
+     */
+    <T> T sendRequest(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType,
+            Duration timeout
+    ) throws ConnectorException;
+
+    /**
+     * Send a request to the connector and wait for response synchronously with path variables.
+     *
+     * @param connector     Connector configuration with URL, auth, and proxyId
+     * @param path          Request path with variables (e.g., "/v1/authorities/{uuid}")
+     * @param method        HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param pathVariables Map of path variable names to values
+     * @param body          Request body (can be null for GET requests)
+     * @param responseType  Expected response type class
+     * @param <T>           Response type
+     * @return Deserialized response object
+     * @throws ConnectorException If request fails or times out
+     */
+    <T> T sendRequest(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Map<String, String> pathVariables,
+            Object body,
+            Class<T> responseType
+    ) throws ConnectorException;
+
+    /**
+     * Send an asynchronous request to the connector.
+     * Uses the default configured timeout.
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param <T>          Response type
+     * @return CompletableFuture that completes with the response
+     */
+    <T> CompletableFuture<T> sendRequestAsync(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType
+    );
+
+    /**
+     * Send an asynchronous request to the connector with custom timeout.
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param timeout      Custom timeout duration
+     * @param <T>          Response type
+     * @return CompletableFuture that completes with the response
+     */
+    <T> CompletableFuture<T> sendRequestAsync(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType,
+            Duration timeout
+    );
+
+    /**
+     * Send an asynchronous request with path variables and custom timeout.
+     *
+     * @param connector     Connector configuration with URL, auth, and proxyId
+     * @param path          Request path with variables (e.g., "/v1/authorities/{uuid}")
+     * @param method        HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param pathVariables Map of path variable names to values
+     * @param body          Request body (can be null for GET requests)
+     * @param responseType  Expected response type class
+     * @param timeout       Custom timeout duration
+     * @param <T>           Response type
+     * @return CompletableFuture that completes with the response
+     */
+    <T> CompletableFuture<T> sendRequestAsync(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Map<String, String> pathVariables,
+            Object body,
+            Class<T> responseType,
+            Duration timeout
+    );
+
+    /**
+     * Send a fire-and-forget request to the connector.
+     *
+     * <p>This method sends the request without waiting for a response. It is useful for
+     * operations that do not require a response, such as notifications or async triggers.</p>
+     *
+     * <p>The response, if any, will be handled by a {@link MessageTypeResponseHandler}
+     * registered for the corresponding message type pattern.</p>
+     *
+     * @param connector Connector configuration with URL, auth, and proxyId
+     * @param path      Request path (e.g., "/v1/notifications")
+     * @param method    HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body      Request body (can be null for GET requests)
+     */
+    void sendFireAndForget(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body
+    );
+
+    /**
+     * Send a fire-and-forget request with custom message type.
+     *
+     * <p>This method allows overriding the message type for routing purposes.
+     * The message type determines which {@link MessageTypeResponseHandler} will
+     * handle the response, using RabbitMQ topic exchange pattern matching.</p>
+     *
+     * @param connector   Connector configuration with URL, auth, and proxyId
+     * @param path        Request path (e.g., "/v1/notifications")
+     * @param method      HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body        Request body (can be null for GET requests)
+     * @param messageType Custom message type for handler routing (e.g., "discovery.trigger")
+     */
+    void sendFireAndForget(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            String messageType
+    );
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/TokenInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/TokenInstanceApiClient.java
@@ -1,0 +1,118 @@
+package com.czertainly.api.clients.mq;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v1.TokenInstanceSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceDto;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceRequestDto;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceStatusDto;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class TokenInstanceApiClient implements TokenInstanceSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/cryptographyProvider/tokens";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+    private static final String HTTP_METHOD_DELETE = "DELETE";
+    private static final String HTTP_METHOD_PATCH = "PATCH";
+
+    private final ProxyClient proxyClient;
+
+    public TokenInstanceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<TokenInstanceDto> listTokenInstances(ApiClientConnectorInfo connector) throws ConnectorException {
+        TokenInstanceDto[] result = proxyClient.sendRequest(connector, BASE_PATH, HTTP_METHOD_GET, null, TokenInstanceDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public TokenInstanceDto getTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, TokenInstanceDto.class);
+    }
+
+    @Override
+    public TokenInstanceDto createTokenInstance(ApiClientConnectorInfo connector, TokenInstanceRequestDto requestDto) throws ConnectorException {
+        return proxyClient.sendRequest(connector, BASE_PATH, HTTP_METHOD_POST, requestDto, TokenInstanceDto.class);
+    }
+
+    @Override
+    public TokenInstanceDto updateTokenInstance(ApiClientConnectorInfo connector, String uuid, TokenInstanceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, TokenInstanceDto.class);
+    }
+
+    @Override
+    public void removeTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid;
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_DELETE, null, Void.class);
+    }
+
+    @Override
+    public TokenInstanceStatusDto getTokenInstanceStatus(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/status";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, TokenInstanceStatusDto.class);
+    }
+
+    @Override
+    public List<BaseAttribute> listTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/tokenProfile/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/tokenProfile/attributes/validate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Void.class);
+    }
+
+    @Override
+    public List<BaseAttribute> listTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/activate/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public void validateTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/activate/attributes/validate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Void.class);
+    }
+
+    @Override
+    public void activateTokenInstance(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/activate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_PATCH, attributes, Void.class);
+    }
+
+    @Override
+    public void deactivateTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + uuid + "/deactivate";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_PATCH, null, Void.class);
+    }
+
+    // Async variants for key methods
+    public CompletableFuture<List<TokenInstanceDto>> listTokenInstancesAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, BASE_PATH, HTTP_METHOD_GET, null, TokenInstanceDto[].class)
+                .thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<TokenInstanceDto> getTokenInstanceAsync(ApiClientConnectorInfo connector, String uuid) {
+        String path = BASE_PATH + "/" + uuid;
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_GET, null, TokenInstanceDto.class);
+    }
+
+    public CompletableFuture<TokenInstanceDto> createTokenInstanceAsync(ApiClientConnectorInfo connector, TokenInstanceRequestDto requestDto) {
+        return proxyClient.sendRequestAsync(connector, BASE_PATH, HTTP_METHOD_POST, requestDto, TokenInstanceDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorAuth.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorAuth.java
@@ -1,0 +1,34 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Authentication configuration for proxy connector requests.
+ * Maps to the proxy's expected authentication format.
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConnectorAuth implements Serializable {
+
+    @Schema(description = "Authentication type",
+            examples = {"NONE", "BASIC", "API_KEY", "BEARER", "JWT", "CERTIFICATE"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String type;
+
+    @Schema(description = "Authentication attributes based on type. " +
+            "BASIC: {username, password}. " +
+            "API_KEY: {headerName, apiKey}. " +
+            "BEARER/JWT: {token}. " +
+            "CERTIFICATE: {keystore, keystorePassword, truststore, truststorePassword}",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private Map<String, Object> attributes;
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorAuth.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorAuth.java
@@ -23,6 +23,7 @@ public class ConnectorAuth implements Serializable {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String type;
 
+    @ToString.Exclude
     @Schema(description = "Authentication attributes based on type. " +
             "BASIC: {username, password}. " +
             "API_KEY: {headerName, apiKey}. " +

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRegistrationRequest.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRegistrationRequest.java
@@ -1,0 +1,45 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Connector registration request sent from proxy to core via message queue.
+ * Mirrors the fields of ConnectorRequestDto used in the REST API.
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConnectorRegistrationRequest implements Serializable {
+
+    @Schema(description = "Name of the Connector",
+            examples = {"Connector1"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Schema(description = "URL of the Connector to connect",
+            examples = {"http://network-discovery-provider:8080"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String url;
+
+    @Schema(description = "Type of authentication for the Connector",
+            examples = {"none", "basic", "certificate", "apiKey"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String authType;
+
+    @Schema(description = "List of authentication Attributes")
+    private List<Object> authAttributes;
+
+    @Schema(description = "List of Custom Attributes")
+    private List<Object> customAttributes;
+
+    @Schema(description = "Proxy code identifying the proxy instance that forwarded this request",
+            examples = {"proxy-001"})
+    private String proxyCode;
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRegistrationRequest.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRegistrationRequest.java
@@ -33,6 +33,7 @@ public class ConnectorRegistrationRequest implements Serializable {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String authType;
 
+    @ToString.Exclude
     @Schema(description = "List of authentication Attributes")
     private List<Object> authAttributes;
 

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRequest.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRequest.java
@@ -1,0 +1,83 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * HTTP request details for proxy to forward to the connector.
+ * This structure is passed within CoreMessage to specify the actual HTTP call.
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConnectorRequest implements Serializable {
+
+    @Schema(description = "Base URL of the connector",
+            examples = {"https://connector.example.com"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String connectorUrl;
+
+    @Schema(description = "HTTP method",
+            examples = {"GET", "POST", "PUT", "DELETE", "PATCH"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String method;
+
+    @Schema(description = "Request path (relative to connectorUrl)",
+            examples = {"/v1/health", "/v1/authorityProvider/authorities/{uuid}"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String path;
+
+    @Schema(description = "Authentication configuration for the connector",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ConnectorAuth connectorAuth;
+
+    @Schema(description = "Path variables for URL substitution. " +
+            "Variables in path like {uuid} will be replaced with values from this map")
+    private Map<String, String> pathVariables;
+
+    @Schema(description = "Additional HTTP headers to include in the request")
+    private Map<String, String> headers;
+
+    @Schema(description = "Request body (JSON object)")
+    private Object body;
+
+    @Schema(description = "Request timeout in Go duration format",
+            examples = {"30s", "1m", "500ms"},
+            defaultValue = "30s")
+    private String timeout;
+
+    @Schema(description = "Retry policy configuration")
+    private RetryPolicy retryPolicy;
+
+    @Schema(description = "Credential data to merge into request body under 'credential' key")
+    private Map<String, Object> credentialData;
+
+    /**
+     * Retry policy for transient failures.
+     */
+    @Getter
+    @Setter
+    @ToString
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class RetryPolicy implements Serializable {
+
+        @Schema(description = "Enable retry on transient failures", defaultValue = "false")
+        private boolean enabled;
+
+        @Schema(description = "Maximum number of retry attempts", defaultValue = "1")
+        private int maxRetries;
+
+        @Schema(description = "Conditions that trigger retry",
+                examples = {"5xx", "timeout", "connection_error"})
+        private String[] retryOn;
+    }
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRequest.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorRequest.java
@@ -44,6 +44,7 @@ public class ConnectorRequest implements Serializable {
     @Schema(description = "Additional HTTP headers to include in the request")
     private Map<String, String> headers;
 
+    @ToString.Exclude
     @Schema(description = "Request body (JSON object)")
     private Object body;
 
@@ -55,6 +56,7 @@ public class ConnectorRequest implements Serializable {
     @Schema(description = "Retry policy configuration")
     private RetryPolicy retryPolicy;
 
+    @ToString.Exclude
     @Schema(description = "Credential data to merge into request body under 'credential' key")
     private Map<String, Object> credentialData;
 

--- a/src/main/java/com/czertainly/api/clients/mq/model/ConnectorResponse.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ConnectorResponse.java
@@ -1,0 +1,60 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * HTTP response details from the connector.
+ * This structure is returned within ProxyMessage to provide the actual HTTP response data.
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConnectorResponse implements Serializable {
+
+    @Schema(description = "HTTP status code from the connector response. " +
+            "0 if request failed before reaching connector",
+            examples = {"200", "404", "500", "0"})
+    private int statusCode;
+
+    @Schema(description = "HTTP response headers from the connector")
+    private Map<String, String> headers;
+
+    @Schema(description = "Response body as JSON object (if Content-Type is application/json)")
+    private Object body;
+
+    @Schema(description = "Base64-encoded response body for non-JSON content types")
+    private String bodyText;
+
+    @Schema(description = "Error message if request failed (empty on success)")
+    private String error;
+
+    @Schema(description = "Error category for classification",
+            examples = {"validation", "authentication", "authorization", "not_found",
+                    "timeout", "connection", "server_error", "unknown"})
+    private String errorCategory;
+
+    @Schema(description = "Whether the error is transient and the message can be retried")
+    private boolean retryable;
+
+    /**
+     * Check if the response indicates a successful request.
+     */
+    public boolean isSuccess() {
+        return (error == null || error.isEmpty()) && statusCode >= 200 && statusCode < 300;
+    }
+
+    /**
+     * Check if the response has an error.
+     */
+    public boolean hasError() {
+        return error != null && !error.isEmpty();
+    }
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/CoreMessage.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/CoreMessage.java
@@ -1,0 +1,38 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * Message envelope for core-to-proxy communication.
+ * This is the top-level message sent to the proxy via message queue.
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CoreMessage implements Serializable {
+
+    @Schema(description = "Unique correlation ID for request/response matching",
+            examples = {"550e8400-e29b-41d4-a716-446655440000"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String correlationId;
+
+    @Schema(description = "Message type identifier for logging and routing. Uses RabbitMQ topic exchange format with '.' as segment separator.",
+            examples = {"GET.v1.health", "POST.v1.authorityProvider.authorities"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String messageType;
+
+    @Schema(description = "Timestamp of message creation (ISO8601)")
+    private Instant timestamp;
+
+    @Schema(description = "The actual HTTP request to be forwarded to the connector",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ConnectorRequest connectorRequest;
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/model/ProxyMessage.java
+++ b/src/main/java/com/czertainly/api/clients/mq/model/ProxyMessage.java
@@ -1,0 +1,83 @@
+package com.czertainly.api.clients.mq.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * Message envelope for proxy-to-core communication.
+ * This is the top-level message received from the proxy via message queue.
+ *
+ * <p>Used for three message types:</p>
+ * <ul>
+ *   <li>Connector responses: Contains correlationId and connectorResponse</li>
+ *   <li>Health checks: Contains only proxyId, messageType="health.check", and timestamp</li>
+ *   <li>Connector registration: Contains connectorRegistrationRequest, messageType="connector.register"</li>
+ * </ul>
+ */
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProxyMessage implements Serializable {
+
+    @Schema(description = "Proxy instance identifier (subscription name)",
+            examples = {"proxy-001", "proxy-azure-west"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String proxyId;
+
+    @Schema(description = "Correlation ID echoed from request for matching. " +
+            "Empty for fire-and-forget messages like health checks.",
+            examples = {"550e8400-e29b-41d4-a716-446655440000"})
+    private String correlationId;
+
+    @Schema(description = "Message type for routing. Uses RabbitMQ topic exchange format with '.' as segment separator. " +
+            "'health.check' for health check messages, or echoed from request for connector responses.",
+            examples = {"health.check", "GET.v1.health", "POST.v1.authorityProvider.authorities"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String messageType;
+
+    @Schema(description = "Timestamp of message creation (ISO8601)")
+    private Instant timestamp;
+
+    @Schema(description = "Connector response data. Null for health check messages.")
+    private ConnectorResponse connectorResponse;
+
+    @Schema(description = "Connector registration request data. Null for non-registration messages.")
+    private ConnectorRegistrationRequest connectorRegistrationRequest;
+
+    /**
+     * Check if this is a health check message.
+     */
+    public boolean isHealthCheck() {
+        return "health.check".equals(messageType);
+    }
+
+    /**
+     * Check if this message has a connector response.
+     */
+    public boolean hasConnectorResponse() {
+        return connectorResponse != null;
+    }
+
+    /**
+     * Check if the connector response indicates success.
+     * Returns false for health checks or messages without connector response.
+     */
+    public boolean isSuccess() {
+        return connectorResponse != null && connectorResponse.isSuccess();
+    }
+
+    /**
+     * Check if the connector response has an error.
+     * Returns false for health checks or messages without connector response.
+     */
+    public boolean hasError() {
+        return connectorResponse != null && connectorResponse.hasError();
+    }
+
+}

--- a/src/main/java/com/czertainly/api/clients/mq/secret/VaultApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/secret/VaultApiClient.java
@@ -1,0 +1,93 @@
+package com.czertainly.api.clients.mq.secret;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.secret.VaultSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class VaultApiClient implements VaultSyncApiClient {
+
+    private static final String VAULT_BASE_PATH = "/v1/secretProvider/vaults";
+    private static final String VAULT_PROFILE_BASE_PATH = "/v1/secretProvider/vaultProfiles";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public VaultApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public void checkVaultConnection(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) throws ConnectorException {
+        proxyClient.sendRequest(
+                connector,
+                VAULT_BASE_PATH,
+                HTTP_METHOD_POST,
+                attributes,
+                Void.class
+        );
+    }
+
+    @Override
+    public List<BaseAttribute> listVaultAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                VAULT_BASE_PATH + "/attributes",
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public List<BaseAttribute> listVaultProfileAttributes(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) throws ConnectorException {
+        BaseAttribute[] result = proxyClient.sendRequest(
+                connector,
+                VAULT_PROFILE_BASE_PATH + "/attributes",
+                HTTP_METHOD_POST,
+                attributes,
+                BaseAttribute[].class
+        );
+        return Arrays.asList(result);
+    }
+
+    // ==================== Async variants ====================
+
+    public CompletableFuture<Void> checkVaultConnectionAsync(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                VAULT_BASE_PATH,
+                HTTP_METHOD_POST,
+                attributes,
+                Void.class
+        );
+    }
+
+    public CompletableFuture<List<BaseAttribute>> listVaultAttributesAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                VAULT_BASE_PATH + "/attributes",
+                HTTP_METHOD_GET,
+                null,
+                BaseAttribute[].class
+        ).thenApply(Arrays::asList);
+    }
+
+    public CompletableFuture<List<BaseAttribute>> listVaultProfileAttributesAsync(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) {
+        return proxyClient.sendRequestAsync(
+                connector,
+                VAULT_PROFILE_BASE_PATH + "/attributes",
+                HTTP_METHOD_POST,
+                attributes,
+                BaseAttribute[].class
+        ).thenApply(Arrays::asList);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -1,0 +1,91 @@
+package com.czertainly.api.clients.mq.v2;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v2.CertificateSyncApiClient;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.v2.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of v2 Certificate API client.
+ */
+public class CertificateApiClient implements CertificateSyncApiClient {
+
+    private static final String BASE_PATH = "/v2/authorityProvider/authorities";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public CertificateApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<BaseAttribute> listIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public Boolean validateIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/attributes/validate";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Boolean.class);
+    }
+
+    @Override
+    public CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+    }
+
+    @Override
+    public CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/renew";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+    }
+
+    @Override
+    public List<BaseAttribute> listRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public Boolean validateRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/attributes/validate";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Boolean.class);
+    }
+
+    @Override
+    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/identify";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateIdentificationResponseDto.class);
+    }
+
+    // Async variants
+    public CompletableFuture<CertificateDataResponseDto> issueCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+    }
+
+    public CompletableFuture<CertificateDataResponseDto> renewCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/renew";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/v2/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/ComplianceApiClient.java
@@ -7,6 +7,8 @@ import com.czertainly.api.interfaces.client.v2.ComplianceSyncApiClient;
 import com.czertainly.api.model.connector.compliance.v2.*;
 import com.czertainly.api.model.core.auth.Resource;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -32,15 +34,15 @@ public class ComplianceApiClient implements ComplianceSyncApiClient {
         StringBuilder pathBuilder = new StringBuilder(BASE_PATH).append("/").append(kind).append("/rules");
         boolean hasQuery = false;
         if (resource != null) {
-            pathBuilder.append("?resource=").append(resource);
+            pathBuilder.append("?resource=").append(URLEncoder.encode(resource.toString(), StandardCharsets.UTF_8));
             hasQuery = true;
         }
         if (type != null) {
-            pathBuilder.append(hasQuery ? "&" : "?").append("type=").append(type);
+            pathBuilder.append(hasQuery ? "&" : "?").append("type=").append(URLEncoder.encode(type, StandardCharsets.UTF_8));
             hasQuery = true;
         }
         if (format != null) {
-            pathBuilder.append(hasQuery ? "&" : "?").append("format=").append(format);
+            pathBuilder.append(hasQuery ? "&" : "?").append("format=").append(URLEncoder.encode(format, StandardCharsets.UTF_8));
         }
         ComplianceRuleResponseDto[] result = proxyClient.sendRequest(connector, pathBuilder.toString(), HTTP_METHOD_GET, null, ComplianceRuleResponseDto[].class);
         return Arrays.asList(result);
@@ -62,7 +64,7 @@ public class ComplianceApiClient implements ComplianceSyncApiClient {
     public List<ComplianceGroupResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind, Resource resource) throws ConnectorException {
         StringBuilder pathBuilder = new StringBuilder(BASE_PATH).append("/").append(kind).append("/groups");
         if (resource != null) {
-            pathBuilder.append("?resource=").append(resource);
+            pathBuilder.append("?resource=").append(URLEncoder.encode(resource.toString(), StandardCharsets.UTF_8));
         }
         ComplianceGroupResponseDto[] result = proxyClient.sendRequest(connector, pathBuilder.toString(), HTTP_METHOD_GET, null, ComplianceGroupResponseDto[].class);
         return Arrays.asList(result);

--- a/src/main/java/com/czertainly/api/clients/mq/v2/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/ComplianceApiClient.java
@@ -1,0 +1,100 @@
+package com.czertainly.api.clients.mq.v2;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.ComplianceSyncApiClient;
+import com.czertainly.api.model.connector.compliance.v2.*;
+import com.czertainly.api.model.core.auth.Resource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of v2 Compliance API client.
+ */
+public class ComplianceApiClient implements ComplianceSyncApiClient {
+
+    private static final String BASE_PATH = "/v2/complianceProvider";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public ComplianceApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<ComplianceRuleResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, Resource resource, String type, String format) throws ConnectorException {
+        StringBuilder pathBuilder = new StringBuilder(BASE_PATH).append("/").append(kind).append("/rules");
+        boolean hasQuery = false;
+        if (resource != null) {
+            pathBuilder.append("?resource=").append(resource);
+            hasQuery = true;
+        }
+        if (type != null) {
+            pathBuilder.append(hasQuery ? "&" : "?").append("type=").append(type);
+            hasQuery = true;
+        }
+        if (format != null) {
+            pathBuilder.append(hasQuery ? "&" : "?").append("format=").append(format);
+        }
+        ComplianceRuleResponseDto[] result = proxyClient.sendRequest(connector, pathBuilder.toString(), HTTP_METHOD_GET, null, ComplianceRuleResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public ComplianceRuleResponseDto getComplianceRule(ApiClientConnectorInfo connector, String kind, UUID ruleUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/rules/" + ruleUuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, ComplianceRuleResponseDto.class);
+    }
+
+    @Override
+    public ComplianceRulesBatchResponseDto getComplianceRulesBatch(ApiClientConnectorInfo connector, String kind, ComplianceRulesBatchRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/rules";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, ComplianceRulesBatchResponseDto.class);
+    }
+
+    @Override
+    public List<ComplianceGroupResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind, Resource resource) throws ConnectorException {
+        StringBuilder pathBuilder = new StringBuilder(BASE_PATH).append("/").append(kind).append("/groups");
+        if (resource != null) {
+            pathBuilder.append("?resource=").append(resource);
+        }
+        ComplianceGroupResponseDto[] result = proxyClient.sendRequest(connector, pathBuilder.toString(), HTTP_METHOD_GET, null, ComplianceGroupResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public ComplianceGroupResponseDto getComplianceGroup(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/groups/" + groupUuid;
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, ComplianceGroupResponseDto.class);
+    }
+
+    @Override
+    public List<ComplianceRuleResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/groups/" + groupUuid + "/rules";
+        ComplianceRuleResponseDto[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, ComplianceRuleResponseDto[].class);
+        return Arrays.asList(result);
+    }
+
+    @Override
+    public ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + kind + "/compliance";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, ComplianceResponseDto.class);
+    }
+
+    // Async variants
+    public CompletableFuture<ComplianceResponseDto> checkComplianceAsync(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) {
+        String path = BASE_PATH + "/" + kind + "/compliance";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, ComplianceResponseDto.class);
+    }
+
+    public CompletableFuture<ComplianceRulesBatchResponseDto> getComplianceRulesBatchAsync(ApiClientConnectorInfo connector, String kind, ComplianceRulesBatchRequestDto requestDto) {
+        String path = BASE_PATH + "/" + kind + "/rules";
+        return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, ComplianceRulesBatchResponseDto.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/v2/HealthApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/HealthApiClient.java
@@ -1,0 +1,53 @@
+package com.czertainly.api.clients.mq.v2;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.HealthSyncApiClient;
+import com.czertainly.api.model.client.connector.v2.HealthInfo;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of v2 Health API client.
+ */
+public class HealthApiClient implements HealthSyncApiClient {
+
+    private static final String HEALTH_PATH = "/v2/health";
+    private static final String HEALTH_LIVENESS_PATH = "/v2/health/liveness";
+    private static final String HEALTH_READINESS_PATH = "/v2/health/readiness";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    public HealthApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public HealthInfo checkHealth(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(connector, HEALTH_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+
+    @Override
+    public HealthInfo checkHealthLiveness(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(connector, HEALTH_LIVENESS_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+
+    @Override
+    public HealthInfo checkHealthReadiness(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(connector, HEALTH_READINESS_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+
+    public CompletableFuture<HealthInfo> checkHealthAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, HEALTH_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+
+    public CompletableFuture<HealthInfo> checkHealthLivenessAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, HEALTH_LIVENESS_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+
+    public CompletableFuture<HealthInfo> checkHealthReadinessAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, HEALTH_READINESS_PATH, HTTP_METHOD_GET, null, HealthInfo.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/v2/InfoApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/InfoApiClient.java
@@ -1,0 +1,33 @@
+package com.czertainly.api.clients.mq.v2;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.InfoSyncApiClient;
+import com.czertainly.api.model.client.connector.v2.InfoResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of v2 Info API client.
+ */
+public class InfoApiClient implements InfoSyncApiClient {
+
+    private static final String INFO_PATH = "/v2/info";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    public InfoApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public InfoResponse getConnectorInfo(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(connector, INFO_PATH, HTTP_METHOD_GET, null, InfoResponse.class);
+    }
+
+    public CompletableFuture<InfoResponse> getConnectorInfoAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, INFO_PATH, HTTP_METHOD_GET, null, InfoResponse.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/v2/MetricsApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/MetricsApiClient.java
@@ -1,0 +1,32 @@
+package com.czertainly.api.clients.mq.v2;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.mq.ProxyClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.MetricsSyncApiClient;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MQ-based implementation of v2 Metrics API client.
+ */
+public class MetricsApiClient implements MetricsSyncApiClient {
+
+    private static final String METRICS_PATH = "/v1/metrics";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    public MetricsApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public String getMetrics(ApiClientConnectorInfo connector) throws ConnectorException {
+        return proxyClient.sendRequest(connector, METRICS_PATH, HTTP_METHOD_GET, null, String.class);
+    }
+
+    public CompletableFuture<String> getMetricsAsync(ApiClientConnectorInfo connector) {
+        return proxyClient.sendRequestAsync(connector, METRICS_PATH, HTTP_METHOD_GET, null, String.class);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/secret/VaultApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/secret/VaultApiClient.java
@@ -3,6 +3,7 @@ package com.czertainly.api.clients.secret;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.secret.VaultSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import org.springframework.http.HttpMethod;
@@ -11,7 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class VaultApiClient extends BaseApiClient {
+public class VaultApiClient extends BaseApiClient implements VaultSyncApiClient {
 
     private static final String VAULT_BASE_PATH = "/v1/secretProvider/vaults";
     private static final String VAULT_PROFILE_BASE_PATH = "/v1/secretProvider/vaultProfiles";

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -1,12 +1,13 @@
 package com.czertainly.api.clients.v2;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.v2.*;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,7 +16,7 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class CertificateApiClient extends BaseApiClient {
+public class CertificateApiClient extends BaseApiClient implements CertificateSyncApiClient {
 
     private static final String CERTIFICATE_BASE_CONTEXT = "/v2/authorityProvider/authorities/{uuid}/certificates";
 
@@ -39,7 +40,8 @@ public class CertificateApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<BaseAttribute> listIssueCertificateAttributes(ConnectorDto connector, String authorityUuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -51,7 +53,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public Boolean validateIssueCertificateAttributes(ConnectorDto connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public Boolean validateIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -64,7 +67,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public CertificateDataResponseDto issueCertificate(ConnectorDto connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
+    @Override
+    public CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -77,7 +81,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public CertificateDataResponseDto renewCertificate(ConnectorDto connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
+    @Override
+    public CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -90,7 +95,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<BaseAttribute> listRevokeCertificateAttributes(ConnectorDto connector, String authorityUuid) throws ConnectorException {
+    @Override
+    public List<BaseAttribute> listRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -102,7 +108,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public Boolean validateRevokeCertificateAttributes(ConnectorDto connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
+    @Override
+    public Boolean validateRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -115,7 +122,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public void revokeCertificate(ConnectorDto connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+    @Override
+    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
@@ -128,7 +136,8 @@ public class CertificateApiClient extends BaseApiClient {
                 connector);
     }
 
-    public CertificateIdentificationResponseDto identifyCertificate(ConnectorDto connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException {
+    @Override
+    public CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/v2/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/ComplianceApiClient.java
@@ -1,10 +1,11 @@
 package com.czertainly.api.clients.v2;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.ComplianceSyncApiClient;
 import com.czertainly.api.model.connector.compliance.v2.*;
 import com.czertainly.api.model.core.auth.Resource;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
@@ -16,7 +17,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-public class ComplianceApiClient extends BaseApiClient {
+public class ComplianceApiClient extends BaseApiClient implements ComplianceSyncApiClient {
 
     private static final String COMPLIANCE_BASE_CONTEXT = "/v2/complianceProvider/{kind}";
     private static final String COMPLIANCE_RULES_GET_CONTEXT = COMPLIANCE_BASE_CONTEXT + "/rules";
@@ -35,7 +36,8 @@ public class ComplianceApiClient extends BaseApiClient {
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
-    public List<ComplianceRuleResponseDto> getComplianceRules(ConnectorDto connector, String kind, Resource resource, String type, String format) throws ConnectorException {
+    @Override
+    public List<ComplianceRuleResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, Resource resource, String type, String format) throws ConnectorException {
         URI uri;
         UriBuilder uriBuilder = UriComponentsBuilder.fromUriString(connector.getUrl());
         uriBuilder.path(COMPLIANCE_RULES_GET_CONTEXT.replace("{kind}", kind));
@@ -60,7 +62,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public ComplianceRuleResponseDto getComplianceRule(ConnectorDto connector, String kind, UUID ruleUuid) throws ConnectorException {
+    @Override
+    public ComplianceRuleResponseDto getComplianceRule(ApiClientConnectorInfo connector, String kind, UUID ruleUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -72,7 +75,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public ComplianceRulesBatchResponseDto getComplianceRulesBatch(ConnectorDto connector, String kind, ComplianceRulesBatchRequestDto requestDto) throws ConnectorException {
+    @Override
+    public ComplianceRulesBatchResponseDto getComplianceRulesBatch(ApiClientConnectorInfo connector, String kind, ComplianceRulesBatchRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -85,7 +89,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<ComplianceGroupResponseDto> getComplianceGroups(ConnectorDto connector, String kind, Resource resource) throws ConnectorException {
+    @Override
+    public List<ComplianceGroupResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind, Resource resource) throws ConnectorException {
         URI uri;
         UriBuilder uriBuilder = UriComponentsBuilder.fromUriString(connector.getUrl());
         uriBuilder.path(COMPLIANCE_GROUPS_GET_CONTEXT.replace("{kind}", kind));
@@ -103,7 +108,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public ComplianceGroupResponseDto getComplianceGroup(ConnectorDto connector, String kind, UUID groupUuid) throws ConnectorException {
+    @Override
+    public ComplianceGroupResponseDto getComplianceGroup(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -115,7 +121,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public List<ComplianceRuleResponseDto> getComplianceGroupRules(ConnectorDto connector, String kind, UUID groupUuid) throws ConnectorException {
+    @Override
+    public List<ComplianceRuleResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
@@ -127,7 +134,8 @@ public class ComplianceApiClient extends BaseApiClient {
                 connector);
     }
 
-    public ComplianceResponseDto checkCompliance(ConnectorDto connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
+    @Override
+    public ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/v2/HealthApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/HealthApiClient.java
@@ -3,19 +3,20 @@ package com.czertainly.api.clients.v2;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.HealthSyncApiClient;
 import com.czertainly.api.model.client.connector.v2.HealthInfo;
-import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.TrustManager;
 
-public class HealthApiClient extends BaseApiClient {
+public class HealthApiClient extends BaseApiClient implements HealthSyncApiClient {
 
     public HealthApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         super(webClient, defaultTrustManagers);
     }
 
+    @Override
     public HealthInfo checkHealth(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
         return processRequest(r -> r
@@ -27,7 +28,8 @@ public class HealthApiClient extends BaseApiClient {
                 connector);
     }
 
-    public HealthInfo checkHealthLiveness(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public HealthInfo checkHealthLiveness(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
         return processRequest(r -> r
                         .uri(connector.getUrl() + "/v2/health/liveness")
@@ -38,7 +40,8 @@ public class HealthApiClient extends BaseApiClient {
                 connector);
     }
 
-    public HealthInfo checkHealthReadiness(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public HealthInfo checkHealthReadiness(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
         return processRequest(r -> r
                         .uri(connector.getUrl() + "/v2/health/readiness")

--- a/src/main/java/com/czertainly/api/clients/v2/InfoApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/InfoApiClient.java
@@ -3,18 +3,20 @@ package com.czertainly.api.clients.v2;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v2.InfoSyncApiClient;
 import com.czertainly.api.model.client.connector.v2.InfoResponse;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.TrustManager;
 
-public class InfoApiClient extends BaseApiClient {
+public class InfoApiClient extends BaseApiClient implements InfoSyncApiClient {
 
     public InfoApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         super(webClient, defaultTrustManagers);
     }
 
+    @Override
     public InfoResponse getConnectorInfo(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
         return processRequest(r -> r

--- a/src/main/java/com/czertainly/api/clients/v2/MetricsApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/MetricsApiClient.java
@@ -1,20 +1,22 @@
 package com.czertainly.api.clients.v2;
 
+import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
-import com.czertainly.api.model.core.connector.ConnectorDto;
+import com.czertainly.api.interfaces.client.v2.MetricsSyncApiClient;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.net.ssl.TrustManager;
 
-public class MetricsApiClient extends BaseApiClient {
+public class MetricsApiClient extends BaseApiClient implements MetricsSyncApiClient {
 
     public MetricsApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         super(webClient, defaultTrustManagers);
     }
 
-    public String getMetrics(ConnectorDto connector) throws ConnectorException {
+    @Override
+    public String getMetrics(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
         return processRequest(r -> r
                         .uri(connector.getUrl() + "/v1/metrics")

--- a/src/main/java/com/czertainly/api/exception/MessageHandlingException.java
+++ b/src/main/java/com/czertainly/api/exception/MessageHandlingException.java
@@ -16,8 +16,18 @@ public class MessageHandlingException extends Exception {
         super(message);
     }
 
+    public MessageHandlingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public MessageHandlingException(String queueName, Object messageData, String message) {
         this(message);
+        this.queueName = queueName;
+        this.messageData = messageData;
+    }
+
+    public MessageHandlingException(String queueName, Object messageData, String message, Throwable cause) {
+        this(message, cause);
         this.queueName = queueName;
         this.messageData = messageData;
     }

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/AttributeSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/AttributeSyncApiClient.java
@@ -1,0 +1,80 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.common.attribute.common.callback.AttributeCallback;
+import com.czertainly.api.model.common.attribute.common.callback.RequestAttributeCallback;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.model.core.connector.FunctionGroupCode;
+
+import java.util.List;
+
+/**
+ * Interface for synchronous attribute API operations against connectors.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface AttributeSyncApiClient {
+
+    /**
+     * List attribute definitions for a connector.
+     *
+     * @param connector         Connector configuration
+     * @param functionGroupCode Function group code
+     * @param kind              Connector kind
+     * @return List of base attributes
+     * @throws ConnectorException If request fails
+     */
+    List<BaseAttribute> listAttributeDefinitions(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) throws ConnectorException;
+
+    /**
+     * List attribute definitions with BaseAttribute return type.
+     *
+     * @param connector         Connector configuration
+     * @param functionGroupCode Function group code
+     * @param kind              Connector kind
+     * @return List of base attributes
+     * @throws ConnectorException If request fails
+     */
+    default List<BaseAttribute> listAttributeDefinitions1(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            String kind) throws ConnectorException {
+        return listAttributeDefinitions(connector, functionGroupCode, kind);
+    }
+
+    /**
+     * Validate attributes against a connector.
+     *
+     * @param connector         Connector configuration
+     * @param functionGroupCode Function group code
+     * @param attributes        Attributes to validate
+     * @param functionGroupType Function group type (kind)
+     * @return null on success
+     * @throws ValidationException If validation fails
+     * @throws ConnectorException  If request fails
+     */
+    Void validateAttributes(
+            ApiClientConnectorInfo connector,
+            FunctionGroupCode functionGroupCode,
+            List<RequestAttribute> attributes,
+            String functionGroupType) throws ValidationException, ConnectorException;
+
+    /**
+     * Execute attribute callback.
+     *
+     * @param connector       Connector configuration
+     * @param callback        Callback configuration with method and context
+     * @param callbackRequest Request with path variables, query params, and body
+     * @return Callback response object
+     * @throws ConnectorException If request fails
+     */
+    Object attributeCallback(
+            ApiClientConnectorInfo connector,
+            AttributeCallback callback,
+            RequestAttributeCallback callbackRequest) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/AttributeSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/AttributeSyncApiClient.java
@@ -32,22 +32,6 @@ public interface AttributeSyncApiClient {
             String kind) throws ConnectorException;
 
     /**
-     * List attribute definitions with BaseAttribute return type.
-     *
-     * @param connector         Connector configuration
-     * @param functionGroupCode Function group code
-     * @param kind              Connector kind
-     * @return List of base attributes
-     * @throws ConnectorException If request fails
-     */
-    default List<BaseAttribute> listAttributeDefinitions1(
-            ApiClientConnectorInfo connector,
-            FunctionGroupCode functionGroupCode,
-            String kind) throws ConnectorException {
-        return listAttributeDefinitions(connector, functionGroupCode, kind);
-    }
-
-    /**
      * Validate attributes against a connector.
      *
      * @param connector         Connector configuration

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/AuthorityInstanceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/AuthorityInstanceSyncApiClient.java
@@ -1,0 +1,40 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceDto;
+import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceRequestDto;
+import com.czertainly.api.model.connector.authority.CaCertificatesRequestDto;
+import com.czertainly.api.model.connector.authority.CaCertificatesResponseDto;
+import com.czertainly.api.model.connector.authority.CertificateRevocationListRequestDto;
+import com.czertainly.api.model.connector.authority.CertificateRevocationListResponseDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Synchronous API client interface for Authority Provider Instance operations.
+ * Implementations include REST-based and MQ-based clients.
+ */
+public interface AuthorityInstanceSyncApiClient {
+
+    List<AuthorityProviderInstanceDto> listAuthorityInstances(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    AuthorityProviderInstanceDto getAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+
+    AuthorityProviderInstanceDto createAuthorityInstance(ApiClientConnectorInfo connector, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException;
+
+    AuthorityProviderInstanceDto updateAuthorityInstance(ApiClientConnectorInfo connector, String uuid, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException;
+
+    void removeAuthorityInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+
+    List<BaseAttribute> listRAProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+
+    Boolean validateRAProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+    CertificateRevocationListResponseDto getCrl(ApiClientConnectorInfo connector, String uuid, CertificateRevocationListRequestDto requestDto) throws ConnectorException;
+
+    CaCertificatesResponseDto getCaCertificates(ApiClientConnectorInfo connector, String uuid, CaCertificatesRequestDto requestDto) throws ValidationException, ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/CertificateSyncApiClient.java
@@ -1,0 +1,37 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.core.authority.CertRevocationDto;
+import com.czertainly.api.model.core.authority.CertificateSignRequestDto;
+import com.czertainly.api.model.core.authority.CertificateSignResponseDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Interface for synchronous certificate operations against connectors.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface CertificateSyncApiClient {
+
+    /**
+     * Issue a certificate via authority provider.
+     *
+     * @param connector            Connector configuration
+     * @param authorityUuid        Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param requestDto           Certificate sign request
+     * @return Certificate sign response with issued certificate
+     * @throws ConnectorException If request fails
+     */
+    CertificateSignResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Revoke a certificate via authority provider.
+     *
+     * @param connector            Connector configuration
+     * @param authorityUuid        Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param requestDto           Certificate revocation request
+     * @throws ConnectorException If request fails
+     */
+    void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, CertRevocationDto requestDto) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/ComplianceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/ComplianceSyncApiClient.java
@@ -1,0 +1,25 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.connector.compliance.ComplianceGroupsResponseDto;
+import com.czertainly.api.model.connector.compliance.ComplianceRequestDto;
+import com.czertainly.api.model.connector.compliance.ComplianceResponseDto;
+import com.czertainly.api.model.connector.compliance.ComplianceRulesResponseDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Sync interface for v1 Compliance API client operations.
+ * This interface is implemented by both REST and MQ clients.
+ */
+public interface ComplianceSyncApiClient {
+
+    List<ComplianceRulesResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, List<String> certificateType) throws ConnectorException;
+
+    List<ComplianceGroupsResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind) throws ConnectorException;
+
+    List<ComplianceRulesResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, String uuid) throws ConnectorException;
+
+    ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/ConnectorSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/ConnectorSyncApiClient.java
@@ -1,0 +1,23 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.connector.InfoResponse;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Interface for synchronous connector API operations.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface ConnectorSyncApiClient {
+
+    /**
+     * List supported functions of a connector.
+     *
+     * @param connector Connector configuration
+     * @return List of supported functions
+     * @throws ConnectorException If request fails
+     */
+    List<InfoResponse> listSupportedFunctions(ApiClientConnectorInfo connector) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/CryptographicOperationsSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/CryptographicOperationsSyncApiClient.java
@@ -1,0 +1,20 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.operations.*;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+public interface CryptographicOperationsSyncApiClient {
+    EncryptDataResponseDto encryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException;
+    DecryptDataResponseDto decryptData(ApiClientConnectorInfo connector, String uuid, String keyUuid, CipherDataRequestDto requestDto) throws ConnectorException;
+    SignDataResponseDto signData(ApiClientConnectorInfo connector, String uuid, String keyUuid, SignDataRequestDto requestDto) throws ConnectorException;
+    VerifyDataResponseDto verifyData(ApiClientConnectorInfo connector, String uuid, String keyUuid, VerifyDataRequestDto requestDto) throws ConnectorException;
+    List<BaseAttribute> listRandomAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    void validateRandomAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    RandomDataResponseDto randomData(ApiClientConnectorInfo connector, String uuid, RandomDataRequestDto requestDto) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/DiscoverySyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/DiscoverySyncApiClient.java
@@ -1,0 +1,44 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
+import com.czertainly.api.model.connector.discovery.DiscoveryProviderDto;
+import com.czertainly.api.model.connector.discovery.DiscoveryRequestDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Interface for synchronous discovery operations against connectors.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface DiscoverySyncApiClient {
+
+    /**
+     * Trigger certificate discovery on a connector.
+     *
+     * @param connector  Connector configuration
+     * @param requestDto Discovery request parameters
+     * @return Discovery provider response with status and UUID
+     * @throws ConnectorException If request fails
+     */
+    DiscoveryProviderDto discoverCertificates(ApiClientConnectorInfo connector, DiscoveryRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Get discovery data from a connector.
+     *
+     * @param connector  Connector configuration
+     * @param requestDto Discovery data request with pagination
+     * @param uuid       Discovery UUID at the connector
+     * @return Discovery provider response with certificate data
+     * @throws ConnectorException If request fails
+     */
+    DiscoveryProviderDto getDiscoveryData(ApiClientConnectorInfo connector, DiscoveryDataRequestDto requestDto, String uuid) throws ConnectorException;
+
+    /**
+     * Remove discovery from a connector.
+     *
+     * @param connector Connector configuration
+     * @param uuid      Discovery UUID at the connector
+     * @throws ConnectorException If request fails
+     */
+    void removeDiscovery(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/EndEntityProfileSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/EndEntityProfileSyncApiClient.java
@@ -1,0 +1,46 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.common.NameAndIdDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Interface for synchronous end entity profile operations against connectors.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface EndEntityProfileSyncApiClient {
+
+    /**
+     * List end entity profiles for an authority instance.
+     *
+     * @param connector     Connector configuration
+     * @param authorityUuid Authority instance UUID
+     * @return List of end entity profiles
+     * @throws ConnectorException If request fails
+     */
+    List<NameAndIdDto> listEndEntityProfiles(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException;
+
+    /**
+     * List certificate profiles for an end entity profile.
+     *
+     * @param connector           Connector configuration
+     * @param authorityUuid       Authority instance UUID
+     * @param endEntityProfileId  End entity profile ID
+     * @return List of certificate profiles
+     * @throws ConnectorException If request fails
+     */
+    List<NameAndIdDto> listCertificateProfiles(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException;
+
+    /**
+     * List CAs available in an end entity profile.
+     *
+     * @param connector           Connector configuration
+     * @param authorityUuid       Authority instance UUID
+     * @param endEntityProfileId  End entity profile ID
+     * @return List of CAs
+     * @throws ConnectorException If request fails
+     */
+    List<NameAndIdDto> listCAsInProfile(ApiClientConnectorInfo connector, String authorityUuid, int endEntityProfileId) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/EndEntitySyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/EndEntitySyncApiClient.java
@@ -1,0 +1,84 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.core.authority.AddEndEntityRequestDto;
+import com.czertainly.api.model.core.authority.EditEndEntityRequestDto;
+import com.czertainly.api.model.core.authority.EndEntityDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Synchronous API client interface for End Entity operations.
+ * This interface provides an abstraction layer allowing both REST and MQ implementations.
+ */
+public interface EndEntitySyncApiClient {
+
+    /**
+     * List all end entities for a given authority and end entity profile.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @return List of end entities
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<EndEntityDto> listEntities(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName) throws ConnectorException;
+
+    /**
+     * Get a specific end entity.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param endEntityName End entity name
+     * @return End entity details
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    EndEntityDto getEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException;
+
+    /**
+     * Create a new end entity.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param requestDto End entity creation request
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void createEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, AddEndEntityRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Update an existing end entity.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param endEntityName End entity name
+     * @param requestDto End entity update request
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void updateEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName, EditEndEntityRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Revoke and delete an end entity.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param endEntityName End entity name
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void revokeAndDeleteEndEntity(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException;
+
+    /**
+     * Reset password for an end entity.
+     *
+     * @param connector Connector to use
+     * @param authorityUuid Authority instance UUID
+     * @param endEntityProfileName End entity profile name
+     * @param endEntityName End entity name
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void resetPassword(ApiClientConnectorInfo connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/EntityInstanceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/EntityInstanceSyncApiClient.java
@@ -1,0 +1,32 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.entity.EntityInstanceDto;
+import com.czertainly.api.model.connector.entity.EntityInstanceRequestDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Synchronous API client interface for Entity Provider Instance operations.
+ * Implementations include REST-based and MQ-based clients.
+ */
+public interface EntityInstanceSyncApiClient {
+
+    List<EntityInstanceDto> listEntityInstances(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    EntityInstanceDto getEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException;
+
+    EntityInstanceDto createEntityInstance(ApiClientConnectorInfo connector, EntityInstanceRequestDto requestDto) throws ConnectorException;
+
+    EntityInstanceDto updateEntityInstance(ApiClientConnectorInfo connector, String entityUuid, EntityInstanceRequestDto requestDto) throws ConnectorException;
+
+    void removeEntityInstance(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException;
+
+    List<BaseAttribute> listLocationAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException;
+
+    void validateLocationAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/HealthSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/HealthSyncApiClient.java
@@ -1,0 +1,21 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.common.HealthDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Interface for synchronous health check operations against connectors.
+ * Implementations can use REST (direct HTTP) or MQ (proxy) communication.
+ */
+public interface HealthSyncApiClient {
+
+    /**
+     * Check health status of a connector.
+     *
+     * @param connector Connector configuration
+     * @return Health status
+     * @throws ConnectorException If request fails
+     */
+    HealthDto checkHealth(ApiClientConnectorInfo connector) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/KeyManagementSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/KeyManagementSyncApiClient.java
@@ -1,0 +1,24 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+public interface KeyManagementSyncApiClient {
+    List<BaseAttribute> listCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    void validateCreateSecretKeyAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    KeyDataResponseDto createSecretKey(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException;
+    List<BaseAttribute> listCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    void validateCreateKeyPairAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    KeyPairDataResponseDto createKeyPair(ApiClientConnectorInfo connector, String uuid, CreateKeyRequestDto requestDto) throws ConnectorException;
+    List<KeyDataResponseDto> listKeys(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    KeyDataResponseDto getKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException;
+    void destroyKey(ApiClientConnectorInfo connector, String uuid, String keyUuid) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/LocationSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/LocationSyncApiClient.java
@@ -1,0 +1,39 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.entity.GenerateCsrRequestDto;
+import com.czertainly.api.model.connector.entity.GenerateCsrResponseDto;
+import com.czertainly.api.model.connector.entity.LocationDetailRequestDto;
+import com.czertainly.api.model.connector.entity.LocationDetailResponseDto;
+import com.czertainly.api.model.connector.entity.PushCertificateRequestDto;
+import com.czertainly.api.model.connector.entity.PushCertificateResponseDto;
+import com.czertainly.api.model.connector.entity.RemoveCertificateRequestDto;
+import com.czertainly.api.model.connector.entity.RemoveCertificateResponseDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Synchronous API client interface for Location operations.
+ * Implementations include REST-based and MQ-based clients.
+ */
+public interface LocationSyncApiClient {
+
+    LocationDetailResponseDto getLocationDetail(ApiClientConnectorInfo connector, String entityUuid, LocationDetailRequestDto requestDto) throws ConnectorException;
+
+    PushCertificateResponseDto pushCertificateToLocation(ApiClientConnectorInfo connector, String entityUuid, PushCertificateRequestDto requestDto) throws ConnectorException;
+
+    List<BaseAttribute> listPushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException;
+
+    void validatePushCertificateAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException;
+
+    RemoveCertificateResponseDto removeCertificateFromLocation(ApiClientConnectorInfo connector, String entityUuid, RemoveCertificateRequestDto requestDto) throws ConnectorException;
+
+    GenerateCsrResponseDto generateCsrLocation(ApiClientConnectorInfo connector, String entityUuid, GenerateCsrRequestDto requestDto) throws ConnectorException;
+
+    List<BaseAttribute> listGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid) throws ConnectorException;
+
+    void validateGenerateCsrAttributes(ApiClientConnectorInfo connector, String entityUuid, List<RequestAttribute> pushAttributes) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/NotificationInstanceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/NotificationInstanceSyncApiClient.java
@@ -1,0 +1,86 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.common.attribute.common.DataAttribute;
+import com.czertainly.api.model.connector.notification.NotificationProviderInstanceDto;
+import com.czertainly.api.model.connector.notification.NotificationProviderInstanceRequestDto;
+import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Synchronous API client interface for Notification Instance operations.
+ * This interface provides an abstraction layer allowing both REST and MQ implementations.
+ */
+public interface NotificationInstanceSyncApiClient {
+
+    /**
+     * List all notification instances.
+     *
+     * @param connector Connector to use
+     * @return List of notification instances
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<NotificationProviderInstanceDto> listNotificationInstances(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    /**
+     * Get a specific notification instance.
+     *
+     * @param connector Connector to use
+     * @param uuid Notification instance UUID
+     * @return Notification instance details
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    NotificationProviderInstanceDto getNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param connector Connector to use
+     * @param requestDto Notification instance creation request
+     * @return Created notification instance
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    NotificationProviderInstanceDto createNotificationInstance(ApiClientConnectorInfo connector, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Update an existing notification instance.
+     *
+     * @param connector Connector to use
+     * @param uuid Notification instance UUID
+     * @param requestDto Notification instance update request
+     * @return Updated notification instance
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    NotificationProviderInstanceDto updateNotificationInstance(ApiClientConnectorInfo connector, String uuid, NotificationProviderInstanceRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Remove a notification instance.
+     *
+     * @param connector Connector to use
+     * @param uuid Notification instance UUID
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void removeNotificationInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+
+    /**
+     * Send a notification.
+     *
+     * @param connector Connector to use
+     * @param uuid Notification instance UUID
+     * @param requestDto Notification request
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    void sendNotification(ApiClientConnectorInfo connector, String uuid, NotificationProviderNotifyRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * List mapping attributes for a notification kind.
+     *
+     * @param connector Connector to use
+     * @param kind Notification provider kind
+     * @return List of data attributes
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<DataAttribute> listMappingAttributes(ApiClientConnectorInfo connector, String kind) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/TokenInstanceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/TokenInstanceSyncApiClient.java
@@ -1,0 +1,27 @@
+package com.czertainly.api.interfaces.client.v1;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceDto;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceRequestDto;
+import com.czertainly.api.model.connector.cryptography.token.TokenInstanceStatusDto;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+public interface TokenInstanceSyncApiClient {
+    List<TokenInstanceDto> listTokenInstances(ApiClientConnectorInfo connector) throws ConnectorException;
+    TokenInstanceDto getTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    TokenInstanceDto createTokenInstance(ApiClientConnectorInfo connector, TokenInstanceRequestDto requestDto) throws ConnectorException;
+    TokenInstanceDto updateTokenInstance(ApiClientConnectorInfo connector, String uuid, TokenInstanceRequestDto requestDto) throws ConnectorException;
+    void removeTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    TokenInstanceStatusDto getTokenInstanceStatus(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    List<BaseAttribute> listTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    void validateTokenProfileAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    List<BaseAttribute> listTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+    void validateTokenInstanceActivationAttributes(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    void activateTokenInstance(ApiClientConnectorInfo connector, String uuid, List<RequestAttribute> attributes) throws ConnectorException;
+    void deactivateTokenInstance(ApiClientConnectorInfo connector, String uuid) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/secret/VaultSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/secret/VaultSyncApiClient.java
@@ -1,0 +1,17 @@
+package com.czertainly.api.interfaces.client.v1.secret;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.List;
+
+public interface VaultSyncApiClient {
+
+    void checkVaultConnection(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) throws ConnectorException;
+
+    List<BaseAttribute> listVaultAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    List<BaseAttribute> listVaultProfileAttributes(ApiClientConnectorInfo connector, List<RequestAttribute> attributes) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
@@ -1,0 +1,33 @@
+package com.czertainly.api.interfaces.client.v2;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.v2.*;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+
+/**
+ * Sync interface for v2 Certificate API client operations.
+ * This interface is implemented by both REST and MQ clients.
+ */
+public interface CertificateSyncApiClient {
+
+    List<BaseAttribute> listIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException;
+
+    Boolean validateIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+    CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException;
+
+    CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException;
+
+    List<BaseAttribute> listRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException;
+
+    Boolean validateRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+    void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
+
+    CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/ComplianceSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/ComplianceSyncApiClient.java
@@ -1,0 +1,95 @@
+package com.czertainly.api.interfaces.client.v2;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.connector.compliance.v2.*;
+import com.czertainly.api.model.core.auth.Resource;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Synchronous API client interface for v2 Compliance Provider operations.
+ * This interface provides an abstraction layer allowing both REST and MQ implementations.
+ */
+public interface ComplianceSyncApiClient {
+
+    /**
+     * Get compliance rules for the given kind with optional filtering.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param resource Resource to filter by (optional)
+     * @param type Resource type to filter by (optional)
+     * @param format Resource format to filter by (optional)
+     * @return List of compliance rules
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<ComplianceRuleResponseDto> getComplianceRules(ApiClientConnectorInfo connector, String kind, Resource resource, String type, String format) throws ConnectorException;
+
+    /**
+     * Get a specific compliance rule by UUID.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param ruleUuid UUID of the rule
+     * @return Compliance rule details
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    ComplianceRuleResponseDto getComplianceRule(ApiClientConnectorInfo connector, String kind, UUID ruleUuid) throws ConnectorException;
+
+    /**
+     * Get compliance rules in batch.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param requestDto Batch request containing rule and group UUIDs
+     * @return Batch response with rules and groups
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    ComplianceRulesBatchResponseDto getComplianceRulesBatch(ApiClientConnectorInfo connector, String kind, ComplianceRulesBatchRequestDto requestDto) throws ConnectorException;
+
+    /**
+     * Get compliance groups for the given kind with optional filtering.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param resource Resource to filter by (optional)
+     * @return List of compliance groups
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<ComplianceGroupResponseDto> getComplianceGroups(ApiClientConnectorInfo connector, String kind, Resource resource) throws ConnectorException;
+
+    /**
+     * Get a specific compliance group by UUID.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param groupUuid UUID of the group
+     * @return Compliance group details
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    ComplianceGroupResponseDto getComplianceGroup(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException;
+
+    /**
+     * Get rules within a compliance group.
+     *
+     * @param connector Connector to use
+     * @param kind Kind of compliance provider
+     * @param groupUuid UUID of the group
+     * @return List of rules in the group
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    List<ComplianceRuleResponseDto> getComplianceGroupRules(ApiClientConnectorInfo connector, String kind, UUID groupUuid) throws ConnectorException;
+
+    /**
+     * Check compliance of a resource against defined rules.
+     *
+     * @param connector Connector to use for compliance check
+     * @param kind Kind of compliance provider
+     * @param requestDto Compliance check request containing resource data and rules to check
+     * @return Compliance response with rule results
+     * @throws ConnectorException If there is an error communicating with the connector
+     */
+    ComplianceResponseDto checkCompliance(ApiClientConnectorInfo connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/HealthSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/HealthSyncApiClient.java
@@ -1,0 +1,18 @@
+package com.czertainly.api.interfaces.client.v2;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.connector.v2.HealthInfo;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Sync interface for v2 Health API client operations.
+ * This interface is implemented by both REST and MQ clients.
+ */
+public interface HealthSyncApiClient {
+
+    HealthInfo checkHealth(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    HealthInfo checkHealthLiveness(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    HealthInfo checkHealthReadiness(ApiClientConnectorInfo connector) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/InfoSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/InfoSyncApiClient.java
@@ -1,0 +1,14 @@
+package com.czertainly.api.interfaces.client.v2;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.client.connector.v2.InfoResponse;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Sync interface for v2 Info API client operations.
+ * This interface is implemented by both REST and MQ clients.
+ */
+public interface InfoSyncApiClient {
+
+    InfoResponse getConnectorInfo(ApiClientConnectorInfo connector) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/MetricsSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/MetricsSyncApiClient.java
@@ -1,0 +1,13 @@
+package com.czertainly.api.interfaces.client.v2;
+
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+
+/**
+ * Sync interface for v2 Metrics API client operations.
+ * This interface is implemented by both REST and MQ clients.
+ */
+public interface MetricsSyncApiClient {
+
+    String getMetrics(ApiClientConnectorInfo connector) throws ConnectorException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/core/web/ProxyController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/ProxyController.java
@@ -1,0 +1,81 @@
+package com.czertainly.api.interfaces.core.web;
+
+import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.interfaces.AuthProtectedController;
+import com.czertainly.api.model.client.proxy.ProxyRequestDto;
+import com.czertainly.api.model.client.proxy.ProxyUpdateRequestDto;
+import com.czertainly.api.model.common.ErrorMessageDto;
+import com.czertainly.api.model.common.UuidDto;
+import com.czertainly.api.model.core.proxy.ProxyDto;
+import com.czertainly.api.model.core.proxy.ProxyInstallInstructionsDto;
+import com.czertainly.api.model.core.proxy.ProxyListDto;
+import com.czertainly.api.model.core.proxy.ProxyStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/v1/proxies")
+@Tag(name = "Proxy Management", description = "Proxy Management API")
+@ApiResponses(
+    value =
+    @ApiResponse(
+        responseCode = "404",
+        description = "Not Found",
+        content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))
+    )
+)
+public interface ProxyController extends AuthProtectedController {
+
+    @Operation(summary = "List Proxies by Function Group and Kind")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "List all Proxies")})
+    @GetMapping(produces = {"application/json"})
+    List<ProxyListDto> listProxys(@RequestParam(required = false) ProxyStatus status);
+
+    @Operation(summary = "Get details of a Proxy")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Proxy details retrieved")})
+    @GetMapping(path = "/{uuid}", produces = {"application/json"})
+    ProxyDto getProxy(@Parameter(description = "Proxy UUID") @PathVariable String uuid) throws NotFoundException;
+
+    @Operation(summary = "Create a new Proxy")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "New Proxy created", content = @Content(schema = @Schema(implementation = UuidDto.class))),
+        @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+            examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))
+    })
+    @PostMapping(consumes = {"application/json"}, produces = {"application/json"})
+    ResponseEntity<?> createProxy(@RequestBody ProxyRequestDto request)
+        throws AlreadyExistException;
+
+    @Operation(summary = "Edit a Proxy")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Proxy updated"),
+        @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+            examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))
+    })
+    @PutMapping(path = "/{uuid}", consumes = {"application/json"}, produces = {"application/json"})
+    ProxyDto editProxy(@Parameter(description = "Proxy UUID") @PathVariable String uuid, @RequestBody ProxyUpdateRequestDto request)
+        throws NotFoundException;
+
+    @Operation(summary = "Delete a Proxy")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Proxy deleted")})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping(path = "/{uuid}", produces = {"application/json"})
+    void deleteProxy(@Parameter(description = "Proxy UUID") @PathVariable String uuid) throws NotFoundException;
+
+    @Operation(summary = "Get instructions to install a Proxy")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Proxy installation instructions retrieved")})
+    @GetMapping(path = "/{uuid}/instructions", produces = {"application/json"})
+    ProxyInstallInstructionsDto getInstallationInstructions(@Parameter(description = "Proxy UUID") @PathVariable String uuid) throws NotFoundException;
+}

--- a/src/main/java/com/czertainly/api/interfaces/core/web/ProxyController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/ProxyController.java
@@ -38,10 +38,10 @@ import java.util.List;
 )
 public interface ProxyController extends AuthProtectedController {
 
-    @Operation(summary = "List Proxies by Function Group and Kind")
+    @Operation(summary = "List Proxies by Status")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "List all Proxies")})
     @GetMapping(produces = {"application/json"})
-    List<ProxyListDto> listProxys(@RequestParam(required = false) ProxyStatus status);
+    List<ProxyListDto> listProxies(@RequestParam(required = false) ProxyStatus status);
 
     @Operation(summary = "Get details of a Proxy")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Proxy details retrieved")})

--- a/src/main/java/com/czertainly/api/interfaces/core/web/TrustedCertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/TrustedCertificateController.java
@@ -1,0 +1,63 @@
+package com.czertainly.api.interfaces.core.web;
+
+import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.interfaces.AuthProtectedController;
+import com.czertainly.api.model.client.trustedcertificate.TrustedCertificateRequestDto;
+import com.czertainly.api.model.client.trustedcertificate.TrustedCertificateDto;
+import com.czertainly.api.model.common.ErrorMessageDto;
+import com.czertainly.api.model.common.UuidDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/v1/trustedCertificates")
+@Tag(name = "Trusted Certificate Management", description = "Trusted Certificate Management API")
+@ApiResponses(
+    value =
+    @ApiResponse(
+        responseCode = "404",
+        description = "Not Found",
+        content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))
+    )
+)
+public interface TrustedCertificateController extends AuthProtectedController {
+
+    @Operation(summary = "List Trusted Certificates")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "List of Trusted Certificates")})
+    @GetMapping(produces = {"application/json"})
+    List<TrustedCertificateDto> listTrustedCertificates();
+
+    @Operation(summary = "Get details of a Trusted Certificate")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Trusted Certificate details retrieved")})
+    @GetMapping(path = "/{uuid}", produces = {"application/json"})
+    TrustedCertificateDto getTrustedCertificate(@Parameter(description = "Trusted Certificate UUID") @PathVariable String uuid) throws NotFoundException;
+
+    @Operation(summary = "Create a new Trusted Certificate")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "New Trusted Certificate created", content = @Content(schema = @Schema(implementation = UuidDto.class))),
+        @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+            examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))
+    })
+    @PostMapping(consumes = {"application/json"}, produces = {"application/json"})
+    ResponseEntity<?> createTrustedCertificate(@RequestBody TrustedCertificateRequestDto request)
+        throws AlreadyExistException;
+
+    @Operation(summary = "Delete a Trusted Certificate")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Trusted Certificate deleted")})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping(path = "/{uuid}", produces = {"application/json"})
+    void deleteTrustedCertificate(@Parameter(description = "Trusted Certificate UUID") @PathVariable String uuid) throws NotFoundException;
+
+}

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectRequestDto.java
@@ -2,6 +2,7 @@ package com.czertainly.api.model.client.connector;
 
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.core.connector.AuthType;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
@@ -34,10 +35,15 @@ public class ConnectRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<RequestAttribute> authAttributes;
 
+    @Schema(description = "Proxy for message queue routing. " +
+        "When set, connector communicates via message queue proxy. " +
+        "When null, connector uses direct REST communication.",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ProxyDto proxy;
+
     @AssertTrue(message = "Authentication Attributes must be provided when Authentication Type is not NONE")
     @JsonIgnore
     public boolean isValid() {
         return authType == AuthType.NONE || (authAttributes != null && !authAttributes.isEmpty());
     }
-
 }

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectorRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectorRequestDto.java
@@ -33,6 +33,14 @@ public class ConnectorRequestDto implements Named {
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttribute> customAttributes;
 
+    @Schema(description = "UUID of the Proxy",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyUuid;
+
+    @Schema(description = "Code of the Proxy that forwarded this registration request",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyCode;
+
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
@@ -41,6 +49,8 @@ public class ConnectorRequestDto implements Named {
                 .append("authType", authType)
                 .append("authAttributes", authAttributes)
                 .append("customAttributes", customAttributes)
+                .append("proxyUuid", proxyUuid)
+                .append("proxyCode", proxyCode)
                 .toString();
     }
 }

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectorUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectorUpdateRequestDto.java
@@ -25,6 +25,10 @@ public class ConnectorUpdateRequestDto {
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttribute> customAttributes;
 
+    @Schema(description = "UUID of the Proxy",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyUuid;
+
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
@@ -32,6 +36,7 @@ public class ConnectorUpdateRequestDto {
                 .append("authType", authType)
                 .append("authAttributes", authAttributes)
                 .append("customAttributes", customAttributes)
+                .append("proxyUuid", proxyUuid)
                 .toString();
     }
 }

--- a/src/main/java/com/czertainly/api/model/client/proxy/ProxyRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/proxy/ProxyRequestDto.java
@@ -1,0 +1,30 @@
+package com.czertainly.api.model.client.proxy;
+
+import com.czertainly.api.model.common.Named;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+@Setter
+@Getter
+public class ProxyRequestDto implements Named {
+
+    @Schema(description = "Name of the Proxy",
+            examples = {"MyProxy123"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+    @Schema(description = "Detailed description of the Proxy",
+            examples = {"This proxy is used for connecting to external connectors in DMZ network"},
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String description;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("name", name)
+                .append("description", description)
+                .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/client/proxy/ProxyUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/proxy/ProxyUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.czertainly.api.model.client.proxy;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+@Setter
+@Getter
+public class ProxyUpdateRequestDto {
+
+    @Schema(description = "Detailed description of the Proxy",
+        examples = {"This proxy is used for connecting to external connectors in DMZ network"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String description;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("description", description)
+            .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateDto.java
+++ b/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateDto.java
@@ -1,0 +1,67 @@
+package com.czertainly.api.model.client.trustedcertificate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class TrustedCertificateDto {
+
+    @Schema(
+            description = "UUID of the Trusted Certificate",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private String uuid;
+
+    @Schema(
+            description = "Base64 encoded Certificate content",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private byte[] certificateContent;
+
+    @Schema(
+            description = "Certificate issuer DN",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String issuer;
+
+    @Schema(
+            description = "Subject alternative names",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String san;
+
+    @Schema(
+            description = "Certificate serial number",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String serialNumber;
+
+    @Schema(
+            description = "Certificate subject DN",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String subject;
+
+    @Schema(
+            description = "Certificate thumbprint (fingerprint)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String thumbprint;
+
+    @Schema(
+            description = "Certificate validity start date",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private LocalDateTime notBefore;
+
+    @Schema(
+            description = "Certificate expiration date",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private LocalDateTime notAfter;
+
+}

--- a/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateDto.java
+++ b/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateDto.java
@@ -17,7 +17,7 @@ public class TrustedCertificateDto {
     private String uuid;
 
     @Schema(
-            description = "Base64 encoded Certificate content",
+            description = "Raw certificate content serialized as Base64 String in JSON",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] certificateContent;

--- a/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateRequestDto.java
@@ -1,0 +1,17 @@
+package com.czertainly.api.model.client.trustedcertificate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class TrustedCertificateRequestDto {
+
+    @Schema(
+            description = "Base64 encoded Certificate content",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private byte[] certificateContent;
+
+}

--- a/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/trustedcertificate/TrustedCertificateRequestDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 public class TrustedCertificateRequestDto {
 
     @Schema(
-            description = "Base64 encoded Certificate content",
+            description = "Raw certificate content serialized as Base64 String in JSON",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] certificateContent;

--- a/src/main/java/com/czertainly/api/model/core/auth/Resource.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/Resource.java
@@ -24,6 +24,7 @@ public enum Resource implements IPlatformEnum {
     CONNECTOR(Codes.CONNECTOR, "Connector", true, true),
     ATTRIBUTE(Codes.ATTRIBUTE, "Attribute", true),
     SCHEDULED_JOB("jobs", "Scheduled job"),
+    PROXY(Codes.PROXY, "Proxy", true),
 
     // AUTH
     USER(Codes.USER, "User", false, true, true, false),
@@ -93,7 +94,10 @@ public enum Resource implements IPlatformEnum {
     ACME_CHALLENGE("acmeChallenges", "ACME Challenge"),
     CMP_TRANSACTION("cmpTransactions", "CMP Transaction"),
     END_ENTITY_PROFILE("endEntityProfiles", "End entity profile"),
-    AUTHENTICATION_PROVIDER("authenticationProviders", "Authentication Provider")
+    AUTHENTICATION_PROVIDER("authenticationProviders", "Authentication Provider"),
+
+    // SAAS
+    TRUSTED_CERTIFICATE("trustedCertificates", "Trusted Certificate")
     ;
 
     private static final Resource[] VALUES;
@@ -219,6 +223,8 @@ public enum Resource implements IPlatformEnum {
         public static final String USER = "users";
         public static final String OID = "oids";
         public static final String ACME_ACCOUNT = "acmeAccounts";
+        public static final String PROXY = "proxies";
+        public static final String TRUSTED_CERTIFICATE = "trustedCertificates";
 
         public static final String CBOM = "cboms";
 

--- a/src/main/java/com/czertainly/api/model/core/auth/Resource.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/Resource.java
@@ -96,15 +96,13 @@ public enum Resource implements IPlatformEnum {
     END_ENTITY_PROFILE("endEntityProfiles", "End entity profile"),
     AUTHENTICATION_PROVIDER("authenticationProviders", "Authentication Provider"),
 
-<<<<<<< main-saas-pr
     // SAAS
-    TRUSTED_CERTIFICATE("trustedCertificates", "Trusted Certificate")
-=======
+    TRUSTED_CERTIFICATE("trustedCertificates", "Trusted Certificate"),
+
     // Secrets
     VAULT(Codes.VAULT, "Vault", true, true),
     VAULT_PROFILE(Codes.VAULT_PROFILE, "Vault Profile", true, true),
     SECRET(Codes.SECRET, "Secret", false, true)
->>>>>>> main
     ;
 
     private static final Resource[] VALUES;
@@ -230,14 +228,11 @@ public enum Resource implements IPlatformEnum {
         public static final String USER = "users";
         public static final String OID = "oids";
         public static final String ACME_ACCOUNT = "acmeAccounts";
-<<<<<<< main-saas-pr
         public static final String PROXY = "proxies";
         public static final String TRUSTED_CERTIFICATE = "trustedCertificates";
-=======
         public static final String VAULT = "vaults";
         public static final String VAULT_PROFILE = "vaultProfiles";
         public static final String SECRET = "secrets";
->>>>>>> main
 
         public static final String CBOM = "cboms";
 

--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorDto.java
@@ -3,6 +3,7 @@ package com.czertainly.api.model.core.connector;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.model.client.attribute.ResponseAttribute;
 import com.czertainly.api.model.common.NameAndUuidDto;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -34,6 +35,11 @@ public class ConnectorDto extends NameAndUuidDto implements ApiClientConnectorIn
             examples = {"CONNECTED"},
             requiredMode = Schema.RequiredMode.REQUIRED)
     private ConnectorStatus status;
+    @Schema(description = "Proxy for message queue routing. " +
+            "When set, connector communicates via message queue proxy. " +
+            "When null, connector uses direct REST communication.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ProxyDto proxy;
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttribute> customAttributes;
 
@@ -45,6 +51,7 @@ public class ConnectorDto extends NameAndUuidDto implements ApiClientConnectorIn
                 .append("authType", authType)
                 .append("authAttributes", authAttributes)
                 .append("status", status)
+                .append("proxy", proxy)
                 .append("name", name)
                 .append("uuid", uuid)
                 .append("customAttributes", customAttributes)

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorApiClientDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorApiClientDto.java
@@ -4,6 +4,7 @@ import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.model.client.attribute.ResponseAttribute;
 import com.czertainly.api.model.core.connector.AuthType;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -43,4 +44,10 @@ public class ConnectorApiClientDto implements ApiClientConnectorInfo {
     @Schema(description = "List of Attributes for the authentication type",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<ResponseAttribute> authAttributes;
+
+    @Schema(description = "Proxy for message queue routing. " +
+            "When set, connector communicates via message queue proxy. " +
+            "When null, connector uses direct REST communication.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ProxyDto proxy;
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDetailDto.java
@@ -2,15 +2,11 @@ package com.czertainly.api.model.core.connector.v2;
 
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.model.client.attribute.ResponseAttribute;
-import com.czertainly.api.model.client.connector.v2.ConnectorInterfaceInfo;
 import com.czertainly.api.model.core.connector.AuthType;
-import com.czertainly.api.model.core.connector.FunctionGroupDto;
-import com.czertainly.api.model.core.proxy.ProxyDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -29,11 +25,5 @@ public class ConnectorDetailDto extends ConnectorDto implements ApiClientConnect
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttribute> customAttributes;
-
-    @Schema(description = "Proxy for message queue routing. " +
-            "When set, connector communicates via message queue proxy. " +
-            "When null, connector uses direct REST communication.",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private ProxyDto proxy;
 
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDetailDto.java
@@ -5,6 +5,7 @@ import com.czertainly.api.model.client.attribute.ResponseAttribute;
 import com.czertainly.api.model.client.connector.v2.ConnectorInterfaceInfo;
 import com.czertainly.api.model.core.connector.AuthType;
 import com.czertainly.api.model.core.connector.FunctionGroupDto;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -36,5 +37,11 @@ public class ConnectorDetailDto extends ConnectorDto implements ApiClientConnect
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttribute> customAttributes;
+
+    @Schema(description = "Proxy for message queue routing. " +
+            "When set, connector communicates via message queue proxy. " +
+            "When null, connector uses direct REST communication.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ProxyDto proxy;
 
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorDto.java
@@ -4,6 +4,7 @@ import com.czertainly.api.model.client.connector.v2.ConnectorVersion;
 import com.czertainly.api.model.common.NameAndUuidDto;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupDto;
+import com.czertainly.api.model.core.proxy.ProxyDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -37,5 +38,11 @@ public class ConnectorDto extends NameAndUuidDto {
     @Schema(description = "List of connector interfaces implemented by the Connector",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ConnectorInterfaceDto> interfaces = new ArrayList<>();
+
+    @Schema(description = "Proxy for message queue routing. " +
+            "When set, connector communicates via message queue proxy. " +
+            "When null, connector uses direct REST communication.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ProxyDto proxy;
 
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorRequestDto.java
@@ -48,6 +48,14 @@ public class ConnectorRequestDto implements Named {
     @Schema(description = "List of Custom Attributes", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttribute> customAttributes = new ArrayList<>();
 
+    @Schema(description = "UUID of the Proxy",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyUuid;
+
+    @Schema(description = "Code of the Proxy that forwarded this registration request",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyCode;
+
     @AssertTrue(message = "Authentication Attributes must be provided when Authentication Type is not NONE")
     @JsonIgnore
     public boolean isValid() {
@@ -56,6 +64,6 @@ public class ConnectorRequestDto implements Named {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("name", name).append("url", url).append("authType", authType).append("authAttributes", authAttributes).append("customAttributes", customAttributes).toString();
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("name", name).append("url", url).append("authType", authType).append("authAttributes", authAttributes).append("customAttributes", customAttributes).append("proxyUuid", proxyUuid).append("proxyCode", proxyCode).toString();
     }
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/v2/ConnectorUpdateRequestDto.java
@@ -39,6 +39,10 @@ public class ConnectorUpdateRequestDto {
     @Schema(description = "List of Custom Attributes", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttribute> customAttributes = new ArrayList<>();
 
+    @Schema(description = "UUID of the Proxy",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String proxyUuid;
+
     @AssertTrue(message = "Authentication Attributes must be provided when Authentication Type is not NONE")
     @JsonIgnore
     public boolean isValid() {
@@ -47,6 +51,6 @@ public class ConnectorUpdateRequestDto {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("url", url).append("authType", authType).append("authAttributes", authAttributes).append("customAttributes", customAttributes).toString();
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("url", url).append("authType", authType).append("authAttributes", authAttributes).append("customAttributes", customAttributes).append("proxyUuid", proxyUuid).toString();
     }
 }

--- a/src/main/java/com/czertainly/api/model/core/logging/enums/Operation.java
+++ b/src/main/java/com/czertainly/api/model/core/logging/enums/Operation.java
@@ -105,6 +105,7 @@ public enum Operation implements IPlatformEnum {
     UNARCHIVE("unarchive", "Unarchive certificate"),
     GET_ASSOCIATIONS("getAssociations", "Get associations"),
     LIST_VERSIONS("listVersions", "List versions"),
+    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation instructions"),
 
     // legacy
     LIST_CERTIFICATE_PROFILES("listCertificateProfiles", "List Certificate profiles"),

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyDto.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyDto.java
@@ -1,0 +1,54 @@
+package com.czertainly.api.model.core.proxy;
+
+import com.czertainly.api.model.common.NameAndUuidDto;
+import com.czertainly.api.model.core.connector.ConnectorDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Setter
+@Getter
+public class ProxyDto extends NameAndUuidDto implements Serializable {
+
+    @Schema(description = "Detailed description of the Proxy",
+        examples = {"This proxy is used for connecting to external connectors in DMZ network"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String description;
+
+    @Schema(description = "Code of the Proxy",
+        examples = {"my-proxy-123"},
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    private String code;
+
+    @Schema(description = "Status of the Proxy",
+        examples = {"CONNECTED"},
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    private ProxyStatus status;
+
+    @Schema(description = "Timestamp of the last activity from the Proxy",
+        examples = {"2024-01-15T10:15:30+01:00"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private OffsetDateTime lastActivity;
+
+    @Schema(description = "List of Connectors associated with the Proxy")
+    private List<ConnectorDto> connectors;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("uuid", uuid)
+            .append("name", name)
+            .append("description", description)
+            .append("code", code)
+            .append("status", status)
+            .append("lastActivity", lastActivity)
+            .append("connectors", connectors)
+            .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyInstallInstructionsDto.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyInstallInstructionsDto.java
@@ -1,0 +1,23 @@
+package com.czertainly.api.model.core.proxy;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProxyInstallInstructionsDto {
+
+    @Schema(description = "Proxy identifier",
+        examples = {"7b55ge1c-844f-11dc-a8a3-0242ac120002"},
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    private String uuid;
+
+    @Schema(description = "Installation instructions for the Proxy",
+        examples = {"helm install my-proxy ./czertainly-proxy --set proxy.code=my-proxy-123"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String installationInstructions;
+
+}

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyInstallInstructionsDto.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyInstallInstructionsDto.java
@@ -11,7 +11,7 @@ import lombok.*;
 public class ProxyInstallInstructionsDto {
 
     @Schema(description = "Proxy identifier",
-        examples = {"7b55ge1c-844f-11dc-a8a3-0242ac120002"},
+        examples = {"7b55be1c-844f-11dc-a8a3-0242ac120002"},
         requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyListDto.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyListDto.java
@@ -1,0 +1,42 @@
+package com.czertainly.api.model.core.proxy;
+
+import com.czertainly.api.model.common.NameAndUuidDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+@Setter
+@Getter
+public class ProxyListDto extends NameAndUuidDto implements Serializable {
+
+    @Schema(description = "Detailed description of the Proxy",
+        examples = {"This proxy is used for connecting to external connectors in DMZ network"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String description;
+
+    @Schema(description = "Status of the Proxy",
+        examples = {"CONNECTED"},
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    private ProxyStatus status;
+
+    @Schema(description = "Timestamp of the last activity from the Proxy",
+        examples = {"2024-01-15T10:15:30+01:00"},
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private OffsetDateTime lastActivity;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("uuid", uuid)
+            .append("name", name)
+            .append("description", description)
+            .append("status", status)
+            .append("lastActivity", lastActivity)
+            .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyStatus.java
@@ -1,0 +1,69 @@
+package com.czertainly.api.model.core.proxy;
+
+import com.czertainly.api.exception.ValidationError;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.common.enums.IPlatformEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+
+@Schema(enumAsRef = true)
+public enum ProxyStatus implements IPlatformEnum {
+
+    INITIALIZED("initialized", "Initial state"),
+    PROVISIONING("provisioning", "Provisioning in progress"),
+    FAILED("failed", "Failed"),
+    WAITING_FOR_INSTALLATION("waitingForInstallation", "Waiting for installation"),
+    CONNECTED("connected", "Connected"),
+    DISCONNECTED("disconnected", "Disconnected")
+    ;
+
+    private static final ProxyStatus[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    @Schema(description = "Proxy status",
+            examples = {"connected"}, requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String code;
+    private final String label;
+    private final String description;
+
+    ProxyStatus(String code, String label) {
+        this(code, label,null);
+    }
+
+    ProxyStatus(String code, String label, String description) {
+        this.code = code;
+        this.label = label;
+        this.description = description;
+    }
+
+    @Override
+    @JsonValue
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getLabel() {
+        return this.label;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @JsonCreator
+    public static ProxyStatus findByCode(String code) {
+        return Arrays.stream(VALUES)
+                .filter(k -> k.code.equals(code))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ValidationException(ValidationError.create("Unknown Connector status {}", code)));
+    }
+}

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyStatus.java
@@ -64,6 +64,6 @@ public enum ProxyStatus implements IPlatformEnum {
                 .filter(k -> k.code.equals(code))
                 .findFirst()
                 .orElseThrow(() ->
-                        new ValidationException(ValidationError.create("Unknown Connector status {}", code)));
+                        new ValidationException(ValidationError.create("Unknown Proxy status {}", code)));
     }
 }

--- a/src/main/java/com/czertainly/api/model/core/settings/authentication/OAuth2ProviderSettingsUpdateDto.java
+++ b/src/main/java/com/czertainly/api/model/core/settings/authentication/OAuth2ProviderSettingsUpdateDto.java
@@ -62,4 +62,7 @@ public class OAuth2ProviderSettingsUpdateDto implements Serializable {
     @Schema(description = "Duration, in seconds, after which an inactive user's session will be terminated. Default value is 900 seconds.", defaultValue = "900", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private int sessionMaxInactiveInterval = 15 * 60;
 
+    @Schema(description = "The claim name used to extract the username from the token.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String usernameClaim;
+
 }

--- a/src/main/java/com/czertainly/core/model/auth/ResourceAction.java
+++ b/src/main/java/com/czertainly/core/model/auth/ResourceAction.java
@@ -47,7 +47,10 @@ public enum ResourceAction implements IPlatformEnum {
     ENCRYPT("encrypt", "Encrypt"),
     DECRYPT("decrypt", "Decrypt"),
     VERIFY("verify", "Verify"),
-    SIGN("sign", "Sign");
+    SIGN("sign", "Sign"),
+
+    // PROXY
+    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation");
 
     @Schema(description = "Resource Action Name",
             example = "create",

--- a/src/main/java/com/czertainly/core/model/auth/ResourceAction.java
+++ b/src/main/java/com/czertainly/core/model/auth/ResourceAction.java
@@ -49,15 +49,13 @@ public enum ResourceAction implements IPlatformEnum {
     VERIFY("verify", "Verify"),
     SIGN("sign", "Sign"),
 
-<<<<<<< main-saas-pr
     // PROXY
-    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation");
-=======
+    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation"),
+
     // Secret
     GET_SECRET_CONTENT("getSecretContent", "Get secret content"),
 
     ;
->>>>>>> main
 
     @Schema(description = "Resource Action Name",
             example = "create",


### PR DESCRIPTION
Introduce message queue-based alternative to direct REST clients, enabling connector communication through a proxy. Add proxy CRUD management, trusted certificate handling, OAuth2 username claim configuration, and v2 client interfaces.