### PR TITLE
Add signing response formatting to signature formatter client

### DIFF
--- a/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/mq/signing/SignatureFormatterApiClient.java
@@ -4,6 +4,10 @@ import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatResponseRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormattedResponseDto;
 import com.czertainly.api.clients.mq.ProxyClient;
 
 import java.util.Arrays;
@@ -13,6 +17,7 @@ public class SignatureFormatterApiClient implements SignatureFormatterSyncApiCli
 
     private static final String BASE_PATH = "/v1/signatureProvider/formatting";
     private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
 
     private final ProxyClient proxyClient;
 
@@ -25,5 +30,17 @@ public class SignatureFormatterApiClient implements SignatureFormatterSyncApiCli
         String path = BASE_PATH + "/attributes";
         BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
         return result == null ? List.of() : Arrays.asList(result);
+    }
+
+    @Override
+    public FormatDtbsResponseDto formatDtbs(ApiClientConnectorInfo connector, FormatDtbsRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/formatDtbs";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, FormatDtbsResponseDto.class);
+    }
+
+    @Override
+    public FormattedResponseDto formatSigningResponse(ApiClientConnectorInfo connector, FormatResponseRequestDto requestDto) throws ConnectorException {
+        String path = BASE_PATH + "/formatResponse";
+        return proxyClient.sendRequest(connector, path, HTTP_METHOD_POST, requestDto, FormattedResponseDto.class);
     }
 }

--- a/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/signing/SignatureFormatterApiClient.java
@@ -5,8 +5,13 @@ import com.czertainly.api.clients.BaseApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatResponseRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormattedResponseDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import javax.net.ssl.TrustManager;
 import java.util.List;
@@ -14,6 +19,8 @@ import java.util.List;
 public class SignatureFormatterApiClient extends BaseApiClient implements SignatureFormatterSyncApiClient {
 
     private static final String ATTRIBUTES_CONTEXT = "/v1/signatureProvider/formatting/attributes";
+    private static final String DTBS_CONTEXT = "/v1/signatureProvider/formatting/formatDtbs";
+    private static final String RESPONSE_CONTEXT = "/v1/signatureProvider/formatting/formatResponse";
 
     public SignatureFormatterApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         this.webClient = webClient;
@@ -31,6 +38,34 @@ public class SignatureFormatterApiClient extends BaseApiClient implements Signat
                             .block();
                     return entity != null && entity.getBody() != null ? entity.getBody() : List.of();
                 },
+                request,
+                connector);
+    }
+
+    @Override
+    public FormatDtbsResponseDto formatDtbs(ApiClientConnectorInfo connector, FormatDtbsRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> r
+                .uri(connector.getUrl() + DTBS_CONTEXT)
+                .body(Mono.just(requestDto), FormatDtbsRequestDto.class)
+                .retrieve()
+                .toEntity(FormatDtbsResponseDto.class)
+                .block().getBody(),
+                request,
+                connector);
+    }
+
+    @Override
+    public FormattedResponseDto formatSigningResponse(ApiClientConnectorInfo connector, FormatResponseRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> r
+                .uri(connector.getUrl() + RESPONSE_CONTEXT)
+                .body(Mono.just(requestDto), FormatResponseRequestDto.class)
+                .retrieve()
+                .toEntity(FormattedResponseDto.class)
+                .block().getBody(),
                 request,
                 connector);
     }

--- a/src/main/java/com/czertainly/api/interfaces/client/v1/signing/SignatureFormatterSyncApiClient.java
+++ b/src/main/java/com/czertainly/api/interfaces/client/v1/signing/SignatureFormatterSyncApiClient.java
@@ -3,11 +3,19 @@ package com.czertainly.api.interfaces.client.v1.signing;
 import com.czertainly.api.clients.ApiClientConnectorInfo;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.model.common.attribute.common.BaseAttribute;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormatResponseRequestDto;
+import com.czertainly.api.model.connector.signatures.formatter.FormattedResponseDto;
 
 import java.util.List;
 
 public interface SignatureFormatterSyncApiClient {
 
     List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    FormatDtbsResponseDto formatDtbs(ApiClientConnectorInfo connector, FormatDtbsRequestDto requestDto) throws ConnectorException;
+
+    FormattedResponseDto formatSigningResponse(ApiClientConnectorInfo connector, FormatResponseRequestDto requestDto) throws ConnectorException;
 
 }


### PR DESCRIPTION
## What

Adds two methods to the signature-formatter sync client and both implementations:

- `formatDtbs` → `POST /v1/signatureProvider/formatting/formatDtbs`
- `formatSigningResponse` → `POST /v1/signatureProvider/formatting/formatResponse`

| File | Change |
|---|---|
| `SignatureFormatterSyncApiClient` (interface) | declares the two methods |
| `clients/signing/SignatureFormatterApiClient` | blocking WebClient implementation |
| `clients/mq/signing/SignatureFormatterApiClient` | MQ/proxy implementation |

## Why

These let callers drive DTBS construction and signing-response formatting through a Signature Formatter connector — the client surface required by the managed-timestamping (TSA) work in Core.

## Notes

- **Purely additive**: 60 insertions, 0 deletions. No existing signatures change.
- **No new model types**: the request/response DTOs (`FormatDtbsRequestDto`, `FormatDtbsResponseDto`, `FormatResponseRequestDto`, `FormattedResponseDto`) already exist on `main`.
- No consumers inside this library; callers live in Core, so this can land independently as a pure API-surface widening.
- Builds clean with `-Dmaven.compiler.proc=full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)