### PR TITLE
Rename RecipientType.MAPPED to OBJECT

### DIFF
--- a/src/main/java/com/czertainly/api/model/client/notification/NotificationProfileUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/notification/NotificationProfileUpdateRequestDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
@@ -21,6 +22,7 @@ public class NotificationProfileUpdateRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String description;
 
+    @NotNull(message = "Recipient type is required")
     @Schema(description = "Recipient type of notifications produced by profile",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private RecipientType recipientType;
@@ -47,8 +49,12 @@ public class NotificationProfileUpdateRequestDto {
 
     @AssertTrue(message = "Recipient UUID is required when recipient type is not Owner, None, Default or Object")
     private boolean isRecipientValid() {
-        return ((recipientType == RecipientType.OWNER || recipientType == RecipientType.NONE || recipientType == RecipientType.DEFAULT || recipientType == RecipientType.OBJECT) && (recipientUuids == null || recipientUuids.isEmpty()))
-                || (recipientType != RecipientType.OWNER && recipientType != RecipientType.NONE && recipientType != RecipientType.DEFAULT && recipientType != RecipientType.OBJECT && recipientUuids != null && !recipientUuids.isEmpty());
+        boolean noRecipientUuids = recipientUuids == null || recipientUuids.isEmpty();
+        boolean typeWithoutRecipientUuids = recipientType == RecipientType.OWNER
+                || recipientType == RecipientType.NONE
+                || recipientType == RecipientType.DEFAULT
+                || recipientType == RecipientType.OBJECT;
+        return typeWithoutRecipientUuids == noRecipientUuids;
     }
 
     @AssertFalse(message = "Cannot send internal notification to recipient of type None, Default or Object")

--- a/src/main/java/com/czertainly/api/model/client/notification/NotificationProfileUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/notification/NotificationProfileUpdateRequestDto.java
@@ -45,15 +45,15 @@ public class NotificationProfileUpdateRequestDto {
     @Schema(description = "Maximum number of repetitions of same notification", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer repetitions;
 
-    @AssertTrue(message = "Recipient UUID is required when recipient type is not Owner, None, Default or Mapped")
+    @AssertTrue(message = "Recipient UUID is required when recipient type is not Owner, None, Default or Object")
     private boolean isRecipientValid() {
-        return ((recipientType == RecipientType.OWNER || recipientType == RecipientType.NONE || recipientType == RecipientType.DEFAULT || recipientType == RecipientType.MAPPED) && (recipientUuids == null || recipientUuids.isEmpty()))
-                || (recipientType != RecipientType.OWNER && recipientType != RecipientType.NONE && recipientType != RecipientType.DEFAULT && recipientType != RecipientType.MAPPED && recipientUuids != null && !recipientUuids.isEmpty());
+        return ((recipientType == RecipientType.OWNER || recipientType == RecipientType.NONE || recipientType == RecipientType.DEFAULT || recipientType == RecipientType.OBJECT) && (recipientUuids == null || recipientUuids.isEmpty()))
+                || (recipientType != RecipientType.OWNER && recipientType != RecipientType.NONE && recipientType != RecipientType.DEFAULT && recipientType != RecipientType.OBJECT && recipientUuids != null && !recipientUuids.isEmpty());
     }
 
-    @AssertFalse(message = "Cannot send internal notification to recipient of type None, Default or Mapped")
+    @AssertFalse(message = "Cannot send internal notification to recipient of type None, Default or Object")
     private boolean isInternalNotificationPossible() {
-        return (recipientType == RecipientType.NONE || recipientType == RecipientType.DEFAULT || recipientType == RecipientType.MAPPED) && internalNotification;
+        return (recipientType == RecipientType.NONE || recipientType == RecipientType.DEFAULT || recipientType == RecipientType.OBJECT) && internalNotification;
     }
 
     @AssertTrue(message = "Notification instance and/or internal notification is required")

--- a/src/main/java/com/czertainly/api/model/core/notification/RecipientType.java
+++ b/src/main/java/com/czertainly/api/model/core/notification/RecipientType.java
@@ -19,7 +19,7 @@ public enum RecipientType implements IPlatformEnum {
     GROUP("group", "Group", "Recipient is group from inventory", Resource.GROUP),
     ROLE("role", "Role", "Recipient is registered role", Resource.ROLE),
     OWNER("owner", "Owner", "Recipient is user that is associated as owner of resource object that is connected with notification", Resource.USER),
-    MAPPED("mapped", "Mapped", "Notification is sent to the contact resolved via the notification instance's mapping attributes", null)
+    OBJECT("object", "Object", "Notification is sent to the recipient resolved from the attributes of the object present in the notification message, via the notification instance's mapping", null)
     ;
 
     private static final RecipientType[] VALUES;


### PR DESCRIPTION
The MAPPED value named its implementation mechanism (the notification instance's mapping attributes) rather than the recipient source. Every sibling value (USER, GROUP, ROLE, OWNER) names who is notified; OBJECT follows that pattern: the recipient is resolved from the attributes of the object present in the notification message.

Renames the enum constant, code ("object"), label, and description, plus the validation messages on NotificationProfileUpdateRequestDto. The separate "mapped attributes" join mechanism keeps its name.