### PR TITLE
Update SonarQube project properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>
-        <sonar.projectKey>interfaces</sonar.projectKey>
+        <sonar.projectKey>ilm_interfaces</sonar.projectKey>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.cpd.exclusions>src/main/java/com/czertainly/api/model/**,src/main/java/com/czertainly/api/interfaces/**</sonar.cpd.exclusions>
         <sonar.coverage.exclusions>src/main/java/com/czertainly/api/interfaces/**</sonar.coverage.exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
     <properties>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-        <sonar.organization>czertainly</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>CZERTAINLY_CZERTAINLY-Interfaces</sonar.projectKey>
+        <sonar.organization>ilm</sonar.organization>
+        <sonar.projectKey>interfaces</sonar.projectKey>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.cpd.exclusions>src/main/java/com/czertainly/api/model/**,src/main/java/com/czertainly/api/interfaces/**</sonar.cpd.exclusions>
         <sonar.coverage.exclusions>src/main/java/com/czertainly/api/interfaces/**</sonar.coverage.exclusions>


### PR DESCRIPTION
Update sonar.organization from 'czertainly' to 'ilm' and simplify sonar.projectKey from 'CZERTAINLY_CZERTAINLY-Interfaces' to 'interfaces'. This aligns the module with the new Sonar organization and project naming.