### PR TITLE
Carry connector and interface on the authority response DTO

### DIFF
--- a/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
+++ b/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
@@ -2,6 +2,7 @@ package com.otilm.api.model.core.authority;
 
 import com.otilm.api.model.client.attribute.ResponseAttribute;
 import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.connector.v2.ConnectorInterfaceDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,12 +28,23 @@ public class AuthorityInstanceDto extends NameAndUuidDto {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String status;
 
-    @Schema(description = "UUID of Authority provider",
+    @Schema(description = "Connector (Authority provider) this instance belongs to.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private NameAndUuidDto connector;
+
+    @Schema(description = "Connector Interface this Authority instance is bound to; null for legacy v1 connectors, "
+            + "which are identified by kind instead.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ConnectorInterfaceDto connectorInterface;
+
+    @Schema(description = "UUID of Authority provider. Deprecated — use connector.uuid instead.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
+    @Deprecated(forRemoval = true)
     private String connectorUuid;
 
-    @Schema(description = "Name of Authority provider",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(description = "Name of Authority provider. Deprecated — use connector.name instead.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
+    @Deprecated(forRemoval = true)
     private String connectorName;
 
     @Schema(description = "Authority Instance Kind",
@@ -48,8 +60,8 @@ public class AuthorityInstanceDto extends NameAndUuidDto {
                 .append("attributes", attributes)
                 .append("customAttributes", customAttributes)
                 .append("status", status)
-                .append("connectorUuid", connectorUuid)
-                .append("connectorName", connectorName)
+                .append("connector", connector)
+                .append("connectorInterface", connectorInterface)
                 .append("kind", kind)
                 .toString();
     }

--- a/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
+++ b/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
@@ -29,19 +29,25 @@ public class AuthorityInstanceDto extends NameAndUuidDto {
     private String status;
 
     @Schema(description = "Connector (Authority provider) this instance belongs to.",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private NameAndUuidDto connector;
 
     @Schema(description = "Connector Interface this Authority instance is bound to; null for legacy v1 connectors, "
             + "which are identified by kind instead.",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
     private ConnectorInterfaceDto connectorInterface;
 
+    /**
+     * @deprecated use {@link #connector} instead.
+     */
     @Schema(description = "UUID of Authority provider. Deprecated — use connector.uuid instead.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
     @Deprecated(forRemoval = true)
     private String connectorUuid;
 
+    /**
+     * @deprecated use {@link #connector} instead.
+     */
     @Schema(description = "Name of Authority provider. Deprecated — use connector.name instead.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
     @Deprecated(forRemoval = true)


### PR DESCRIPTION
Adds `connector` and `connectorInterface` to the authority list/detail response DTO so the bound connector and its interface — including the interface **version** (v2/v3) — are visible to API consumers, matching how `VaultInstanceDto` already exposes them.

## Why

An authority instance is created against a specific connector AUTHORITY interface (`interfaceUuid` on the create request), and Core now persists that binding. But `AuthorityInstanceDto` had no field to surface it, so the selected interface/version could not be displayed — unlike vault, which carries both `connector` and `connectorInterface`. This closes that response-side gap (the request-side `interfaceUuid` was added earlier).

## What

- **`connector: NameAndUuidDto`** — the owning connector as a single name+uuid object (vault-consistent).
- **`connectorInterface: ConnectorInterfaceDto`** — the bound interface (uuid, code, **version**, features). **Nullable**: legacy v1 (framework-V1) connectors declare no interface and remain identified by `kind`, so a v1 authority has `connectorInterface = null` + `kind` set, while v2/v3 authorities carry `connectorInterface`.
- **Deprecate** `connectorUuid` / `connectorName` (flat strings) in favour of `connector`. They stay in the payload — Core keeps populating them — so this is **non-breaking**; consumers migrate to `connector` at their own pace and the strings are dropped in a later cleanup (coordinated with fe-administrator).

## Downstream

Once released, Core's `AuthorityInstanceReference.mapToDto()` will populate `connector` + `connectorInterface` (mirroring `VaultInstance.mapToDto()`), wired into the v3 authority work (core #1601 / PR #1614 and the activation slice #1603). No consumer change is required to merge this.

Part of OmniTrustILM/ilm#110.
