### PR TITLE
Fix broken javadoc link after issueExistingCertificate rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn -B verify -f pom.xml
+        run: mvn -B verify javadoc:jar -f pom.xml  # javadoc:jar catches broken {@link} refs before they break the publish workflow
   build:
     if: github.event_name != 'pull_request'
     name: Build

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -74,7 +74,7 @@ import java.util.List;
  *
  * <h3>Synchronous paths (connector returns 200 OK)</h3>
  * <ul>
- *   <li>{@link #issueCertificate}, {@link #issueRequestedCertificate},
+ *   <li>{@link #issueCertificate}, {@link #issueExistingCertificate},
  *       {@link #renewCertificate}, {@link #rekeyCertificate}: cert moves to
  *       {@code ISSUED}. If the connector reports a failure during the call the cert
  *       moves to {@code FAILED} instead.</li>
@@ -83,7 +83,7 @@ import java.util.List;
  *
  * <h3>Asynchronous paths (connector returns 202 Accepted)</h3>
  * <ul>
- *   <li>{@code issueCertificate} / {@code issueRequestedCertificate} /
+ *   <li>{@code issueCertificate} / {@code issueExistingCertificate} /
  *       {@code renewCertificate} / {@code rekeyCertificate}: cert moves to
  *       {@code PENDING_ISSUE}. An operator finalizes it via
  *       {@link #manuallyIssueCertificate} (→ {@code ISSUED}) or aborts via
@@ -94,7 +94,7 @@ import java.util.List;
  *       certificate was never actually revoked upstream).</li>
  * </ul>
  *
- * <p>{@code rekeyCertificate} and {@code issueRequestedCertificate} use the same
+ * <p>{@code rekeyCertificate} and {@code issueExistingCertificate} use the same
  * authority-provider call as {@code issueCertificate}, so they can complete either
  * synchronously or asynchronously depending on what the connector returns.</p>
  *


### PR DESCRIPTION
## Summary

The **Publish package** workflow on `main` is failing ([run 27400201057](https://github.com/OmniTrustILM/interfaces/actions/runs/27400201057)) because `maven-javadoc-plugin:jar` errors out:

```
ClientOperationController.java:77: error: reference not found
 *   <li>{@link #issueCertificate}, {@link #issueRequestedCertificate},
```

PR #681 renamed `issueRequestedCertificate` → `issueExistingCertificate` but the class-level javadoc on the v2 `ClientOperationController` still referenced the old name. Javadoc treats an unresolved `{@link}` as an error, so the javadoc jar required for the Maven Central publish fails.

## Changes

- `{@link #issueRequestedCertificate}` → `{@link #issueExistingCertificate}` (line 77, the actual build breaker)
- Two stale `{@code issueRequestedCertificate}` text mentions updated to match (lines 86, 97)
- **CI hardening:** PR `Check` job now runs `mvn -B verify javadoc:jar`, so a broken `{@link}` fails the PR instead of the post-merge publish. Same Maven invocation — adds ~15–20 s to the ~38 s Check job. Javadoc *errors* block; the pre-existing "no comment" *warnings* remain non-blocking.

## Verification

`mvn --batch-mode javadoc:jar` succeeds locally on this branch: 0 errors, javadoc jar built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)