### PR TITLE
Fix validation for optional email fields

### DIFF
--- a/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
@@ -1,9 +1,9 @@
 package com.czertainly.api.model.client.auth;
 
 import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.common.validation.NullableNotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -24,7 +24,7 @@ public class UpdateUserRequestDto {
 
     @Schema(description = "Email of the user")
     @Email
-    @Size(min = 1)
+    @NullableNotBlank
     private String email;
 
     @Schema(description = "Groups UUIDs of the user (set to empty list to remove certificate from all groups)")

--- a/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
@@ -24,7 +24,7 @@ public class UpdateUserRequestDto {
 
     @Schema(description = "Email of the user")
     @Email
-    @NullableNotBlank
+    @NullableNotBlank(message = "Email cannot be blank if provided")
     private String email;
 
     @Schema(description = "Groups UUIDs of the user (set to empty list to remove certificate from all groups)")

--- a/src/main/java/com/czertainly/api/model/common/validation/NullableNotBlank.java
+++ b/src/main/java/com/czertainly/api/model/common/validation/NullableNotBlank.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Documented
 public @interface NullableNotBlank {
 
-    String message() default "Value cannot be blank if provided";
+    String message() default "Name cannot be blank if provided";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/czertainly/api/model/common/validation/NullableNotBlank.java
+++ b/src/main/java/com/czertainly/api/model/common/validation/NullableNotBlank.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Documented
 public @interface NullableNotBlank {
 
-    String message() default "Name cannot be blank if provided";
+    String message() default "Value cannot be blank if provided";
 
     Class<?>[] groups() default {};
 


### PR DESCRIPTION
Replace `@Size(min = 1)` with @NullableNotBlank on the UpdateUserRequestDto.email field so null is allowed but provided values cannot be blank.