### PR TITLE
Asynchronous authority provider operations

### DIFF
--- a/hack/sonar-local.sh
+++ b/hack/sonar-local.sh
@@ -78,33 +78,70 @@ echo ""
 echo "=== SonarQube Results ==="
 echo "Dashboard: ${SONAR_URL}/dashboard?id=${PROJECT_KEY}"
 
-sleep 10
+# Sonar processes the analysis report asynchronously after upload. Poll until
+# the projectStatus payload is available, then report.
+echo ""
+echo "Waiting for Sonar to process the analysis..."
+for i in $(seq 1 60); do
+    PROBE=$(curl -s -u "${SONAR_CREDS}" \
+        "${SONAR_URL}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}" 2>/dev/null || true)
+    if echo "${PROBE}" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'projectStatus' in d else 1)" 2>/dev/null; then
+        break
+    fi
+    sleep 2
+done
+
+# Determine the set of files changed against the upstream base branch (main).
+# We filter the issues report to those files only — ephemeral SonarQube has no
+# previous analysis to use as a "new code" baseline, so we approximate
+# PR-style focus by intersecting with the git diff.
+BASE_BRANCH="${BASE_BRANCH:-main}"
+CHANGED=$(git diff --name-only "${BASE_BRANCH}...HEAD" 2>/dev/null || true)
+if [ -z "${CHANGED}" ]; then
+    echo ""
+    echo "(No changes vs ${BASE_BRANCH}; reporting full project for first-run baseline.)"
+    SCOPE_DESC="all project files"
+else
+    echo ""
+    echo "Files changed vs ${BASE_BRANCH}:"
+    echo "${CHANGED}" | sed 's/^/  /'
+    SCOPE_DESC="changed files only"
+fi
 
 echo ""
-echo "Quality Gate:"
-curl -sf -u "${SONAR_CREDS}" \
-    "${SONAR_URL}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}" \
-    | python3 -c "
+echo "Quality Gate (whole project; new-code conditions trivially OK without baseline):"
+echo "${PROBE}" | python3 -c "
 import sys, json
-d = json.load(sys.stdin)['projectStatus']
-print(f'  Status: {d[\"status\"]}')
-for c in d.get('conditions', []):
-    print(f'  {c[\"metricKey\"]}: {c[\"actualValue\"]} (threshold: {c[\"errorThreshold\"]}) - {c[\"status\"]}')
+try:
+    d = json.load(sys.stdin)['projectStatus']
+    print(f'  Status: {d[\"status\"]}')
+    for c in d.get('conditions', []):
+        print(f'  {c[\"metricKey\"]}: {c[\"actualValue\"]} (threshold: {c[\"errorThreshold\"]}) - {c[\"status\"]}')
+except Exception as e:
+    print(f'  WARN: Quality gate not yet available ({e}). See dashboard.')
 "
 
 echo ""
-echo "Issues:"
-curl -sf -u "${SONAR_CREDS}" \
-    "${SONAR_URL}/api/issues/search?projectKeys=${PROJECT_KEY}&statuses=OPEN&ps=100" \
-    | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-print(f'  Total: {d[\"total\"]}')
-for i in d['issues'][:30]:
-    comp = i['component'].split(':')[-1]
-    line = i.get('line', '?')
-    print(f'  [{i[\"severity\"]}] {comp}:{line} - {i[\"message\"]}')
+echo "Issues — ${SCOPE_DESC}:"
+curl -s -u "${SONAR_CREDS}" \
+    "${SONAR_URL}/api/issues/search?projectKeys=${PROJECT_KEY}&statuses=OPEN&ps=500" \
+    | CHANGED_LIST="${CHANGED}" python3 -c "
+import sys, json, os
+changed = [f.strip() for f in os.environ.get('CHANGED_LIST', '').splitlines() if f.strip()]
+try:
+    d = json.load(sys.stdin)
+    issues = d.get('issues', [])
+    if changed:
+        # Keep only issues whose component path ends with one of the changed files
+        issues = [i for i in issues if any(i.get('component', '').endswith(f) for f in changed)]
+    print(f'  Total in scope: {len(issues)}')
+    for i in issues[:50]:
+        comp = i['component'].split(':')[-1]
+        line = i.get('line', '?')
+        print(f'  [{i[\"severity\"]}] {comp}:{line} - {i[\"message\"]}')
+except Exception as e:
+    print(f'  WARN: Issues list not available ({e}).')
 "
 
 echo ""
-echo "Done."
+echo "Done. (Set BASE_BRANCH=<other> to compare against a different base; default: main.)"

--- a/hack/sonar-local.sh
+++ b/hack/sonar-local.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Local SonarQube analysis for interfaces (Java/Maven).
+# Spins up an ephemeral SonarQube Community container, runs mvn verify with
+# JaCoCo coverage, then mvn sonar:sonar against the local instance, and
+# prints the quality gate + open issues.
+# Usage: ./hack/sonar-local.sh
+set -euo pipefail
+
+CONTAINER_NAME="ilm-interfaces-sonarqube"
+SONAR_PORT="${SONAR_PORT:-9000}"
+PROJECT_KEY="ilm-interfaces"
+SONAR_URL="http://localhost:${SONAR_PORT}"
+
+cleanup() {
+    echo "Stopping SonarQube..."
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
+echo "Starting SonarQube Community on port ${SONAR_PORT}..."
+docker run -d --name "${CONTAINER_NAME}" -p "${SONAR_PORT}:9000" sonarqube:community >/dev/null
+
+echo "Waiting for SonarQube to be ready (up to 2 minutes)..."
+for i in $(seq 1 120); do
+    if curl -sf "${SONAR_URL}/api/system/status" 2>/dev/null | grep -q '"status":"UP"'; then
+        echo "SonarQube is ready."
+        break
+    fi
+    if [ "$i" -eq 120 ]; then
+        echo "ERROR: SonarQube failed to start within 2 minutes."
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Configuring SonarQube..."
+curl -s -o /dev/null -u admin:admin -X POST \
+    "${SONAR_URL}/api/users/change_password?login=admin&previousPassword=admin&password=Admin12345678!" 2>/dev/null || true
+
+if curl -sf -u admin:Admin12345678! "${SONAR_URL}/api/system/status" >/dev/null 2>&1; then
+    SONAR_CREDS="admin:Admin12345678!"
+elif curl -sf -u admin:admin "${SONAR_URL}/api/system/status" >/dev/null 2>&1; then
+    SONAR_CREDS="admin:admin"
+else
+    echo "ERROR: Cannot authenticate to SonarQube."
+    exit 1
+fi
+
+TOKEN_NAME="ci-$(date +%s)"
+TOKEN=$(curl -sf -u "${SONAR_CREDS}" -X POST \
+    "${SONAR_URL}/api/user_tokens/generate?name=${TOKEN_NAME}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+if [ -z "${TOKEN}" ]; then
+    echo "ERROR: Failed to generate SonarQube token."
+    exit 1
+fi
+
+# Note: -Dmaven.compiler.proc=full is required because the parent POM
+# (com.czertainly:dependencies:1.4.0) doesn't configure annotation processor
+# paths explicitly, and maven-compiler-plugin 3.13+ no longer auto-discovers
+# Lombok from the classpath without it.
+echo "Running mvn verify with JaCoCo..."
+mvn -B -U verify -Dmaven.compiler.proc=full
+
+echo "Running sonar:sonar..."
+mvn -B sonar:sonar \
+    -Dmaven.compiler.proc=full \
+    -Dsonar.projectKey="${PROJECT_KEY}" \
+    -Dsonar.host.url="${SONAR_URL}" \
+    -Dsonar.token="${TOKEN}" \
+    -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml \
+    -Dsonar.cpd.minimumTokens=100
+
+echo ""
+echo "=== SonarQube Results ==="
+echo "Dashboard: ${SONAR_URL}/dashboard?id=${PROJECT_KEY}"
+
+sleep 10
+
+echo ""
+echo "Quality Gate:"
+curl -sf -u "${SONAR_CREDS}" \
+    "${SONAR_URL}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}" \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)['projectStatus']
+print(f'  Status: {d[\"status\"]}')
+for c in d.get('conditions', []):
+    print(f'  {c[\"metricKey\"]}: {c[\"actualValue\"]} (threshold: {c[\"errorThreshold\"]}) - {c[\"status\"]}')
+"
+
+echo ""
+echo "Issues:"
+curl -sf -u "${SONAR_CREDS}" \
+    "${SONAR_URL}/api/issues/search?projectKeys=${PROJECT_KEY}&statuses=OPEN&ps=100" \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(f'  Total: {d[\"total\"]}')
+for i in d['issues'][:30]:
+    comp = i['component'].split(':')[-1]
+    line = i.get('line', '?')
+    print(f'  [{i[\"severity\"]}] {comp}:{line} - {i[\"message\"]}')
+"
+
+echo ""
+echo "Done."

--- a/scripts/sonar-local.sh
+++ b/scripts/sonar-local.sh
@@ -3,7 +3,17 @@
 # Spins up an ephemeral SonarQube Community container, runs mvn verify with
 # JaCoCo coverage, then mvn sonar:sonar against the local instance, and
 # prints the quality gate + open issues.
-# Usage: ./hack/sonar-local.sh
+# Usage: ./scripts/sonar-local.sh
+#
+# IMPORTANT — Limitation of ephemeral SonarQube:
+# The SonarQube container is freshly started on every run, so it has no
+# previous analysis to use as a "new code" baseline. The Quality Gate's
+# new-code conditions therefore evaluate trivially OK and do NOT match the
+# behaviour you'll see on SonarCloud (where a real baseline exists). To
+# approximate PR-style focus locally, this script intersects the Sonar
+# issue list with `git diff --name-only main...HEAD` and reports only
+# issues on changed files. Use it as a smoke-check; treat SonarCloud on
+# the actual PR as authoritative.
 set -euo pipefail
 
 CONTAINER_NAME="ilm-interfaces-sonarqube"
@@ -36,6 +46,11 @@ for i in $(seq 1 120); do
 done
 
 echo "Configuring SonarQube..."
+# SonarQube ships with `admin/admin` as the factory default; the server forces
+# this password to be changed on first login. We rotate it to `Admin12345678!`
+# (a value that satisfies SonarQube's password policy) so the rest of the script
+# can authenticate. Both credentials are scoped to this ephemeral container only —
+# the container is removed by the EXIT trap, so neither value is persisted.
 curl -s -o /dev/null -u admin:admin -X POST \
     "${SONAR_URL}/api/users/change_password?login=admin&previousPassword=admin&password=Admin12345678!" 2>/dev/null || true
 
@@ -58,10 +73,6 @@ if [ -z "${TOKEN}" ]; then
     exit 1
 fi
 
-# Note: -Dmaven.compiler.proc=full is required because the parent POM
-# (com.czertainly:dependencies:1.4.0) doesn't configure annotation processor
-# paths explicitly, and maven-compiler-plugin 3.13+ no longer auto-discovers
-# Lombok from the classpath without it.
 echo "Running mvn verify with JaCoCo..."
 mvn -B -U verify -Dmaven.compiler.proc=full
 
@@ -109,6 +120,16 @@ else
 fi
 
 echo ""
+echo "================================================================================"
+echo "EPHEMERAL SONARQUBE — LIMITATION"
+echo "================================================================================"
+echo "  This run uses a freshly-started SonarQube container with no previous"
+echo "  analysis to act as a 'new code' baseline. The Quality Gate evaluates"
+echo "  trivially OK and does NOT match SonarCloud, where a real baseline exists."
+echo "  Treat this as a smoke check; SonarCloud on the actual PR is authoritative."
+echo "================================================================================"
+
+echo ""
 echo "Quality Gate (whole project; new-code conditions trivially OK without baseline):"
 echo "${PROBE}" | python3 -c "
 import sys, json
@@ -122,7 +143,7 @@ except Exception as e:
 "
 
 echo ""
-echo "Issues — ${SCOPE_DESC}:"
+echo "Issues — ${SCOPE_DESC} (filtered to git diff vs ${BASE_BRANCH}; not a full project view):"
 curl -s -u "${SONAR_CREDS}" \
     "${SONAR_URL}/api/issues/search?projectKeys=${PROJECT_KEY}&statuses=OPEN&ps=500" \
     | CHANGED_LIST="${CHANGED}" python3 -c "

--- a/src/main/java/com/czertainly/api/clients/mq/ProxyClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/ProxyClient.java
@@ -3,6 +3,7 @@ package com.czertainly.api.clients.mq;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.exception.ConnectorException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.http.ResponseEntity;
 
 import java.time.Duration;
 import java.util.Map;
@@ -41,6 +42,38 @@ public interface ProxyClient {
             Object body,
             Class<T> responseType
     ) throws ConnectorException;
+
+    /**
+     * Send a request to the connector and wait for response synchronously, preserving the
+     * upstream HTTP status. Required for callers that distinguish {@code 200 OK} (synchronous
+     * completion) from {@code 202 Accepted} (asynchronous completion).
+     *
+     * <p>The default implementation falls back to {@link #sendRequest} and wraps the result in
+     * {@code ResponseEntity.ok(...)}, which collapses every successful upstream status to
+     * {@code 200}. Implementations that need true status fidelity (e.g. for the asynchronous
+     * authority-provider operations contract) <b>must</b> override this method and propagate
+     * the actual upstream status code.</p>
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param <T>          Response type
+     * @return ResponseEntity carrying the upstream status and deserialized body
+     *         (the body may be {@code null} when the upstream response had no body, e.g. 204)
+     * @throws ConnectorException If request fails or times out
+     */
+    default <T> ResponseEntity<T> sendRequestForEntity(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType
+    ) throws ConnectorException {
+        T result = sendRequest(connector, path, method, body, responseType);
+        return ResponseEntity.ok(result);
+    }
 
     /**
      * Send a request to the connector and wait for response synchronously with custom timeout.

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -23,6 +23,24 @@ public class CertificateApiClient implements CertificateSyncApiClient {
     private static final String HTTP_METHOD_GET = "GET";
     private static final String HTTP_METHOD_POST = "POST";
 
+    // Path templates relative to the authority instance under BASE_PATH/{uuid}.
+    private static final String PATH_ISSUE_ATTRIBUTES = "/certificates/issue/attributes";
+    private static final String PATH_ISSUE_ATTRIBUTES_VALIDATE = "/certificates/issue/attributes/validate";
+    private static final String PATH_ISSUE = "/certificates/issue";
+    private static final String PATH_RENEW = "/certificates/renew";
+    private static final String PATH_REVOKE_ATTRIBUTES = "/certificates/revoke/attributes";
+    private static final String PATH_REVOKE_ATTRIBUTES_VALIDATE = "/certificates/revoke/attributes/validate";
+    private static final String PATH_REVOKE = "/certificates/revoke";
+    private static final String PATH_IDENTIFY = "/certificates/identify";
+    private static final String PATH_ISSUE_CANCEL = "/certificates/issue/cancel";
+    private static final String PATH_REVOKE_CANCEL = "/certificates/revoke/cancel";
+    private static final String PATH_ISSUE_STATUS = "/certificates/issue/status";
+    private static final String PATH_REVOKE_STATUS = "/certificates/revoke/status";
+
+    private static String authorityPath(String authorityUuid, String suffix) {
+        return BASE_PATH + "/" + authorityUuid + suffix;
+    }
+
     private final ProxyClient proxyClient;
 
     public CertificateApiClient(ProxyClient proxyClient) {
@@ -31,89 +49,91 @@ public class CertificateApiClient implements CertificateSyncApiClient {
 
     @Override
     public List<BaseAttribute> listIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/attributes";
+        String path = authorityPath(authorityUuid, PATH_ISSUE_ATTRIBUTES);
         BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
         return Arrays.asList(result);
     }
 
     @Override
     public Boolean validateIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/attributes/validate";
+        String path = authorityPath(authorityUuid, PATH_ISSUE_ATTRIBUTES_VALIDATE);
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Boolean.class);
     }
 
     @Override
     public ResponseEntity<CertificateDataResponseDto> issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";
-        CertificateDataResponseDto body = proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
-        return ResponseEntity.ok(body);
+        String path = authorityPath(authorityUuid, PATH_ISSUE);
+        // sendRequestForEntity preserves the upstream HTTP status so 202 Accepted is not
+        // collapsed to 200 OK by the proxy hop — required for asynchronous-issuance detection.
+        return proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
     }
 
     @Override
     public ResponseEntity<CertificateDataResponseDto> renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/renew";
-        CertificateDataResponseDto body = proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
-        return ResponseEntity.ok(body);
+        String path = authorityPath(authorityUuid, PATH_RENEW);
+        return proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
     }
 
     @Override
     public List<BaseAttribute> listRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/attributes";
+        String path = authorityPath(authorityUuid, PATH_REVOKE_ATTRIBUTES);
         BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
         return Arrays.asList(result);
     }
 
     @Override
     public Boolean validateRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/attributes/validate";
+        String path = authorityPath(authorityUuid, PATH_REVOKE_ATTRIBUTES_VALIDATE);
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, attributes, Boolean.class);
     }
 
     @Override
     public ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke";
-        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
-        return ResponseEntity.ok().build();
+        String path = authorityPath(authorityUuid, PATH_REVOKE);
+        // Preserve the upstream HTTP status so 202 Accepted (asynchronous revoke) is not
+        // collapsed to 200 OK. The body is empty for revoke regardless of status, but the
+        // status is the signal Core uses to decide PENDING_REVOKE vs REVOKED.
+        return proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
     }
 
     @Override
     public CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/identify";
+        String path = authorityPath(authorityUuid, PATH_IDENTIFY);
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateIdentificationResponseDto.class);
     }
 
     @Override
     public void cancelIssueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/cancel";
+        String path = authorityPath(authorityUuid, PATH_ISSUE_CANCEL);
         proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
     }
 
     @Override
     public void cancelRevokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/cancel";
+        String path = authorityPath(authorityUuid, PATH_REVOKE_CANCEL);
         proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
     }
 
     @Override
     public CertificateOperationStatusResponseDto getIssueCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/status";
+        String path = authorityPath(authorityUuid, PATH_ISSUE_STATUS);
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateOperationStatusResponseDto.class);
     }
 
     @Override
     public CertificateOperationStatusResponseDto getRevokeCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/status";
+        String path = authorityPath(authorityUuid, PATH_REVOKE_STATUS);
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateOperationStatusResponseDto.class);
     }
 
     // Async variants
     public CompletableFuture<CertificateDataResponseDto> issueCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";
+        String path = authorityPath(authorityUuid, PATH_ISSUE);
         return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
     }
 
     public CompletableFuture<CertificateDataResponseDto> renewCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) {
-        String path = BASE_PATH + "/" + authorityUuid + "/certificates/renew";
+        String path = authorityPath(authorityUuid, PATH_RENEW);
         return proxyClient.sendRequestAsync(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
     }
 }

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -16,7 +16,14 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * MQ-based implementation of v2 Certificate API client.
+ *
+ * <p>The path constants below are part of the v2 connector API contract — they describe
+ * the routes a connector implementation must expose, not URIs that are configurable per
+ * environment. This is the same pattern as the sibling WebClient-based
+ * {@link com.czertainly.api.clients.v2.CertificateApiClient}, where paths like
+ * {@code /v2/authorityProvider/authorities/{uuid}/certificates/issue} are also hardcoded.</p>
  */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public class CertificateApiClient implements CertificateSyncApiClient {
 
     private static final String BASE_PATH = "/v2/authorityProvider/authorities";

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -78,6 +78,30 @@ public class CertificateApiClient implements CertificateSyncApiClient {
         return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateIdentificationResponseDto.class);
     }
 
+    @Override
+    public void cancelIssueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/cancel";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public void cancelRevokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/cancel";
+        proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+    }
+
+    @Override
+    public CertificateOperationStatusResponseDto getIssueCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue/status";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateOperationStatusResponseDto.class);
+    }
+
+    @Override
+    public CertificateOperationStatusResponseDto getRevokeCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke/status";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateOperationStatusResponseDto.class);
+    }
+
     // Async variants
     public CompletableFuture<CertificateDataResponseDto> issueCertificateAsync(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) {
         String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -8,6 +8,7 @@ import com.czertainly.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.v2.*;
+import org.springframework.http.ResponseEntity;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,15 +43,17 @@ public class CertificateApiClient implements CertificateSyncApiClient {
     }
 
     @Override
-    public CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
         String path = BASE_PATH + "/" + authorityUuid + "/certificates/issue";
-        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+        CertificateDataResponseDto body = proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+        return ResponseEntity.ok(body);
     }
 
     @Override
-    public CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
         String path = BASE_PATH + "/" + authorityUuid + "/certificates/renew";
-        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+        CertificateDataResponseDto body = proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+        return ResponseEntity.ok(body);
     }
 
     @Override
@@ -67,9 +70,10 @@ public class CertificateApiClient implements CertificateSyncApiClient {
     }
 
     @Override
-    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
         String path = BASE_PATH + "/" + authorityUuid + "/certificates/revoke";
         proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+        return ResponseEntity.ok().build();
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -100,8 +100,7 @@ public class CertificateApiClient implements CertificateSyncApiClient {
         // Preserve the upstream HTTP status so 202 Accepted (asynchronous revoke) is not
         // collapsed to 200 OK. The body is empty for revoke regardless of status — only
         // the status is meaningful (Core uses it to decide PENDING_REVOKE vs REVOKED).
-        ResponseEntity<Void> response = proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
-        return response;
+        return proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/v2/CertificateApiClient.java
@@ -95,12 +95,13 @@ public class CertificateApiClient implements CertificateSyncApiClient {
     }
 
     @Override
-    public ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+    public ResponseEntity<Void> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
         String path = authorityPath(authorityUuid, PATH_REVOKE);
         // Preserve the upstream HTTP status so 202 Accepted (asynchronous revoke) is not
-        // collapsed to 200 OK. The body is empty for revoke regardless of status, but the
-        // status is the signal Core uses to decide PENDING_REVOKE vs REVOKED.
-        return proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, CertificateDataResponseDto.class);
+        // collapsed to 200 OK. The body is empty for revoke regardless of status — only
+        // the status is meaningful (Core uses it to decide PENDING_REVOKE vs REVOKED).
+        ResponseEntity<Void> response = proxyClient.sendRequestForEntity(connector, path, HTTP_METHOD_POST, requestDto, Void.class);
+        return response;
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -138,14 +138,14 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
     }
 
     @Override
-    public ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+    public ResponseEntity<Void> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_CONTEXT, authorityUuid)
                 .body(Mono.just(requestDto), CertRevocationDto.class)
                 .retrieve()
-                .toEntity(CertificateDataResponseDto.class)
+                .toBodilessEntity()
                 .block(),
                 request,
                 connector);

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -10,6 +10,7 @@ import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.v2.*;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -73,7 +74,7 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
     }
 
     @Override
-    public CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -81,13 +82,13 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
                 .body(Mono.just(requestDto), CertificateSignRequestDto.class)
                 .retrieve()
                 .toEntity(CertificateDataResponseDto.class)
-                .block().getBody(),
+                .block(),
                 request,
                 connector);
     }
 
     @Override
-    public CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
@@ -95,7 +96,7 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
                 .body(Mono.just(requestDto), CertificateRenewRequestDto.class)
                 .retrieve()
                 .toEntity(CertificateDataResponseDto.class)
-                .block().getBody(),
+                .block(),
                 request,
                 connector);
     }
@@ -128,15 +129,15 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
     }
 
     @Override
-    public void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
+    public ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
-        processRequest(r -> r
+        return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_CONTEXT, authorityUuid)
                 .body(Mono.just(requestDto), CertRevocationDto.class)
                 .retrieve()
-                .toEntity(Void.class)
-                .block().getBody(),
+                .toEntity(CertificateDataResponseDto.class)
+                .block(),
                 request,
                 connector);
     }

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -17,6 +17,15 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
+/**
+ * WebClient (HTTP) implementation of v2 Certificate API client.
+ *
+ * <p>The path constants below are part of the v2 connector API contract — they describe
+ * the routes a connector implementation must expose, not URIs that are configurable per
+ * environment. This is the same pattern as the sibling MQ-based
+ * {@link com.czertainly.api.clients.mq.v2.CertificateApiClient}.</p>
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public class CertificateApiClient extends BaseApiClient implements CertificateSyncApiClient {
 
     private static final String CERTIFICATE_BASE_CONTEXT = "/v2/authorityProvider/authorities/{uuid}/certificates";

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -32,6 +32,11 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
     private static final String CERTIFICATE_REVOKE_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/revoke";
     private static final String CERTIFICATE_IDENTIFY_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/identify";
 
+    private static final String CERTIFICATE_ISSUE_CANCEL_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/issue/cancel";
+    private static final String CERTIFICATE_REVOKE_CANCEL_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/revoke/cancel";
+    private static final String CERTIFICATE_ISSUE_STATUS_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/issue/status";
+    private static final String CERTIFICATE_REVOKE_STATUS_CONTEXT = CERTIFICATE_BASE_CONTEXT + "/revoke/status";
+
     private static final ParameterizedTypeReference<List<RequestAttribute>> ATTRIBUTE_LIST_TYPE_REF = new ParameterizedTypeReference<>() {
     };
 
@@ -145,6 +150,62 @@ public class CertificateApiClient extends BaseApiClient implements CertificateSy
                         .body(Mono.just(requestDto), CertificateSignRequestDto.class)
                         .retrieve()
                         .toEntity(CertificateIdentificationResponseDto.class)
+                        .block().getBody(),
+                request,
+                connector);
+    }
+
+    @Override
+    public void cancelIssueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        processRequest(r -> r
+                        .uri(connector.getUrl() + CERTIFICATE_ISSUE_CANCEL_CONTEXT, authorityUuid)
+                        .body(Mono.just(requestDto), CertificateOperationCancelRequestDto.class)
+                        .retrieve()
+                        .toEntity(Void.class)
+                        .block().getBody(),
+                request,
+                connector);
+    }
+
+    @Override
+    public void cancelRevokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        processRequest(r -> r
+                        .uri(connector.getUrl() + CERTIFICATE_REVOKE_CANCEL_CONTEXT, authorityUuid)
+                        .body(Mono.just(requestDto), CertificateOperationCancelRequestDto.class)
+                        .retrieve()
+                        .toEntity(Void.class)
+                        .block().getBody(),
+                request,
+                connector);
+    }
+
+    @Override
+    public CertificateOperationStatusResponseDto getIssueCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> r
+                        .uri(connector.getUrl() + CERTIFICATE_ISSUE_STATUS_CONTEXT, authorityUuid)
+                        .body(Mono.just(requestDto), CertificateOperationStatusRequestDto.class)
+                        .retrieve()
+                        .toEntity(CertificateOperationStatusResponseDto.class)
+                        .block().getBody(),
+                request,
+                connector);
+    }
+
+    @Override
+    public CertificateOperationStatusResponseDto getRevokeCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> r
+                        .uri(connector.getUrl() + CERTIFICATE_REVOKE_STATUS_CONTEXT, authorityUuid)
+                        .body(Mono.just(requestDto), CertificateOperationStatusRequestDto.class)
+                        .retrieve()
+                        .toEntity(CertificateOperationStatusResponseDto.class)
                         .block().getBody(),
                 request,
                 connector);

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
@@ -22,9 +22,9 @@ public interface CertificateSyncApiClient {
 
     /**
      * Issue a certificate. Returns a {@link ResponseEntity} so callers can distinguish a
-     * synchronous {@code 200 OK} (body carries the issued certificate) from a non-synchronous
+     * synchronous {@code 200 OK} (body carries the issued certificate) from an asynchronous
      * {@code 202 Accepted} (body may carry connector-defined metadata; certificate completion
-     * happens externally).
+     * is asynchronous).
      */
     ResponseEntity<CertificateDataResponseDto> issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException;
 
@@ -39,7 +39,7 @@ public interface CertificateSyncApiClient {
 
     /**
      * Revoke a certificate. Returns a {@link ResponseEntity} so callers can distinguish a
-     * synchronous {@code 200 OK}/{@code 204 No Content} from a non-synchronous {@code 202
+     * synchronous {@code 200 OK}/{@code 204 No Content} from an asynchronous {@code 202
      * Accepted}. The body is empty in the synchronous case; a {@code 202} body MAY carry
      * connector-defined metadata in the standard {@code meta} field.
      */

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
@@ -6,6 +6,7 @@ import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
 import com.czertainly.api.model.connector.v2.*;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -19,15 +20,30 @@ public interface CertificateSyncApiClient {
 
     Boolean validateIssueCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
-    CertificateDataResponseDto issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException;
+    /**
+     * Issue a certificate. Returns a {@link ResponseEntity} so callers can distinguish a
+     * synchronous {@code 200 OK} (body carries the issued certificate) from a non-synchronous
+     * {@code 202 Accepted} (body may carry connector-defined metadata; certificate completion
+     * happens externally).
+     */
+    ResponseEntity<CertificateDataResponseDto> issueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException;
 
-    CertificateDataResponseDto renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException;
+    /**
+     * Renew a certificate. Same {@code 200}/{@code 202} semantics as {@link #issueCertificate}.
+     */
+    ResponseEntity<CertificateDataResponseDto> renewCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException;
 
     List<BaseAttribute> listRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid) throws ConnectorException;
 
     Boolean validateRevokeCertificateAttributes(ApiClientConnectorInfo connector, String authorityUuid, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
-    void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
+    /**
+     * Revoke a certificate. Returns a {@link ResponseEntity} so callers can distinguish a
+     * synchronous {@code 200 OK}/{@code 204 No Content} from a non-synchronous {@code 202
+     * Accepted}. The body is empty in the synchronous case; a {@code 202} body MAY carry
+     * connector-defined metadata in the standard {@code meta} field.
+     */
+    ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
 
     CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException;
 

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
@@ -30,4 +30,12 @@ public interface CertificateSyncApiClient {
     void revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
 
     CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException;
+
+    void cancelIssueCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException;
+
+    void cancelRevokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationCancelRequestDto requestDto) throws ValidationException, ConnectorException;
+
+    CertificateOperationStatusResponseDto getIssueCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException;
+
+    CertificateOperationStatusResponseDto getRevokeCertificateStatus(ApiClientConnectorInfo connector, String authorityUuid, CertificateOperationStatusRequestDto requestDto) throws ConnectorException;
 }

--- a/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v2/CertificateSyncApiClient.java
@@ -39,11 +39,12 @@ public interface CertificateSyncApiClient {
 
     /**
      * Revoke a certificate. Returns a {@link ResponseEntity} so callers can distinguish a
-     * synchronous {@code 200 OK}/{@code 204 No Content} from an asynchronous {@code 202
-     * Accepted}. The body is empty in the synchronous case; a {@code 202} body MAY carry
-     * connector-defined metadata in the standard {@code meta} field.
+     * synchronous {@code 200 OK} / {@code 204 No Content} from an asynchronous
+     * {@code 202 Accepted}. The body is empty for revoke regardless of status — the
+     * platform tracks the operation by transactionId / certificate identity, not by
+     * connector-emitted metadata.
      */
-    ResponseEntity<CertificateDataResponseDto> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
+    ResponseEntity<Void> revokeCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException;
 
     CertificateIdentificationResponseDto identifyCertificate(ApiClientConnectorInfo connector, String authorityUuid, CertificateIdentificationRequestDto requestDto) throws ValidationException, ConnectorException;
 

--- a/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -62,13 +63,23 @@ public interface CertificateController extends AuthProtectedConnectorController 
             @RequestBody List<RequestAttribute>attributes) throws NotFoundException, ValidationException;
 
     @Operation(
-            summary = "Issue Certificate"
+            summary = "Issue Certificate",
+            description = "Issue a certificate. The Authority Provider may complete the operation "
+                    + "synchronously or non-synchronously."
     )
     @ApiResponses(
             value = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "Certificate issued"
+                            description = "Certificate issued synchronously; response carries the issued certificate."
+                    ),
+                    @ApiResponse(
+                            responseCode = "202",
+                            description = "Issuance is not synchronous; the operation will complete externally. The "
+                                    + "optional response body may carry `MetadataAttribute` entries — technology-"
+                                    + "specific state — that the platform will return on subsequent calls related "
+                                    + "to this operation.",
+                            content = @Content(schema = @Schema(implementation = CertificateDataResponseDto.class))
                     ),
                     @ApiResponse(
                             responseCode = "422",
@@ -83,13 +94,23 @@ public interface CertificateController extends AuthProtectedConnectorController 
             @RequestBody CertificateSignRequestDto request) throws NotFoundException, CertificateOperationException, CertificateRequestException;
 
     @Operation(
-            summary = "Renew Certificate"
+            summary = "Renew Certificate",
+            description = "Renew a certificate. The Authority Provider may complete the operation "
+                    + "synchronously or non-synchronously."
     )
     @ApiResponses(
             value = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "Certificate renewed"
+                            description = "Certificate renewed synchronously; response carries the new certificate."
+                    ),
+                    @ApiResponse(
+                            responseCode = "202",
+                            description = "Renewal is not synchronous; the operation will complete externally. The "
+                                    + "optional response body may carry `MetadataAttribute` entries — technology-"
+                                    + "specific state — that the platform will return on subsequent calls related "
+                                    + "to this operation.",
+                            content = @Content(schema = @Schema(implementation = CertificateDataResponseDto.class))
                     ),
                     @ApiResponse(
                             responseCode = "422",
@@ -145,13 +166,22 @@ public interface CertificateController extends AuthProtectedConnectorController 
             @RequestBody List<RequestAttribute>attributes) throws NotFoundException, ValidationException;
 
     @Operation(
-            summary = "Revoke Certificate"
+            summary = "Revoke Certificate",
+            description = "Revoke a certificate. The Authority Provider may complete the operation "
+                    + "synchronously or non-synchronously."
     )
     @ApiResponses(
             value = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "Certificate revoked"
+                            description = "Certificate revoked synchronously."
+                    ),
+                    @ApiResponse(
+                            responseCode = "202",
+                            description = "Revocation is not synchronous; the operation will complete externally. The "
+                                    + "optional response body may carry `MetadataAttribute` entries — technology-"
+                                    + "specific state — that the platform will return on subsequent calls related "
+                                    + "to this operation."
                     ),
                     @ApiResponse(
                             responseCode = "422",
@@ -191,4 +221,132 @@ public interface CertificateController extends AuthProtectedConnectorController 
     CertificateIdentificationResponseDto identifyCertificate(
             @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
             @RequestBody CertificateIdentificationRequestDto request) throws NotFoundException, ValidationException;
+
+    @Operation(
+            summary = "Cancel Certificate Issuance",
+            description = """
+                    Abort an in-flight certificate issuance.
+
+                    Called for a non-synchronous issuance or renewal that previously responded
+                    `202 Accepted`. The request body carries the RA profile attributes and the
+                    same `MetadataAttribute` entries returned in the original `202 Accepted`
+                    response, so the Authority Provider can resolve the operation it must abort.
+                    """
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "The operation has been aborted."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "The Authority Provider does not track this operation (e.g., it was finalized "
+                                    + "externally and forgotten, or the implementation is stateless)."
+                    ),
+                    @ApiResponse(
+                            responseCode = "422",
+                            description = "The Authority Provider tracks the operation but refuses to abort it (e.g., the "
+                                    + "underlying CA does not support cancel, or the issuance is past a point of no "
+                                    + "return).",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                                    examples = {@ExampleObject(value = "[\"CA does not support cancellation\",\"Issuance is past the point of no return\"]")}
+                            ))
+            })
+    @PostMapping(path = "/issue/cancel", consumes = {MediaType.APPLICATION_JSON_VALUE})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void cancelIssueCertificate(
+            @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
+            @RequestBody CertificateOperationCancelRequestDto request) throws NotFoundException, ValidationException;
+
+    @Operation(
+            summary = "Cancel Certificate Revocation",
+            description = """
+                    Abort an in-flight certificate revocation.
+
+                    Called for a non-synchronous revocation that previously responded
+                    `202 Accepted`. The request body carries the RA profile attributes and the
+                    same `MetadataAttribute` entries returned in the original `202 Accepted`
+                    response.
+                    """
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "The operation has been aborted."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "The Authority Provider does not track this operation."
+                    ),
+                    @ApiResponse(
+                            responseCode = "422",
+                            description = "The Authority Provider tracks the operation but refuses to abort it (e.g., the "
+                                    + "revocation has already been submitted to a CRL).",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                                    examples = {@ExampleObject(value = "[\"CA does not support cancellation\",\"Revocation already submitted to CRL\"]")}
+                            ))
+            })
+    @PostMapping(path = "/revoke/cancel", consumes = {MediaType.APPLICATION_JSON_VALUE})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void cancelRevokeCertificate(
+            @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
+            @RequestBody CertificateOperationCancelRequestDto request) throws NotFoundException, ValidationException;
+
+    @Operation(
+            summary = "Get Certificate Issuance Status",
+            description = """
+                    Return the current status of a non-synchronous certificate issuance.
+
+                    Called for a non-synchronous issuance or renewal that previously responded
+                    `202 Accepted`. The request body carries the RA profile attributes and the
+                    same `MetadataAttribute` entries returned in the original `202 Accepted`
+                    response, so the Authority Provider can resolve the operation.
+                    """
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Status retrieved. Response carries one of `IN_PROGRESS`, `COMPLETED`, or "
+                                    + "`FAILED`. When `COMPLETED`, the response includes the issued certificate "
+                                    + "(Base64) in `certificateData`."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "The Authority Provider does not track this operation."
+                    )
+            })
+    @PostMapping(path = "/issue/status", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
+    CertificateOperationStatusResponseDto getIssueCertificateStatus(
+            @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
+            @RequestBody CertificateOperationStatusRequestDto request) throws NotFoundException;
+
+    @Operation(
+            summary = "Get Certificate Revocation Status",
+            description = """
+                    Return the current status of a non-synchronous certificate revocation.
+
+                    Called for a non-synchronous revocation that previously responded
+                    `202 Accepted`. For revocation, the `certificateData` field of the response
+                    is unused (revocation completion carries no payload).
+                    """
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Status retrieved. Response carries one of `IN_PROGRESS`, `COMPLETED`, or "
+                                    + "`FAILED`."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "The Authority Provider does not track this operation."
+                    )
+            })
+    @PostMapping(path = "/revoke/status", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
+    CertificateOperationStatusResponseDto getRevokeCertificateStatus(
+            @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
+            @RequestBody CertificateOperationStatusRequestDto request) throws NotFoundException;
 }

--- a/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -89,7 +90,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                             ))
             })
     @PostMapping(path = "/issue", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
-    CertificateDataResponseDto issueCertificate(
+    ResponseEntity<CertificateDataResponseDto> issueCertificate(
             @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
             @RequestBody CertificateSignRequestDto request) throws NotFoundException, CertificateOperationException, CertificateRequestException;
 
@@ -120,7 +121,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                             ))
             })
     @PostMapping(path = "/renew", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
-    CertificateDataResponseDto renewCertificate(
+    ResponseEntity<CertificateDataResponseDto> renewCertificate(
             @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
             @RequestBody CertificateRenewRequestDto request) throws NotFoundException, CertificateOperationException, CertificateRequestException;
 
@@ -190,7 +191,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                             ))
             })
     @PostMapping(path = "/revoke", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
-    void revokeCertificate(
+    ResponseEntity<Void> revokeCertificate(
             @Parameter(description = "Authority Instance UUID") @PathVariable String uuid,
             @RequestBody CertRevocationDto request) throws NotFoundException, CertificateOperationException;
 

--- a/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
@@ -222,14 +222,15 @@ public interface CertificateController extends AuthProtectedConnectorController 
             @RequestBody CertificateIdentificationRequestDto request) throws NotFoundException, ValidationException;
 
     @Operation(
-            summary = "Cancel Certificate Issuance",
+            summary = "Cancel Certificate Issuance or Renewal",
             description = """
-                    Abort an in-flight certificate issuance.
+                    Abort an in-flight certificate issuance or renewal.
 
-                    Called for an asynchronous issuance or renewal that previously responded
-                    `202 Accepted`. The request body carries the RA profile attributes and the
-                    same `MetadataAttribute` entries returned in the original `202 Accepted`
-                    response, so the Authority Provider can resolve the operation it must abort.
+                    Called for an asynchronous issuance, renewal, or rekey that previously
+                    responded `202 Accepted`. The request body carries the RA profile
+                    attributes and the same `MetadataAttribute` entries returned in the
+                    original `202 Accepted` response, so the Authority Provider can resolve
+                    the operation it must abort.
                     """
     )
     @ApiResponses(

--- a/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
@@ -179,9 +179,8 @@ public interface CertificateController extends AuthProtectedConnectorController 
                     @ApiResponse(
                             responseCode = "202",
                             description = "Revocation is asynchronous; the operation will complete asynchronously. The "
-                                    + "optional response body may carry `MetadataAttribute` entries — technology-"
-                                    + "specific state — that the platform will return on subsequent calls related "
-                                    + "to this operation."
+                                    + "response body is empty for revocation — the platform tracks the operation by "
+                                    + "transactionId / certificate identity, not by connector-emitted metadata."
                     ),
                     @ApiResponse(
                             responseCode = "422",

--- a/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/connector/v2/CertificateController.java
@@ -65,7 +65,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
     @Operation(
             summary = "Issue Certificate",
             description = "Issue a certificate. The Authority Provider may complete the operation "
-                    + "synchronously or non-synchronously."
+                    + "synchronously or asynchronously."
     )
     @ApiResponses(
             value = {
@@ -75,7 +75,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                     ),
                     @ApiResponse(
                             responseCode = "202",
-                            description = "Issuance is not synchronous; the operation will complete externally. The "
+                            description = "Issuance is asynchronous; the operation will complete asynchronously. The "
                                     + "optional response body may carry `MetadataAttribute` entries — technology-"
                                     + "specific state — that the platform will return on subsequent calls related "
                                     + "to this operation.",
@@ -96,7 +96,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
     @Operation(
             summary = "Renew Certificate",
             description = "Renew a certificate. The Authority Provider may complete the operation "
-                    + "synchronously or non-synchronously."
+                    + "synchronously or asynchronously."
     )
     @ApiResponses(
             value = {
@@ -106,7 +106,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                     ),
                     @ApiResponse(
                             responseCode = "202",
-                            description = "Renewal is not synchronous; the operation will complete externally. The "
+                            description = "Renewal is asynchronous; the operation will complete asynchronously. The "
                                     + "optional response body may carry `MetadataAttribute` entries — technology-"
                                     + "specific state — that the platform will return on subsequent calls related "
                                     + "to this operation.",
@@ -168,7 +168,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
     @Operation(
             summary = "Revoke Certificate",
             description = "Revoke a certificate. The Authority Provider may complete the operation "
-                    + "synchronously or non-synchronously."
+                    + "synchronously or asynchronously."
     )
     @ApiResponses(
             value = {
@@ -178,7 +178,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
                     ),
                     @ApiResponse(
                             responseCode = "202",
-                            description = "Revocation is not synchronous; the operation will complete externally. The "
+                            description = "Revocation is asynchronous; the operation will complete asynchronously. The "
                                     + "optional response body may carry `MetadataAttribute` entries — technology-"
                                     + "specific state — that the platform will return on subsequent calls related "
                                     + "to this operation."
@@ -227,7 +227,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
             description = """
                     Abort an in-flight certificate issuance.
 
-                    Called for a non-synchronous issuance or renewal that previously responded
+                    Called for an asynchronous issuance or renewal that previously responded
                     `202 Accepted`. The request body carries the RA profile attributes and the
                     same `MetadataAttribute` entries returned in the original `202 Accepted`
                     response, so the Authority Provider can resolve the operation it must abort.
@@ -241,8 +241,8 @@ public interface CertificateController extends AuthProtectedConnectorController 
                     ),
                     @ApiResponse(
                             responseCode = "404",
-                            description = "The Authority Provider does not track this operation (e.g., it was finalized "
-                                    + "externally and forgotten, or the implementation is stateless)."
+                            description = "The Authority Provider does not track this operation (e.g., the operation has "
+                                    + "already completed and was forgotten, or the implementation is stateless)."
                     ),
                     @ApiResponse(
                             responseCode = "422",
@@ -264,7 +264,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
             description = """
                     Abort an in-flight certificate revocation.
 
-                    Called for a non-synchronous revocation that previously responded
+                    Called for an asynchronous revocation that previously responded
                     `202 Accepted`. The request body carries the RA profile attributes and the
                     same `MetadataAttribute` entries returned in the original `202 Accepted`
                     response.
@@ -297,9 +297,9 @@ public interface CertificateController extends AuthProtectedConnectorController 
     @Operation(
             summary = "Get Certificate Issuance Status",
             description = """
-                    Return the current status of a non-synchronous certificate issuance.
+                    Return the current status of an asynchronous certificate issuance.
 
-                    Called for a non-synchronous issuance or renewal that previously responded
+                    Called for an asynchronous issuance or renewal that previously responded
                     `202 Accepted`. The request body carries the RA profile attributes and the
                     same `MetadataAttribute` entries returned in the original `202 Accepted`
                     response, so the Authority Provider can resolve the operation.
@@ -326,9 +326,9 @@ public interface CertificateController extends AuthProtectedConnectorController 
     @Operation(
             summary = "Get Certificate Revocation Status",
             description = """
-                    Return the current status of a non-synchronous certificate revocation.
+                    Return the current status of an asynchronous certificate revocation.
 
-                    Called for a non-synchronous revocation that previously responded
+                    Called for an asynchronous revocation that previously responded
                     `202 Accepted`. For revocation, the `certificateData` field of the response
                     is unused (revocation completion carries no payload).
                     """

--- a/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
@@ -29,6 +29,84 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.List;
 
+/**
+ * Client API for certificate lifecycle operations through an RA profile (issue, renew,
+ * rekey, revoke, finalize, confirm-revoke, cancel).
+ *
+ * <h2>Certificate state transitions exposed by this API</h2>
+ *
+ * <p>The following diagram shows the state transitions an operator can drive through
+ * the endpoints on this controller. Synchronous paths complete in a single request;
+ * asynchronous paths leave the certificate in a {@code PENDING_*} state until an
+ * operator finalizes or cancels it.</p>
+ *
+ * <pre>
+ *                                +-----------+
+ *                                | REQUESTED |
+ *                                +-----------+
+ *                              /     |   |    \
+ *            connector 200    /      |   |     \  connector 202
+ *            (sync success)  /       |   |      \ (async accepted)
+ *                           /        |   |       \
+ *                          v         v   v        v
+ *                   +--------+   +-------+   +---------------+
+ *                   | ISSUED |   |FAILED |   | PENDING_ISSUE |
+ *                   +--------+   +-------+   +---------------+
+ *                       ^                       /         \
+ *                       |                      /           \
+ *                       |        manuallyIssue/             \cancelPending
+ *                       |             v                      v
+ *                       +-------- ISSUED                   FAILED
+ *
+ *   ISSUED + revokeCertificate:
+ *     connector 200  -->  REVOKED                                (sync)
+ *     connector 202  -->  PENDING_REVOKE                         (async)
+ *                                /                       \
+ *                manuallyConfirmRevoke              cancelPendingCertificateOperation
+ *                              v                              v
+ *                          REVOKED                          ISSUED
+ * </pre>
+ *
+ * <p>Transitions driven by other controllers (notably {@code Issued → PendingApproval},
+ * {@code PendingApproval → PendingIssue / PendingRevoke / Issued / Revoked / Rejected})
+ * are part of the approval flow and are not shown here.</p>
+ *
+ * <h3>Synchronous paths (connector returns 200 OK)</h3>
+ * <ul>
+ *   <li>{@link #issueCertificate}, {@link #issueRequestedCertificate},
+ *       {@link #renewCertificate}, {@link #rekeyCertificate}: cert moves to
+ *       {@code ISSUED}. If the connector reports a failure during the call the cert
+ *       moves to {@code FAILED} instead.</li>
+ *   <li>{@link #revokeCertificate}: cert moves to {@code REVOKED}.</li>
+ * </ul>
+ *
+ * <h3>Asynchronous paths (connector returns 202 Accepted)</h3>
+ * <ul>
+ *   <li>{@code issueCertificate} / {@code issueRequestedCertificate} /
+ *       {@code renewCertificate} / {@code rekeyCertificate}: cert moves to
+ *       {@code PENDING_ISSUE}. An operator finalizes it via
+ *       {@link #manuallyIssueCertificate} (→ {@code ISSUED}) or aborts via
+ *       {@link #cancelPendingCertificateOperation} (→ {@code FAILED}).</li>
+ *   <li>{@code revokeCertificate}: cert moves to {@code PENDING_REVOKE}. An operator
+ *       confirms it via {@link #manuallyConfirmRevoke} (→ {@code REVOKED}) or aborts
+ *       via {@link #cancelPendingCertificateOperation} (→ {@code ISSUED}, since the
+ *       certificate was never actually revoked upstream).</li>
+ * </ul>
+ *
+ * <p>{@code rekeyCertificate} and {@code issueRequestedCertificate} use the same
+ * authority-provider call as {@code issueCertificate}, so they can complete either
+ * synchronously or asynchronously depending on what the connector returns.</p>
+ *
+ * <h3>Terminal states (no transition via this API)</h3>
+ * <ul>
+ *   <li>{@code REVOKED} — definitive; the certificate cannot be reissued.</li>
+ *   <li>{@code REJECTED} — set by approval / compliance flows; the certificate cannot
+ *       be retried, a new certificate request must be created.</li>
+ *   <li>{@code FAILED} — set when synchronous issuance failed at the connector or when
+ *       an asynchronous issuance was cancelled; a new certificate request must be
+ *       created to retry.</li>
+ * </ul>
+ */
 @RequestMapping("/v2/operations/authorities/{authorityUuid}/raProfiles/{raProfileUuid}")
 @Tag(name = "Client Operations v2", description = "Client Operations v2 API")
 @ApiResponses(

--- a/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
@@ -3,8 +3,11 @@ package com.czertainly.api.interfaces.core.client.v2;
 import com.czertainly.api.exception.*;
 import com.czertainly.api.interfaces.AuthProtectedController;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.certificate.CancelPendingCertificateRequestDto;
+import com.czertainly.api.model.client.certificate.UploadCertificateRequestDto;
 import com.czertainly.api.model.common.ErrorMessageDto;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.core.certificate.CertificateDetailDto;
 import com.czertainly.api.model.core.v2.*;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,7 +51,10 @@ import java.util.List;
 		})
 public interface ClientOperationController extends AuthProtectedController {
 
-	@Operation(summary = "Get issue Certificate Attributes")
+	@Operation(
+			summary = "Get issue certificate attributes",
+			description = "Return the list of attributes the client must populate when requesting an issuance through this RA profile. The list reflects the certificate authority's current attribute schema."
+	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes list obtained"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
@@ -57,7 +63,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid) throws NotFoundException, ConnectorException;
 
-	@Operation(summary = "Validate issue Certificate Attributes")
+	@Operation(
+			summary = "Validate issue certificate attributes",
+			description = "Validate a candidate set of issuance attributes against this RA profile's schema before submitting an issuance request. Returns 422 with a list of error messages when the attributes are not acceptable."
+	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attributes validated"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
@@ -67,7 +76,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@RequestBody List<RequestAttribute>attributes) throws NotFoundException, ConnectorException, ValidationException;
 
-	@Operation(summary = "Issue existing certificate with status Requested")
+	@Operation(
+			summary = "Issue an existing certificate request",
+			description = "Trigger issuance for a certificate already in state `REQUESTED`. Used after the certificate request has been created (typically via a protocol such as ACME, SCEP, or CMP) and any approval and compliance flows have completed."
+	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
@@ -77,7 +89,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException;
 
-	@Operation(summary = "Issue Certificate")
+	@Operation(
+			summary = "Issue certificate",
+			description = "Submit a new certificate signing request and trigger issuance through this RA profile. If the issuance is non-synchronous, the certificate is returned in state `PENDING_ISSUE` and must be finalized once it is issued externally."
+	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
@@ -87,7 +102,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@RequestBody ClientCertificateSignRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
 
-	@Operation(summary = "Renew Certificate")
+	@Operation(
+			summary = "Renew certificate",
+			description = "Renew an existing certificate using the same key pair. The original certificate stays in state `ISSUED`; the renewed certificate is returned and, if its issuance is non-synchronous, ends in state `PENDING_ISSUE` until it is finalized."
+	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate renewed"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
@@ -118,14 +136,20 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
 			@RequestBody ClientCertificateRekeyRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
 
-	@Operation(summary = "Get revocation Attributes")
+	@Operation(
+			summary = "Get revocation attributes",
+			description = "Return the list of attributes the client must populate when revoking a certificate through this RA profile."
+	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes obtained") })
 	@GetMapping(path = "/attributes/revoke", produces = {"application/json"})
 	List<BaseAttribute> listRevokeCertificateAttributes(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid) throws ConnectorException, NotFoundException;
 
-	@Operation(summary = "Validate revocation Attributes")
+	@Operation(
+			summary = "Validate revocation attributes",
+			description = "Validate a candidate set of revocation attributes against this RA profile's schema before submitting a revocation request."
+	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes validated")})
 	@PostMapping(path = "/attributes/revoke/validate", consumes = {"application/json"}, produces = {"application/json"})
 	void validateRevokeCertificateAttributes(
@@ -133,7 +157,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@RequestBody List<RequestAttribute>attributes) throws ConnectorException, ValidationException, NotFoundException;
 
-	@Operation(summary = "Revoke Certificate")
+	@Operation(
+			summary = "Revoke certificate",
+			description = "Revoke a certificate currently in state `ISSUED`. If the revocation is non-synchronous, the certificate moves to state `PENDING_REVOKE` and must be confirmed once the revocation has been performed externally."
+	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Certificate revoked")})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
@@ -142,5 +169,86 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
 			@RequestBody ClientCertificateRevocationDto request) throws ConnectorException, AttributeException, NotFoundException;
+
+	@Operation(
+			summary = "Finalize a non-synchronous certificate issuance",
+			description = """
+					Upload an externally-issued certificate to finalize a certificate currently in
+					state `PENDING_ISSUE`. On success, the certificate transitions to `ISSUED`
+					and is pushed to any pre-associated locations.
+
+					Validation:
+					- the certificate request's public key must match the uploaded certificate's
+					  public key (mandatory);
+					- the certificate request's subject DN should match the uploaded certificate's
+					  subject DN (warning on mismatch — some CAs canonicalise the DN);
+					- the uploaded certificate must be verifiable against the certificate
+					  authority associated with the RA profile (mandatory).
+
+					Request body carries a Base64-encoded single certificate and an optional list
+					of certificate-level custom attributes.
+					"""
+	)
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate finalized"),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples={@ExampleObject(value="[\"Certificate is not in PENDING_ISSUE state\",\"Public key mismatch with certificate request\"]")}))})
+	@PostMapping(path = "/certificates/{certificateUuid}/issue/finalize", consumes = {"application/json"}, produces = {"application/json"})
+	CertificateDetailDto manuallyIssueCertificate(
+			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
+			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
+			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
+			@RequestBody UploadCertificateRequestDto request)
+			throws NotFoundException, CertificateException, AlreadyExistException, ConnectorException, AttributeException;
+
+	@Operation(
+			summary = "Confirm a non-synchronous certificate revocation",
+			description = """
+					Confirm that an externally-revoked certificate has been revoked. The certificate
+					must be in state `PENDING_REVOKE`. The platform applies the destroy-key flag and
+					revoke attributes from the original revoke request, transitions the certificate
+					to `REVOKED`, and clears the data carried over from the original request.
+					"""
+	)
+	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Revocation confirmed"),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples={@ExampleObject(value="[\"Certificate is not in PENDING_REVOKE state\"]")}))})
+	@PostMapping(path = "/certificates/{certificateUuid}/revoke/confirm")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	void manuallyConfirmRevoke(
+			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
+			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
+			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid)
+			throws NotFoundException;
+
+	@Operation(
+			summary = "Cancel a pending certificate operation",
+			description = """
+					State-aware cancel for a certificate currently in state `PENDING_ISSUE` or
+					`PENDING_REVOKE`. Transitions:
+
+					- `PENDING_ISSUE` → `FAILED`
+					- `PENDING_REVOKE` → `ISSUED`
+
+					The optional `reason` from the request body is recorded in the certificate
+					event history.
+
+					If the underlying operation cannot be aborted (for example, it has
+					progressed beyond a point where cancellation is possible), the response is
+					`422 Unprocessable Entity` with the reason, and the certificate **stays in
+					its pending state**. In that case the operation can still be resolved by
+					waiting for it to complete externally and then finalizing or confirming
+					the certificate, or by retrying the cancel later if circumstances change.
+					"""
+	)
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Cancellation completed"),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples={@ExampleObject(value="[\"Certificate is not in a pending state\",\"Authority refused to cancel: CA does not support cancellation\"]")}))})
+	@PostMapping(path = "/certificates/{certificateUuid}/cancel", consumes = {"application/json"}, produces = {"application/json"})
+	CertificateDetailDto cancelPendingCertificateOperation(
+			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
+			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
+			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
+			@RequestBody(required = false) CancelPendingCertificateRequestDto request)
+			throws NotFoundException;
 
 }

--- a/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/client/v2/ClientOperationController.java
@@ -91,7 +91,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Issue certificate",
-			description = "Submit a new certificate signing request and trigger issuance through this RA profile. If the issuance is non-synchronous, the certificate is returned in state `PENDING_ISSUE` and must be finalized once it is issued externally."
+			description = "Submit a new certificate signing request and trigger issuance through this RA profile. If the issuance is asynchronous, the certificate is returned in state `PENDING_ISSUE` and must be finalized once it has been issued."
 	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
@@ -104,7 +104,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Renew certificate",
-			description = "Renew an existing certificate using the same key pair. The original certificate stays in state `ISSUED`; the renewed certificate is returned and, if its issuance is non-synchronous, ends in state `PENDING_ISSUE` until it is finalized."
+			description = "Renew an existing certificate using the same key pair. The original certificate stays in state `ISSUED`; the renewed certificate is returned and, if its issuance is asynchronous, ends in state `PENDING_ISSUE` until it is finalized."
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate renewed"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
@@ -159,7 +159,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Revoke certificate",
-			description = "Revoke a certificate currently in state `ISSUED`. If the revocation is non-synchronous, the certificate moves to state `PENDING_REVOKE` and must be confirmed once the revocation has been performed externally."
+			description = "Revoke a certificate currently in state `ISSUED`. If the revocation is asynchronous, the certificate moves to state `PENDING_REVOKE` and must be confirmed once the revocation has been performed."
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Certificate revoked")})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
@@ -171,9 +171,9 @@ public interface ClientOperationController extends AuthProtectedController {
 			@RequestBody ClientCertificateRevocationDto request) throws ConnectorException, AttributeException, NotFoundException;
 
 	@Operation(
-			summary = "Finalize a non-synchronous certificate issuance",
+			summary = "Finalize an asynchronous certificate issuance",
 			description = """
-					Upload an externally-issued certificate to finalize a certificate currently in
+					Upload an issued certificate to finalize a certificate currently in
 					state `PENDING_ISSUE`. On success, the certificate transitions to `ISSUED`
 					and is pushed to any pre-associated locations.
 
@@ -201,9 +201,9 @@ public interface ClientOperationController extends AuthProtectedController {
 			throws NotFoundException, CertificateException, AlreadyExistException, ConnectorException, AttributeException;
 
 	@Operation(
-			summary = "Confirm a non-synchronous certificate revocation",
+			summary = "Confirm an asynchronous certificate revocation",
 			description = """
-					Confirm that an externally-revoked certificate has been revoked. The certificate
+					Confirm that a revoked certificate has been revoked. The certificate
 					must be in state `PENDING_REVOKE`. The platform applies the destroy-key flag and
 					revoke attributes from the original revoke request, transitions the certificate
 					to `REVOKED`, and clears the data carried over from the original request.
@@ -236,7 +236,7 @@ public interface ClientOperationController extends AuthProtectedController {
 					progressed beyond a point where cancellation is possible), the response is
 					`422 Unprocessable Entity` with the reason, and the certificate **stays in
 					its pending state**. In that case the operation can still be resolved by
-					waiting for it to complete externally and then finalizing or confirming
+					waiting for it to complete and then finalizing or confirming
 					the certificate, or by retrying the cancel later if circumstances change.
 					"""
 	)

--- a/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
@@ -1,6 +1,7 @@
 package com.czertainly.api.model.client.certificate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 /**
@@ -22,5 +23,6 @@ public class CancelPendingCertificateRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED,
             maxLength = 1000
     )
+    @Size(max = 1000, message = "reason must be at most 1000 characters")
     private String reason;
 }

--- a/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
@@ -1,0 +1,26 @@
+package com.czertainly.api.model.client.certificate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * Request body for the cancel endpoint that aborts an in-flight non-synchronous
+ * certificate issuance or revocation.
+ *
+ * <p>Cancel transitions:</p>
+ * <ul>
+ *   <li>{@code PENDING_ISSUE} &rarr; {@code FAILED} — the certificate was never issued and never will be.</li>
+ *   <li>{@code PENDING_REVOKE} &rarr; {@code ISSUED} — the certificate remains valid; the revocation was abandoned.</li>
+ * </ul>
+ */
+@Data
+public class CancelPendingCertificateRequestDto {
+
+    @Schema(
+            description = "Optional free-text reason from the user explaining why the pending operation "
+                    + "is being cancelled. Recorded in the certificate event history.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            maxLength = 1000
+    )
+    private String reason;
+}

--- a/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDto.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 /**
- * Request body for the cancel endpoint that aborts an in-flight non-synchronous
+ * Request body for the cancel endpoint that aborts an in-flight asynchronous
  * certificate issuance or revocation.
  *
  * <p>Cancel transitions:</p>

--- a/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
+++ b/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
@@ -2,15 +2,11 @@ package com.czertainly.api.model.common.events.data;
 
 import com.czertainly.api.model.core.certificate.CertificateState;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.UUID;
-
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
 public class CertificateActionPerformedEventData extends CertificateEventAuthorityData {
@@ -30,5 +26,16 @@ public class CertificateActionPerformedEventData extends CertificateEventAuthori
                     + "was introduced.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CertificateState state;
+
+    public CertificateActionPerformedEventData(String action, String errorMessage) {
+        this.action = action;
+        this.errorMessage = errorMessage;
+    }
+
+    public CertificateActionPerformedEventData(String action, String errorMessage, CertificateState state) {
+        this.action = action;
+        this.errorMessage = errorMessage;
+        this.state = state;
+    }
 
 }

--- a/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
+++ b/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
@@ -19,9 +19,13 @@ public class CertificateActionPerformedEventData extends CertificateEventAuthori
 
     @Schema(
             description = "Certificate state observed at the moment the event was emitted. "
-                    + "Subscribers use this to distinguish a synchronous success "
-                    + "(state=ISSUED / REVOKED) from an asynchronous-pending outcome "
-                    + "(state=PENDING_ISSUE / PENDING_REVOKE) for the same action. "
+                    + "Any value of `CertificateState` may appear; the values commonly seen by "
+                    + "subscribers of this event are:\n"
+                    + "- `ISSUED` — synchronous issuance / renewal / rekey completed,\n"
+                    + "- `REVOKED` — synchronous revocation completed or asynchronous revocation confirmed,\n"
+                    + "- `PENDING_ISSUE` — asynchronous issuance / renewal / rekey accepted, awaiting completion,\n"
+                    + "- `PENDING_REVOKE` — asynchronous revocation accepted, awaiting completion,\n"
+                    + "- `FAILED` — asynchronous issuance was cancelled, or issuance failed.\n"
                     + "Optional for backward compatibility with subscribers built before the field "
                     + "was introduced.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
+++ b/src/main/java/com/czertainly/api/model/common/events/data/CertificateActionPerformedEventData.java
@@ -1,5 +1,6 @@
 package com.czertainly.api.model.common.events.data;
 
+import com.czertainly.api.model.core.certificate.CertificateState;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,5 +20,15 @@ public class CertificateActionPerformedEventData extends CertificateEventAuthori
 
     @Schema(description = "Error message. Filled when action failed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String errorMessage;
+
+    @Schema(
+            description = "Certificate state observed at the moment the event was emitted. "
+                    + "Subscribers use this to distinguish a synchronous success "
+                    + "(state=ISSUED / REVOKED) from an asynchronous-pending outcome "
+                    + "(state=PENDING_ISSUE / PENDING_REVOKE) for the same action. "
+                    + "Optional for backward compatibility with subscribers built before the field "
+                    + "was introduced.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private CertificateState state;
 
 }

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateDataResponseDto.java
@@ -16,8 +16,11 @@ import java.util.List;
 @Data
 public class CertificateDataResponseDto {
 
-    @Schema(description = "Base64 encoded Certificate content",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Base64 encoded Certificate content. Required for synchronous "
+                    + "(HTTP 200) responses; absent for asynchronous (HTTP 202) responses, "
+                    + "where the operation is still in flight and only optional metadata "
+                    + "may be carried in the body.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String certificateData;
 
     @Schema(description = "UUID of Certificate",

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationCancelRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationCancelRequestDto.java
@@ -1,0 +1,45 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.MetadataAttribute;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.List;
+
+/**
+ * Body for the Authority Provider cancel endpoints. The operation type to abort is
+ * determined by which cancel endpoint is called; this body carries only the data the
+ * Authority Provider needs to identify the in-flight operation — the RA profile attributes
+ * and the technology-specific {@link MetadataAttribute} entries that were returned
+ * alongside the original {@code 202 Accepted} response.
+ */
+@Setter
+@Getter
+public class CertificateOperationCancelRequestDto {
+
+    @Schema(
+            description = "List of RA Profile attributes",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private List<RequestAttribute> raProfileAttributes;
+
+    @Schema(
+            description = "Technology-specific metadata that was returned by the Authority Provider in the "
+                    + "original `202 Accepted` response, sent back here so the Authority Provider can identify "
+                    + "the in-flight operation it must abort.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<MetadataAttribute> meta;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("raProfileAttributes", raProfileAttributes)
+                .append("meta", meta)
+                .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatus.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatus.java
@@ -10,16 +10,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 
 /**
- * Status of a non-synchronous certificate operation reported by an Authority Provider on
+ * Status of an asynchronous certificate operation reported by an Authority Provider on
  * the status-check endpoints. Returned for an issuance, renewal, or revocation that
  * previously responded {@code 202 Accepted}.
  */
 @Schema(enumAsRef = true)
 public enum CertificateOperationStatus implements IPlatformEnum {
 
-    IN_PROGRESS("inProgress", "In progress", "Operation is still being processed externally"),
-    COMPLETED("completed", "Completed", "Operation finished externally; cert data included for issue/renew, no payload for revoke"),
-    FAILED("failed", "Failed", "Operation failed externally; reason field carries detail");
+    IN_PROGRESS("inProgress", "In progress", "Operation is still being processed asynchronously"),
+    COMPLETED("completed", "Completed", "Operation finished; cert data included for issue/renew, no payload for revoke"),
+    FAILED("failed", "Failed", "Operation failed; reason field carries detail");
 
     private static final CertificateOperationStatus[] VALUES;
 

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatus.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatus.java
@@ -1,0 +1,67 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.czertainly.api.exception.ValidationError;
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.common.enums.IPlatformEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+
+/**
+ * Status of a non-synchronous certificate operation reported by an Authority Provider on
+ * the status-check endpoints. Returned for an issuance, renewal, or revocation that
+ * previously responded {@code 202 Accepted}.
+ */
+@Schema(enumAsRef = true)
+public enum CertificateOperationStatus implements IPlatformEnum {
+
+    IN_PROGRESS("inProgress", "In progress", "Operation is still being processed externally"),
+    COMPLETED("completed", "Completed", "Operation finished externally; cert data included for issue/renew, no payload for revoke"),
+    FAILED("failed", "Failed", "Operation failed externally; reason field carries detail");
+
+    private static final CertificateOperationStatus[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    @Schema(description = "Operation status code",
+            examples = {"inProgress", "completed", "failed"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String code;
+    private final String label;
+    private final String description;
+
+    CertificateOperationStatus(String code, String label, String description) {
+        this.code = code;
+        this.label = label;
+        this.description = description;
+    }
+
+    @Override
+    @JsonValue
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getLabel() {
+        return this.label;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @JsonCreator
+    public static CertificateOperationStatus findByCode(String code) {
+        return Arrays.stream(VALUES)
+                .filter(k -> k.code.equals(code))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ValidationException(ValidationError.create("Unknown certificate operation status {}", code)));
+    }
+}

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusRequestDto.java
@@ -1,0 +1,44 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.attribute.common.MetadataAttribute;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.List;
+
+/**
+ * Body for the Authority Provider status-check endpoints. The operation type is
+ * determined by which status endpoint is called; this body returns the technology-specific
+ * {@link MetadataAttribute} entries that the Authority Provider returned in the original
+ * {@code 202 Accepted} response so it can resolve and report on the in-flight operation.
+ */
+@Setter
+@Getter
+public class CertificateOperationStatusRequestDto {
+
+    @Schema(
+            description = "List of RA Profile attributes",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private List<RequestAttribute> raProfileAttributes;
+
+    @Schema(
+            description = "Technology-specific metadata that was returned by the Authority Provider in the "
+                    + "original `202 Accepted` response, sent back here so the Authority Provider can resolve "
+                    + "the in-flight operation and report its status.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<MetadataAttribute> meta;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("raProfileAttributes", raProfileAttributes)
+                .append("meta", meta)
+                .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusResponseDto.java
@@ -1,0 +1,59 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.czertainly.api.model.common.attribute.common.MetadataAttribute;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.List;
+
+/**
+ * Response from the Authority Provider status-check endpoints. The same DTO is used for
+ * issuance and revocation status — for revocation the {@code certificateData} field is
+ * unused (revocation completion carries no payload).
+ *
+ * <p>When {@link CertificateOperationStatus#COMPLETED} is reported for an issuance or
+ * renewal, the Authority Provider populates {@code certificateData} (Base64-encoded). When
+ * {@link CertificateOperationStatus#FAILED}, the {@code reason} field carries the failure
+ * detail. The optional {@code meta} field lets the Authority Provider report updated
+ * technology-specific state on each call.</p>
+ */
+@Data
+public class CertificateOperationStatusResponseDto {
+
+    @Schema(
+            description = "Operation status as known to the Authority Provider",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private CertificateOperationStatus status;
+
+    @Schema(
+            description = "Base64-encoded certificate content. Present when status=COMPLETED for issue/renew. "
+                    + "Unused for revoke status responses.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String certificateData;
+
+    @Schema(
+            description = "Updated technology-specific metadata. The Authority Provider may report a refreshed "
+                    + "value on each call.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<MetadataAttribute> meta;
+
+    @Schema(
+            description = "Failure detail when `status` is `FAILED`.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String reason;
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("status", status)
+                .append("certificateData", certificateData != null ? "<present>" : null)
+                .append("reason", reason)
+                .toString();
+    }
+}

--- a/src/main/java/com/czertainly/api/model/core/logging/enums/Operation.java
+++ b/src/main/java/com/czertainly/api/model/core/logging/enums/Operation.java
@@ -103,6 +103,15 @@ public enum Operation implements IPlatformEnum {
     PROMOTE_METADATA("promoteMetadata", "Promote metadata"),
     ARCHIVE("archive", "Archive certificate"),
     UNARCHIVE("unarchive", "Unarchive certificate"),
+    FINALIZE_ISSUE("finalizeIssue", "Finalize certificate issuance",
+            "Operator-driven finalization of an asynchronous issuance: the externally-issued "
+                    + "certificate is uploaded and the certificate moves from PENDING_ISSUE to ISSUED."),
+    CONFIRM_REVOKE("confirmRevoke", "Confirm certificate revocation",
+            "Operator-driven confirmation of an asynchronous revocation: the certificate moves "
+                    + "from PENDING_REVOKE to REVOKED."),
+    CANCEL("cancel", "Cancel pending certificate operation",
+            "Cancel an in-flight asynchronous issuance or revocation. PENDING_ISSUE -> FAILED, "
+                    + "PENDING_REVOKE -> ISSUED."),
     GET_ASSOCIATIONS("getAssociations", "Get associations"),
     LIST_VERSIONS("listVersions", "List versions"),
     GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation instructions"),

--- a/src/test/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDtoTest.java
+++ b/src/test/java/com/czertainly/api/model/client/certificate/CancelPendingCertificateRequestDtoTest.java
@@ -1,0 +1,39 @@
+package com.czertainly.api.model.client.certificate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CancelPendingCertificateRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void deserializesEmptyBody() throws Exception {
+        CancelPendingCertificateRequestDto dto =
+                mapper.readValue("{}", CancelPendingCertificateRequestDto.class);
+        assertNull(dto.getReason());
+    }
+
+    @Test
+    void deserializesWithReason() throws Exception {
+        CancelPendingCertificateRequestDto dto = mapper.readValue(
+                "{\"reason\":\"requirement changed\"}",
+                CancelPendingCertificateRequestDto.class);
+        assertEquals("requirement changed", dto.getReason());
+    }
+
+    @Test
+    void roundTripsReason() throws Exception {
+        CancelPendingCertificateRequestDto dto = new CancelPendingCertificateRequestDto();
+        dto.setReason("ops decision reversed");
+
+        String json = mapper.writeValueAsString(dto);
+        CancelPendingCertificateRequestDto back =
+                mapper.readValue(json, CancelPendingCertificateRequestDto.class);
+
+        assertEquals("ops decision reversed", back.getReason());
+    }
+}

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationCancelRequestDtoTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationCancelRequestDtoTest.java
@@ -1,0 +1,51 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CertificateOperationCancelRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void roundTripsEmptyLists() throws Exception {
+        CertificateOperationCancelRequestDto dto = new CertificateOperationCancelRequestDto();
+        dto.setRaProfileAttributes(List.of());
+        dto.setMeta(List.of());
+
+        String json = mapper.writeValueAsString(dto);
+        CertificateOperationCancelRequestDto back =
+                mapper.readValue(json, CertificateOperationCancelRequestDto.class);
+
+        assertNotNull(back);
+        assertNotNull(back.getRaProfileAttributes());
+        assertNotNull(back.getMeta());
+        assertTrue(back.getRaProfileAttributes().isEmpty());
+        assertTrue(back.getMeta().isEmpty());
+    }
+
+    @Test
+    void deserializesWithoutMeta() throws Exception {
+        // meta is optional; an Authority Provider that omits it must still parse cleanly
+        String json = "{\"raProfileAttributes\":[]}";
+        CertificateOperationCancelRequestDto dto =
+                mapper.readValue(json, CertificateOperationCancelRequestDto.class);
+        assertNotNull(dto.getRaProfileAttributes());
+    }
+
+    @Test
+    void toStringIncludesBothFields() {
+        CertificateOperationCancelRequestDto dto = new CertificateOperationCancelRequestDto();
+        dto.setRaProfileAttributes(List.of());
+        dto.setMeta(List.of());
+
+        String s = dto.toString();
+        assertTrue(s.contains("raProfileAttributes"));
+        assertTrue(s.contains("meta"));
+    }
+}

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusRequestDtoTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusRequestDtoTest.java
@@ -1,0 +1,50 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CertificateOperationStatusRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void roundTripsEmptyLists() throws Exception {
+        CertificateOperationStatusRequestDto dto = new CertificateOperationStatusRequestDto();
+        dto.setRaProfileAttributes(List.of());
+        dto.setMeta(List.of());
+
+        String json = mapper.writeValueAsString(dto);
+        CertificateOperationStatusRequestDto back =
+                mapper.readValue(json, CertificateOperationStatusRequestDto.class);
+
+        assertNotNull(back);
+        assertNotNull(back.getRaProfileAttributes());
+        assertNotNull(back.getMeta());
+        assertTrue(back.getRaProfileAttributes().isEmpty());
+        assertTrue(back.getMeta().isEmpty());
+    }
+
+    @Test
+    void deserializesWithoutMeta() throws Exception {
+        String json = "{\"raProfileAttributes\":[]}";
+        CertificateOperationStatusRequestDto dto =
+                mapper.readValue(json, CertificateOperationStatusRequestDto.class);
+        assertNotNull(dto.getRaProfileAttributes());
+    }
+
+    @Test
+    void toStringIncludesBothFields() {
+        CertificateOperationStatusRequestDto dto = new CertificateOperationStatusRequestDto();
+        dto.setRaProfileAttributes(List.of());
+        dto.setMeta(List.of());
+
+        String s = dto.toString();
+        assertTrue(s.contains("raProfileAttributes"));
+        assertTrue(s.contains("meta"));
+    }
+}

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusResponseDtoTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusResponseDtoTest.java
@@ -1,0 +1,66 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CertificateOperationStatusResponseDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesInProgress_omitsAbsentOptionalFields() throws Exception {
+        CertificateOperationStatusResponseDto dto = new CertificateOperationStatusResponseDto();
+        dto.setStatus(CertificateOperationStatus.IN_PROGRESS);
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"status\":\"inProgress\""),
+                "expected status code 'inProgress' in JSON, got: " + json);
+        // certificateData/reason are null and should serialize as null (default Jackson) — they're not omitted but explicit nulls are acceptable
+    }
+
+    @Test
+    void serializesCompletedWithCertificateData() throws Exception {
+        CertificateOperationStatusResponseDto dto = new CertificateOperationStatusResponseDto();
+        dto.setStatus(CertificateOperationStatus.COMPLETED);
+        dto.setCertificateData("BASE64DATA==");
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"status\":\"completed\""));
+        assertTrue(json.contains("\"certificateData\":\"BASE64DATA==\""));
+    }
+
+    @Test
+    void serializesFailedWithReason() throws Exception {
+        CertificateOperationStatusResponseDto dto = new CertificateOperationStatusResponseDto();
+        dto.setStatus(CertificateOperationStatus.FAILED);
+        dto.setReason("CA rejected request");
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"status\":\"failed\""));
+        assertTrue(json.contains("\"reason\":\"CA rejected request\""));
+    }
+
+    @Test
+    void deserializesInProgressFromMinimalJson() throws Exception {
+        CertificateOperationStatusResponseDto dto = mapper.readValue(
+                "{\"status\":\"inProgress\"}",
+                CertificateOperationStatusResponseDto.class);
+        assertEquals(CertificateOperationStatus.IN_PROGRESS, dto.getStatus());
+        assertNull(dto.getCertificateData());
+        assertNull(dto.getReason());
+    }
+
+    @Test
+    void toStringRedactsCertificateData() {
+        CertificateOperationStatusResponseDto dto = new CertificateOperationStatusResponseDto();
+        dto.setStatus(CertificateOperationStatus.COMPLETED);
+        dto.setCertificateData("BASE64DATA==");
+        String s = dto.toString();
+        assertTrue(s.contains("<present>"),
+                "toString should not leak cert content; got: " + s);
+        assertFalse(s.contains("BASE64DATA"),
+                "toString should not leak cert content; got: " + s);
+    }
+}

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
@@ -1,0 +1,52 @@
+package com.czertainly.api.model.connector.v2;
+
+import com.czertainly.api.exception.ValidationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CertificateOperationStatusTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesToJsonValueCode() throws Exception {
+        assertEquals("\"inProgress\"", mapper.writeValueAsString(CertificateOperationStatus.IN_PROGRESS));
+        assertEquals("\"completed\"", mapper.writeValueAsString(CertificateOperationStatus.COMPLETED));
+        assertEquals("\"failed\"", mapper.writeValueAsString(CertificateOperationStatus.FAILED));
+    }
+
+    @Test
+    void deserializesFromJsonValueCode() throws Exception {
+        assertEquals(CertificateOperationStatus.IN_PROGRESS,
+                mapper.readValue("\"inProgress\"", CertificateOperationStatus.class));
+        assertEquals(CertificateOperationStatus.COMPLETED,
+                mapper.readValue("\"completed\"", CertificateOperationStatus.class));
+        assertEquals(CertificateOperationStatus.FAILED,
+                mapper.readValue("\"failed\"", CertificateOperationStatus.class));
+    }
+
+    @Test
+    void unknownCodeThrowsValidationException() {
+        assertThrows(Exception.class,
+                () -> mapper.readValue("\"bogus\"", CertificateOperationStatus.class));
+    }
+
+    @Test
+    void findByCodeRejectsUnknownDirectly() {
+        assertThrows(ValidationException.class,
+                () -> CertificateOperationStatus.findByCode("bogus"));
+    }
+
+    @Test
+    void labelsAndDescriptionsArePopulated() {
+        for (CertificateOperationStatus status : CertificateOperationStatus.values()) {
+            assertEquals(false, status.getLabel().isBlank(),
+                    "label missing for " + status.name());
+            assertEquals(false, status.getDescription().isBlank(),
+                    "description missing for " + status.name());
+        }
+    }
+}

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
@@ -1,10 +1,12 @@
 package com.czertainly.api.model.connector.v2;
 
 import com.czertainly.api.exception.ValidationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CertificateOperationStatusTest {
@@ -30,8 +32,12 @@ class CertificateOperationStatusTest {
 
     @Test
     void unknownCodeThrowsValidationException() {
-        assertThrows(Exception.class,
+        // Jackson wraps the @JsonCreator's ValidationException in JsonMappingException;
+        // assert both the wrapper type and that the underlying cause is ValidationException.
+        JsonMappingException ex = assertThrows(JsonMappingException.class,
                 () -> mapper.readValue("\"bogus\"", CertificateOperationStatus.class));
+        assertInstanceOf(ValidationException.class, ex.getCause(),
+                "expected the underlying cause to be ValidationException, got: " + ex.getCause());
     }
 
     @Test

--- a/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
+++ b/src/test/java/com/czertainly/api/model/connector/v2/CertificateOperationStatusTest.java
@@ -32,8 +32,9 @@ class CertificateOperationStatusTest {
 
     @Test
     void unknownCodeThrowsValidationException() {
-        // Jackson wraps the @JsonCreator's ValidationException in JsonMappingException;
-        // assert both the wrapper type and that the underlying cause is ValidationException.
+        // Deserializing an unknown code surfaces a Jackson mapping error whose root
+        // cause carries the validation failure raised by the enum factory method.
+        // The assertion walks the cause chain to verify both layers.
         JsonMappingException ex = assertThrows(JsonMappingException.class,
                 () -> mapper.readValue("\"bogus\"", CertificateOperationStatus.class));
         assertInstanceOf(ValidationException.class, ex.getCause(),


### PR DESCRIPTION
## Summary
- Add HTTP 202 as the asynchronous-completion signal on the v2 connector certificate API (issue/renew/revoke), with optional metadata in the response body. Any authority provider connector can opt into this; connectors that always complete synchronously continue to use 200 unchanged.
- Add new connector endpoints for cancelling and getting the status of asynchronous operations (`cancelIssueCertificate`, `cancelRevokeCertificate`, `getIssueCertificateStatus`, `getRevokeCertificateStatus`).
- Add new client API endpoints for the asynchronous lifecycle: `manuallyIssueCertificate` (finalize), `manuallyConfirmRevoke`, and `cancelPendingCertificateOperation`.
- Add `CancelPendingCertificateRequestDto`, `CertificateOperationCancelRequestDto`, `CertificateOperationStatus*` DTOs.
- Add `Operation.FINALIZE_ISSUE`, `Operation.CONFIRM_REVOKE`, `Operation.CANCEL` for audit/event logging.
- Add optional `state` field to `CertificateActionPerformedEventData` so subscribers can distinguish synchronous success (state=ISSUED/REVOKED) from an asynchronous-pending outcome (state=PENDING_ISSUE/PENDING_REVOKE).
- Add `sendRequestForEntity` (default method) on `ProxyClient` so MQ-proxied authority calls preserve the upstream HTTP status (202 vs 200) instead of collapsing to 200.
- Relax `CertificateDataResponseDto.certificateData` to `NOT_REQUIRED` so the same DTO matches both synchronous (200, certificate present) and asynchronous (202, only metadata) responses.
- Standardise wording on "asynchronous"; enrich existing OpenAPI summaries/descriptions for clarity.

## Backwards compatibility
- All new types and endpoints are additive; existing controller method signatures are unchanged.
- New DTO fields use `@Schema(requiredMode = NOT_REQUIRED)`; subscribers that ignore them continue to work.
- `CertificateActionPerformedEventData` keeps the existing `(action, errorMessage)` constructor as an explicit method so callers built against the previous Lombok-generated constructor compile unchanged; a new `(action, errorMessage, state)` constructor is added alongside it.
- `ProxyClient.sendRequestForEntity` is a `default` method that falls back to `sendRequest` + `ResponseEntity.ok(...)` when not overridden — existing `ProxyClient` implementations work without recompilation. `ProxyClientImpl` (in core) overrides it to propagate the actual upstream status code.
- `CertificateDataResponseDto.certificateData` was `REQUIRED` and is now `NOT_REQUIRED`. This is a relaxation: existing producers that always emit it remain valid; existing consumers that always read it continue to work.
- One internal helper (`com.czertainly.api.clients.v2.CertificateApiClient`) has its return types changed from `CertificateDataResponseDto` / `void` to `ResponseEntity<...>` so callers can inspect HTTP status. Documented for downstream consumers; runtime/HTTP behaviour is unaffected.

## Test plan
- [x] All existing/new unit tests pass under JDK 21 (`mvn -B test`).
- [x] DTO round-trip tests added for all new request/response types.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
