### PR TITLE
Replace ProxyDto.connectors items with ConnectorSummaryDto

### DIFF
--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorApiClientDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorApiClientDto.java
@@ -40,7 +40,6 @@ public class ConnectorApiClientDto extends NameAndUuidDto implements ApiClientCo
     @Schema(description = "Proxy for message queue routing. " +
             "When set, connector communicates via message queue proxy. " +
             "When null, connector uses direct REST communication.",
-            implementation = ProxyDto.class,
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private ProxyDto proxy;
 }

--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorSummaryDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorSummaryDto.java
@@ -1,0 +1,39 @@
+package com.czertainly.api.model.core.connector;
+
+import com.czertainly.api.model.common.NameAndUuidDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Lightweight reference to a Connector. Carries the fields needed to render a Connector in
+ * list-of-references contexts (e.g., the connectors associated with a Proxy) without pulling in
+ * the full {@link ConnectorDto}, which contains a back-reference to {@link com.czertainly.api.model.core.proxy.ProxyDto}
+ * and would otherwise create a circular schema reference.
+ */
+@Setter
+@Getter
+@ToString(callSuper = true)
+public class ConnectorSummaryDto extends NameAndUuidDto {
+
+    @Schema(description = "URL of the Connector",
+            examples = {"http://network-discovery-provider:8080"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String url;
+
+    @Schema(description = "Status of the Connector",
+            examples = {"CONNECTED"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ConnectorStatus status;
+
+    public ConnectorSummaryDto() {
+        super();
+    }
+
+    public ConnectorSummaryDto(String uuid, String name, String url, ConnectorStatus status) {
+        super(uuid, name);
+        this.url = url;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/czertainly/api/model/core/proxy/ProxyDto.java
+++ b/src/main/java/com/czertainly/api/model/core/proxy/ProxyDto.java
@@ -1,7 +1,7 @@
 package com.czertainly.api.model.core.proxy;
 
 import com.czertainly.api.model.common.NameAndUuidDto;
-import com.czertainly.api.model.core.connector.ConnectorDto;
+import com.czertainly.api.model.core.connector.ConnectorSummaryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,7 +37,7 @@ public class ProxyDto extends NameAndUuidDto implements Serializable {
     private OffsetDateTime lastActivity;
 
     @Schema(description = "List of Connectors associated with the Proxy")
-    private List<ConnectorDto> connectors;
+    private List<ConnectorSummaryDto> connectors;
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Summary

`ProxyDto.connectors` was `List<ConnectorDto>`, and `ConnectorDto` (via `ConnectorApiClientDto`) carries a `ProxyDto` reference. The bidirectional type relationship caused two real problems:

- **OpenAPI schema generation.** Springdoc's cycle handler emitted a malformed schema for `ConnectorDto.proxy` in some per-group YAMLs — only the description and a dangling `required` list survived; `properties` and `$ref` were dropped, failing redocly's `no-required-schema-properties-undefined` rule. A previous PR (#665) added `@Schema(implementation = ProxyDto.class)` as a workaround that fixed the umbrella YAML but not all per-group YAMLs.
- **Runtime serialization.** Core has had to maintain a `Proxy.mapToDtoSimple()` workaround (with a comment "*Don't set connectors to avoid circular reference*") to skip the connectors list when mapping a Connector's proxy back-reference, otherwise Jackson would loop indefinitely.

The structural fix is to break the cycle by narrowing the reverse-collection side to a summary type:

- New `ConnectorSummaryDto extends NameAndUuidDto` carrying `url` and `status` — the fields actually consumed in proxy-detail UIs (verified against fe-administrator's Managed Connectors table).
- `ProxyDto.connectors` is now `List<ConnectorSummaryDto>`. The forward direction (`Connector → Proxy`) keeps the full `ProxyDto` unchanged.
- `@Schema(implementation = ProxyDto.class)` workaround on `ConnectorApiClientDto.proxy` is removed — no cycle, no need for the hint.

## Wire-format impact

Items in `ProxyDto.connectors` lose `authType`, `authAttributes`, `customAttributes`, `functionGroups`, and the partial proxy back-reference. Fields that remain — `uuid`, `name`, `url`, `status` — match every consumer of `ProxyDto.connectors` known today.

`ProxyDto` is brand-new in `2.17.1-SNAPSHOT` (introduced by the SaaS migration) and has not yet shipped in a released contract.

## Test plan

- [x] `mvn install` builds clean under JDK 21.
- [x] Verified the regenerated OpenAPI YAMLs in `interface-documentation` (against this snapshot) lint clean across all 51 per-group documents — including `doc-openapi-core-proxy.yaml` which previously failed on the malformed `ConnectorDto.proxy` schema.
- [x] Verified `ProxyDto.connectors` items now `$ref` `ConnectorSummaryDto` cleanly with no inlined-and-broken schema anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)