### PR TITLE
Declare success responses on v3 authority provider endpoints

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/connector/v3/AuthorityController.java
+++ b/src/main/java/com/otilm/api/interfaces/connector/v3/AuthorityController.java
@@ -19,6 +19,7 @@ import java.util.List;
 public interface AuthorityController extends AuthProtectedConnectorController {
 
     @Operation(summary = "List authority attributes", description = "Top-level authority attribute schema (for the create-authority UI)")
+    @ApiResponse(responseCode = "200", description = "Authority attributes retrieved")
     @GetMapping(path = "/attributes", produces = MediaType.APPLICATION_JSON_VALUE)
     List<BaseAttribute> listAuthorityAttributes();
 
@@ -30,16 +31,19 @@ public interface AuthorityController extends AuthProtectedConnectorController {
             @RequestBody List<RequestAttribute> attributes);
 
     @Operation(summary = "List RA Profile Attributes", description = "RA profile attribute schema given authority context")
+    @ApiResponse(responseCode = "200", description = "RA profile attributes retrieved")
     @PostMapping(path = "/raProfile/attributes", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     List<BaseAttribute> listRaProfileAttributes(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Authority attributes", required = true)
             @RequestBody List<RequestAttribute> attributes);
 
     @Operation(summary = "Get the latest CRL for Authority", description = "Fetch CRL (full or delta) from the upstream CA based on request")
+    @ApiResponse(responseCode = "200", description = "CRL retrieved")
     @PostMapping(path = "/crl", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CrlResponseDto getCrl(@RequestBody CrlRequestDtoV3 request);
 
     @Operation(summary = "Get certificate chain for Authority", description = "Fetch CA certificate chain from the upstream CA")
+    @ApiResponse(responseCode = "200", description = "CA certificate chain retrieved")
     @PostMapping(path = "/caCertificates", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CaCertificatesResponseDto getCaCertificates(@RequestBody CaCertificatesRequestDtoV3 request);
 }

--- a/src/main/java/com/otilm/api/interfaces/connector/v3/CertificateController.java
+++ b/src/main/java/com/otilm/api/interfaces/connector/v3/CertificateController.java
@@ -37,7 +37,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
     ResponseEntity<CertificateDataResponseDto> issue(@RequestBody @Valid CertificateSignRequestDtoV3 request);
 
     @Operation(summary = "Get async issue operation status", description = "Get status of an async issue/renew/rekey operation")
-    @ApiResponses(@ApiResponse(responseCode = "200", description = "Operation status retrieved"))
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Issue operation status retrieved"))
     @PostMapping(path = "/issue/status", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CertificateOperationStatusResponseDto getIssueStatus(@RequestBody @Valid CertificateOperationStatusRequestDtoV3 request);
 

--- a/src/main/java/com/otilm/api/interfaces/connector/v3/CertificateController.java
+++ b/src/main/java/com/otilm/api/interfaces/connector/v3/CertificateController.java
@@ -37,6 +37,7 @@ public interface CertificateController extends AuthProtectedConnectorController 
     ResponseEntity<CertificateDataResponseDto> issue(@RequestBody @Valid CertificateSignRequestDtoV3 request);
 
     @Operation(summary = "Get async issue operation status", description = "Get status of an async issue/renew/rekey operation")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Operation status retrieved"))
     @PostMapping(path = "/issue/status", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CertificateOperationStatusResponseDto getIssueStatus(@RequestBody @Valid CertificateOperationStatusRequestDtoV3 request);
 
@@ -52,12 +53,17 @@ public interface CertificateController extends AuthProtectedConnectorController 
     // ---- Renew (status/cancel via /issue/*) ----
 
     @Operation(summary = "Renew certificate", description = "Renew a certificate (sync 200 or async 202)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Renewed synchronously"),
+            @ApiResponse(responseCode = "202", description = "Renewal accepted asynchronously; body carries meta tracking handle")
+    })
     @PostMapping(path = "/renew", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<CertificateDataResponseDto> renew(@RequestBody @Valid CertificateRenewRequestDtoV3 request);
 
     // ---- Revoke ----
 
     @Operation(summary = "List revoke operation attributes", description = "List dynamic attributes for revoke")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Revoke attributes retrieved"))
     @PostMapping(path = "/revoke/attributes", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     List<BaseAttribute> listRevokeAttributes(@RequestBody @Valid CertificateAttributeListRequestDtoV3 request);
 
@@ -70,34 +76,52 @@ public interface CertificateController extends AuthProtectedConnectorController 
     ResponseEntity<CertificateDataResponseDto> revoke(@RequestBody @Valid CertificateRevocationRequestDtoV3 request);
 
     @Operation(summary = "Get async revoke operation status", description = "Get status of an async revoke operation")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Revoke operation status retrieved"))
     @PostMapping(path = "/revoke/status", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CertificateOperationStatusResponseDto getRevokeStatus(@RequestBody @Valid CertificateOperationStatusRequestDtoV3 request);
 
     @Operation(summary = "Cancel async revoke operation", description = "Cancel an in-flight async revoke operation")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Aborted"),
+            @ApiResponse(responseCode = "404", description = "Operation not tracked — treat as terminal cancellation"),
+            @ApiResponse(responseCode = "422", description = "Refused — past point of no return")
+    })
     @PostMapping(path = "/revoke/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<Void> cancelRevoke(@RequestBody @Valid CertificateOperationCancelRequestDtoV3 request);
 
     // ---- Register ----
 
     @Operation(summary = "List register operation attributes", description = "List dynamic attributes for register")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Register attributes retrieved"))
     @PostMapping(path = "/register/attributes", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     List<BaseAttribute> listRegisterAttributes(@RequestBody @Valid CertificateAttributeListRequestDtoV3 request);
 
     @Operation(summary = "Register certificate", description = "Pre-register a certificate's identity at the upstream CA (no CSR)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Registered synchronously; end-entity reference returned in meta (no certificate is produced)"),
+            @ApiResponse(responseCode = "202", description = "Registration accepted asynchronously; body carries meta tracking handle")
+    })
     @PostMapping(path = "/register", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<CertificateDataResponseDto> register(@RequestBody @Valid CertificateRegistrationRequestDtoV3 request);
 
     @Operation(summary = "Get async register operation status", description = "Get status of an async register operation")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Register operation status retrieved"))
     @PostMapping(path = "/register/status", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CertificateOperationStatusResponseDto getRegisterStatus(@RequestBody @Valid CertificateOperationStatusRequestDtoV3 request);
 
     @Operation(summary = "Cancel async register operation", description = "Cancel an in-flight async register operation")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Aborted"),
+            @ApiResponse(responseCode = "404", description = "Operation not tracked — treat as terminal cancellation"),
+            @ApiResponse(responseCode = "422", description = "Refused — past point of no return")
+    })
     @PostMapping(path = "/register/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<Void> cancelRegister(@RequestBody @Valid CertificateOperationCancelRequestDtoV3 request);
 
     // ---- Identify ----
 
     @Operation(summary = "Identify certificate", description = "Identify a certificate at the upstream CA (always synchronous)")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "Certificate identified"))
     @PostMapping(path = "/identify", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CertificateIdentificationResponseDto identify(@RequestBody @Valid CertificateIdentificationRequestDtoV3 request);
 }

--- a/src/main/java/com/otilm/api/model/connector/v3/authority/CrlResponseDto.java
+++ b/src/main/java/com/otilm/api/model/connector/v3/authority/CrlResponseDto.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
+@Schema(name = "CrlResponseDtoV3")
 public class CrlResponseDto {
 
     @Schema(description = "Base64-encoded CRL (DER). Core parses nextUpdate, issuer, and revoked-entry data from the CRL itself.",


### PR DESCRIPTION
## Problem

The v3 `AuthorityController` and `CertificateController` interfaces left **14 operations** without an explicit success `@ApiResponse`. springdoc only emits a `2XX` entry when the method declares one — the global customizer supplies the shared `401`/`404`/`500` set and suppresses the auto-generated `200`. As a result the generated OpenAPI for these operations carried only error responses, tripping Redocly's `operation-2xx-response` rule in `interface-documentation`:

> Operation must have at least one `2XX` response.

(Lint run: [interface-documentation PR #208](https://github.com/OmniTrustILM/interface-documentation/actions/runs/27533107114/job/81375753739?pr=208).)

The already-correct `issue` / `revoke` / `listIssueAttributes` / `cancelIssue` methods showed the pattern; the rest were simply missed.

## Fix

Add the missing `@ApiResponse` declarations, mirroring the existing annotated methods. springdoc fills each response's content from the method return type — no DTO changes needed.

**AuthorityController** (4): `listAuthorityAttributes`, `listRaProfileAttributes`, `getCrl`, `getCaCertificates`

**CertificateController** (10): `getIssueStatus`, `renew`, `listRevokeAttributes`, `getRevokeStatus`, `cancelRevoke`, `listRegisterAttributes`, `register`, `getRegisterStatus`, `cancelRegister`, `identify`

Async ops (`renew`, `register`) declare both `200` and `202`; cancel ops mirror `cancelIssue` (`204` / `404` / `422`); the rest declare `200`.

Also names `CrlResponseDto`'s generated schema `CrlResponseDtoV3` for parity with its `CrlRequestDtoV3` sibling and the other v3 response DTOs (follows #711).

## Verification

- `mvn -o compile` — clean
- `mvn -o test` — green

Downstream, `interface-documentation` regenerates from the published interfaces artifact, after which the Redocly lint passes.