### PR TITLE
Fix OpenAPI lint for connector proxy schema

### DIFF
--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorApiClientDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorApiClientDto.java
@@ -40,6 +40,7 @@ public class ConnectorApiClientDto extends NameAndUuidDto implements ApiClientCo
     @Schema(description = "Proxy for message queue routing. " +
             "When set, connector communicates via message queue proxy. " +
             "When null, connector uses direct REST communication.",
+            implementation = ProxyDto.class,
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private ProxyDto proxy;
 }


### PR DESCRIPTION
## Summary

`ConnectorDto.proxy` is a `ProxyDto`, and `ProxyDto.connectors` is `List<ConnectorDto>` — a circular reference. When `springdoc-openapi` resolves the schema for `ConnectorDto`, its cycle-detector inlines the `ProxyDto` body but emits a malformed shape: the field retains its description and the resolved `required` list (`code`, `name`, `status`, `uuid`) while dropping both `properties` and `$ref`.

Adding `implementation = ProxyDto.class` to the field's `@Schema` annotation steers the generator to emit `$ref: "#/components/schemas/ProxyDto"`, which resolves to the top-level `ProxyDto` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)