### PR TITLE
Relax authority kind to nullable and tidy schema descriptions

### DIFF
--- a/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
+++ b/src/main/java/com/otilm/api/model/core/authority/AuthorityInstanceDto.java
@@ -28,19 +28,19 @@ public class AuthorityInstanceDto extends NameAndUuidDto {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String status;
 
-    @Schema(description = "Connector (Authority provider) this instance belongs to.",
+    @Schema(description = "Connector (Authority provider) this instance belongs to",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private NameAndUuidDto connector;
 
     @Schema(description = "Connector Interface this Authority instance is bound to; null for legacy v1 connectors, "
-            + "which are identified by kind instead.",
+            + "which are identified by kind instead",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
     private ConnectorInterfaceDto connectorInterface;
 
     /**
      * @deprecated use {@link #connector} instead.
      */
-    @Schema(description = "UUID of Authority provider. Deprecated — use connector.uuid instead.",
+    @Schema(description = "UUID of Authority provider; deprecated, use connector.uuid instead",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
     @Deprecated(forRemoval = true)
     private String connectorUuid;
@@ -48,14 +48,15 @@ public class AuthorityInstanceDto extends NameAndUuidDto {
     /**
      * @deprecated use {@link #connector} instead.
      */
-    @Schema(description = "Name of Authority provider. Deprecated — use connector.name instead.",
+    @Schema(description = "Name of Authority provider; deprecated, use connector.name instead",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED, deprecated = true)
     @Deprecated(forRemoval = true)
     private String connectorName;
 
-    @Schema(description = "Authority Instance Kind",
-            examples = {"LegacyEjbca, ADCS, etc."},
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Authority instance kind; present for legacy v1 connectors, null for v2/v3 authorities "
+            + "which are identified by connectorInterface",
+            examples = {"LegacyEjbca", "ADCS"},
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
     private String kind;
 
     @Override


### PR DESCRIPTION
Follow-up to #719 (which merged just before this small change landed). Relaxes `AuthorityInstanceDto.kind` to nullable and tidies the new schema descriptions.

## Why

`kind` is v1-only: `AuthorityInstanceRequestDto.kind` is documented "used only by v1 connectors (framework V1)… v2 connectors ignore it (they dispatch on connector interface)," so v2/v3 authorities leave it null. The response DTO marking `kind` `REQUIRED` was therefore already dishonest for v2/v3 at runtime. This relaxes it to `NOT_REQUIRED, nullable = true` — symmetric to `connectorInterface` — so the schema matches reality and freshly-generated clients handle the null correctly.

## Also

- Drop en-dashes and trailing periods from the `connector` / `connectorInterface` / deprecated-string descriptions (these strings land in generated OpenAPI JSON consumed by client generators → ASCII, consistent with the file's other descriptions).

Surfaced by a guided PR review of #719. Part of OmniTrustILM/ilm#110.
