### PR TITLE
Introduce InBandResponseController base for CMP and TSP protocol endpoints

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/InBandResponseController.java
+++ b/src/main/java/com/otilm/api/interfaces/InBandResponseController.java
@@ -1,0 +1,33 @@
+package com.otilm.api.interfaces;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Base controller for unauthenticated binary protocol endpoints that convey
+ * every outcome in-band rather than via REST-style HTTP error codes.
+ *
+ * <p>Unlike {@link NoAuthController}, this base deliberately declares no
+ * {@code @ApiResponses}: protocols such as RFC 3161 TSP and RFC 4210 CMP answer
+ * both success and failure with the same HTTP 200 response, encoding the result
+ * inside the protocol payload (e.g. {@code PKIStatus} / a CMP error
+ * {@code PKIBody}). Declaring generic 400/404/500 responses here would
+ * misrepresent that contract, so each endpoint documents its own responses
+ * instead.</p>
+ *
+ * @see NoAuthController
+ */
+@OpenAPIDefinition(
+        servers = {
+                @Server(
+                        url = "https://demo.otilm.com/api",
+                        description = "Platform Demo server"
+                )
+        }
+)
+@RestController
+@SecurityRequirements
+public interface InBandResponseController {
+}

--- a/src/main/java/com/otilm/api/interfaces/core/cmp/CmpController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/cmp/CmpController.java
@@ -1,6 +1,6 @@
 package com.otilm.api.interfaces.core.cmp;
 
-import com.otilm.api.interfaces.NoAuthController;
+import com.otilm.api.interfaces.InBandResponseController;
 import com.otilm.api.interfaces.core.cmp.error.CmpBaseException;
 import com.otilm.api.model.core.acme.ProblemDocument;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.*;
         description = "Internal Server Error",
         content = {@Content}
 )})
-public interface CmpController extends NoAuthController {
+public interface CmpController extends InBandResponseController {
 
     @Operation(summary = "CMP Get Operations")
     @ApiResponses(value = {

--- a/src/main/java/com/otilm/api/interfaces/core/cmp/CmpController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/cmp/CmpController.java
@@ -2,7 +2,6 @@ package com.otilm.api.interfaces.core.cmp;
 
 import com.otilm.api.interfaces.InBandResponseController;
 import com.otilm.api.interfaces.core.cmp.error.CmpBaseException;
-import com.otilm.api.model.core.acme.ProblemDocument;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,38 +17,6 @@ import org.springframework.web.bind.annotation.*;
         name = "CMP operations",
         description = "Interfaces used by CMP clients to request CMP related operations. CMP Profile defines the behaviour for the specific CMP configuration. When the CMP Profile contains default RA Profile, it can be used by the CMP clients to request operations on their specific URL."
 )
-@ApiResponses(value = {@ApiResponse(
-        responseCode = "400",
-        description = "Bad Request",
-        content = {@Content(
-                mediaType = "application/problem+json",
-                schema = @Schema(
-                        implementation = ProblemDocument.class
-                )
-        )}
-), @ApiResponse(
-        responseCode = "401",
-        description = "Unauthorized",
-        content = {@Content(
-                mediaType = "application/problem+json",
-                schema = @Schema(
-                        implementation = ProblemDocument.class
-                )
-        )}
-), @ApiResponse(
-        responseCode = "403",
-        description = "Forbidden",
-        content = {@Content(
-                mediaType = "application/problem+json",
-                schema = @Schema(
-                        implementation = ProblemDocument.class
-                )
-        )}
-), @ApiResponse(
-        responseCode = "500",
-        description = "Internal Server Error",
-        content = {@Content}
-)})
 public interface CmpController extends InBandResponseController {
 
     @Operation(summary = "CMP Get Operations")

--- a/src/main/java/com/otilm/api/interfaces/core/cmp/CmpRaProfileController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/cmp/CmpRaProfileController.java
@@ -1,6 +1,6 @@
 package com.otilm.api.interfaces.core.cmp;
 
-import com.otilm.api.interfaces.NoAuthController;
+import com.otilm.api.interfaces.InBandResponseController;
 import com.otilm.api.interfaces.core.cmp.error.CmpBaseException;
 import com.otilm.api.model.core.acme.ProblemDocument;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.*;
                         content = @Content
                 )
         })
-public interface CmpRaProfileController extends NoAuthController {
+public interface CmpRaProfileController extends InBandResponseController {
 
     @Operation(summary = "CMP Get Operations")
     @ApiResponses(value = {

--- a/src/main/java/com/otilm/api/interfaces/core/cmp/CmpRaProfileController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/cmp/CmpRaProfileController.java
@@ -2,7 +2,6 @@ package com.otilm.api.interfaces.core.cmp;
 
 import com.otilm.api.interfaces.InBandResponseController;
 import com.otilm.api.interfaces.core.cmp.error.CmpBaseException;
-import com.otilm.api.model.core.acme.ProblemDocument;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,32 +17,6 @@ import org.springframework.web.bind.annotation.*;
         "on top of RA Profile. CMP Profile defines the behaviour for the specific CMP configuration. CMP Profile is " +
         "bound with specific RA Profile and it can be used by the CMP clients to request operations on their specific " +
         "URL. These operations are always specific only for the RA Profile.")
-@ApiResponses(
-        value = {
-                @ApiResponse(
-                        responseCode = "400",
-                        description = "Bad Request",
-                        content = @Content(mediaType = "application/problem+json",
-                                schema = @Schema(implementation = ProblemDocument.class))
-                ),
-                @ApiResponse(
-                        responseCode = "401",
-                        description = "Unauthorized",
-                        content = @Content(mediaType = "application/problem+json",
-                                schema = @Schema(implementation = ProblemDocument.class))
-                ),
-                @ApiResponse(
-                        responseCode = "403",
-                        description = "Forbidden",
-                        content = @Content(mediaType = "application/problem+json",
-                                schema = @Schema(implementation = ProblemDocument.class))
-                ),
-                @ApiResponse(
-                        responseCode = "500",
-                        description = "Internal Server Error",
-                        content = @Content
-                )
-        })
 public interface CmpRaProfileController extends InBandResponseController {
 
     @Operation(summary = "CMP Get Operations")

--- a/src/main/java/com/otilm/api/interfaces/core/tsp/TspController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/tsp/TspController.java
@@ -1,5 +1,6 @@
 package com.otilm.api.interfaces.core.tsp;
 
+import com.otilm.api.interfaces.InBandResponseController;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
                         schema = @Schema(type = "string", format = "binary"))
         )
 })
-public interface TspController {
+public interface TspController extends InBandResponseController {
 
     @Operation(
             summary = "Request a timestamp token",

--- a/src/main/java/com/otilm/api/interfaces/core/tsp/TspSigningProfileController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/tsp/TspSigningProfileController.java
@@ -1,5 +1,6 @@
 package com.otilm.api.interfaces.core.tsp;
 
+import com.otilm.api.interfaces.InBandResponseController;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -46,7 +47,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
                         schema = @Schema(type = "string", format = "binary"))
         )
 })
-public interface TspSigningProfileController {
+public interface TspSigningProfileController extends InBandResponseController {
 
     @Operation(
             summary = "Request a timestamp token",


### PR DESCRIPTION
Replace `NoAuthController` with `InBandResponseController` and add shared interface implementation