### PR TITLE
Declare AttributeException on validateRAProfileAttributes

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -102,10 +102,12 @@ public interface AuthorityInstanceController extends AuthProtectedController {
     List<BaseAttribute> listRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid) throws ConnectorException, NotFoundException;
 
     @Operation(summary = "Validate RA Profile Attributes")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attribute information validated")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attribute information validated"),
+            @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")})),})
     @PostMapping(path = "/{uuid}/attributes/raProfile/validate", consumes = {
             "application/json"}, produces = {"application/json"})
-    void validateRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid, @RequestBody List<RequestAttribute>attributes)
+    void validateRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid, @RequestBody List<RequestAttribute> attributes)
             throws ConnectorException, AttributeException, NotFoundException;
 
     @Operation(summary = "Delete multiple Authority instances")

--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -106,7 +106,7 @@ public interface AuthorityInstanceController extends AuthProtectedController {
     @PostMapping(path = "/{uuid}/attributes/raProfile/validate", consumes = {
             "application/json"}, produces = {"application/json"})
     void validateRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid, @RequestBody List<RequestAttribute>attributes)
-            throws ConnectorException, NotFoundException;
+            throws ConnectorException, AttributeException, NotFoundException;
 
     @Operation(summary = "Delete multiple Authority instances")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority instances deleted"),


### PR DESCRIPTION
Declares `AttributeException` on `AuthorityInstanceController.validateRAProfileAttributes`.

## Why

For v3 authorities, Core validates RA-profile attributes **locally** (the v3 connector contract is stateless and has no `/validate` endpoint), which can fail with `AttributeException` — and that should surface to the caller, not be swallowed. `createAuthorityInstance` and `editAuthorityInstance` on this same interface already declare `AttributeException`; this brings `validateRAProfileAttributes` in line so the Core controller can propagate it.

Purely a checked-exception declaration on the endpoint contract — no behavioral or wire change for existing v1/v2 callers.

Unblocks the Core v3 authority-instance support (OmniTrustILM/core#1614). Part of OmniTrustILM/ilm#110.
