### PR TITLE
Add signature formatter API client

### DIFF
--- a/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
@@ -1,0 +1,29 @@
+package com.czertainly.api.clients.mq.signing;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.clients.mq.ProxyClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SignatureFormatterApiClient implements SignatureFormatterSyncApiClient {
+
+    private static final String BASE_PATH = "/v1/signatureProvider/formatting";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private final ProxyClient proxyClient;
+
+    public SignatureFormatterApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+        String path = BASE_PATH + "/attributes";
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
+        return Arrays.asList(result);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
@@ -24,6 +24,6 @@ public class SignatureFormatterApiClient implements SignatureFormatterSyncApiCli
     public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
         String path = BASE_PATH + "/attributes";
         BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
-        return Arrays.asList(result);
+        return result == null ? List.of() : Arrays.asList(result);
     }
 }

--- a/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
@@ -1,0 +1,35 @@
+package com.czertainly.api.clients.signing;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.clients.BaseApiClient;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import javax.net.ssl.TrustManager;
+import java.util.List;
+
+public class SignatureFormatterApiClient extends BaseApiClient implements SignatureFormatterSyncApiClient {
+
+    private static final String ATTRIBUTES_CONTEXT = "/v1/signatureProvider/formatting/attributes";
+
+    public SignatureFormatterApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        this.webClient = webClient;
+        this.defaultTrustManagers = defaultTrustManagers;
+    }
+
+    @Override
+    public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
+
+        return processRequest(r -> r
+                .uri(connector.getUrl() + ATTRIBUTES_CONTEXT)
+                .retrieve()
+                .toEntityList(BaseAttribute.class)
+                .block().getBody(),
+                request,
+                connector);
+    }
+}

--- a/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
@@ -24,11 +24,13 @@ public class SignatureFormatterApiClient extends BaseApiClient implements Signat
     public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
-        return processRequest(r -> r
-                .uri(connector.getUrl() + ATTRIBUTES_CONTEXT)
-                .retrieve()
-                .toEntityList(BaseAttribute.class)
-                .block().getBody(),
+        return processRequest(r -> {
+                    var entity = r.uri(connector.getUrl() + ATTRIBUTES_CONTEXT)
+                            .retrieve()
+                            .toEntityList(BaseAttribute.class)
+                            .block();
+                    return entity != null && entity.getBody() != null ? entity.getBody() : List.of();
+                },
                 request,
                 connector);
     }

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/signing/SignatureFormatterSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/signing/SignatureFormatterSyncApiClient.java
@@ -1,0 +1,13 @@
+package com.czertainly.api.interfaces.client.v1.signing;
+
+import com.czertainly.api.clients.ApiClientConnectorInfo;
+import com.czertainly.api.exception.ConnectorException;
+import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.List;
+
+public interface SignatureFormatterSyncApiClient {
+
+    List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
+
+}


### PR DESCRIPTION
Add `SignatureFormatterApiClient` implementation for HTTP and MQ communication with `SignatureFormatterSyncApiClient` interface definition