### PR TITLE
Add Attributes v2 API clients (HTTP + MQ)

### DIFF
--- a/src/main/java/com/otilm/api/clients/mq/v2/AttributesApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/v2/AttributesApiClient.java
@@ -1,0 +1,89 @@
+package com.otilm.api.clients.mq.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.mq.ProxyClient;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.interfaces.client.v2.AttributesSyncApiClient;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * MQ-based implementation of the Attributes v2 API client (common NG provider interface), mirroring the
+ * sibling MQ Info client and the HTTP {@link com.otilm.api.clients.v2.AttributesApiClient}.
+ *
+ * <p><b>AC5 / MQ error parity is intentionally NOT handled here — it is a Core concern.</b> The
+ * {@link ProxyClient} implementation maps connector errors by raw HTTP status code and does not
+ * reconstruct a {@code ConnectorProblemException} from the connector's {@code errorCode}. So a connector
+ * 404 ({@code ATTRIBUTE_DEFINITION_NOT_FOUND}) over MQ surfaces without its error code. Restoring that
+ * parity is tracked as a Core gate (#1622); #726 ships the transport only.</p>
+ *
+ * <p>{@code ProxyClient} also has no notion of a query string, so the exploded {@code uuids} filter rides
+ * inside the request path string (e.g. {@code /v2/attributes?uuids=a&uuids=b}); whether that survives the
+ * bus is a Core/MQ verify-item, not asserted here.</p>
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
+public class AttributesApiClient implements AttributesSyncApiClient {
+
+    private static final String ATTRIBUTES_PATH = "/v2/attributes";
+    private static final String CALLBACK_PATH = ATTRIBUTES_PATH + "/callback";
+
+    private static final String UUIDS_QUERY_PARAM = "uuids";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+
+    public AttributesApiClient(ProxyClient proxyClient) {
+        this.proxyClient = proxyClient;
+    }
+
+    @Override
+    public AttributeDefinitionsDto listDefinitions(ApiClientConnectorInfo connector, List<UUID> uuids) throws ConnectorException {
+        return proxyClient.sendRequest(connector, listDefinitionsPath(uuids), HTTP_METHOD_GET, null, AttributeDefinitionsDto.class);
+    }
+
+    public CompletableFuture<AttributeDefinitionsDto> listDefinitionsAsync(ApiClientConnectorInfo connector, List<UUID> uuids) {
+        return proxyClient.sendRequestAsync(connector, listDefinitionsPath(uuids), HTTP_METHOD_GET, null, AttributeDefinitionsDto.class);
+    }
+
+    @Override
+    public BaseAttribute getDefinition(ApiClientConnectorInfo connector, UUID uuid) throws ConnectorException {
+        return proxyClient.sendRequest(connector, definitionPath(uuid), HTTP_METHOD_GET, null, BaseAttribute.class);
+    }
+
+    public CompletableFuture<BaseAttribute> getDefinitionAsync(ApiClientConnectorInfo connector, UUID uuid) {
+        return proxyClient.sendRequestAsync(connector, definitionPath(uuid), HTTP_METHOD_GET, null, BaseAttribute.class);
+    }
+
+    @Override
+    public AttributeCallbackResponseDto callback(ApiClientConnectorInfo connector, AttributeCallbackRequestDto request) throws ConnectorException {
+        return proxyClient.sendRequest(connector, CALLBACK_PATH, HTTP_METHOD_POST, request, AttributeCallbackResponseDto.class);
+    }
+
+    public CompletableFuture<AttributeCallbackResponseDto> callbackAsync(ApiClientConnectorInfo connector, AttributeCallbackRequestDto request) {
+        return proxyClient.sendRequestAsync(connector, CALLBACK_PATH, HTTP_METHOD_POST, request, AttributeCallbackResponseDto.class);
+    }
+
+    private static String listDefinitionsPath(List<UUID> uuids) {
+        if (uuids == null || uuids.isEmpty()) {
+            return ATTRIBUTES_PATH;
+        }
+        // Exploded form (one repeated `uuids` param per UUID), carried in the path since the proxy has
+        // no query-string notion. Bus survival of this is a Core/MQ gate, not asserted in #726.
+        String query = uuids.stream()
+                .map(uuid -> UUIDS_QUERY_PARAM + "=" + uuid)
+                .collect(Collectors.joining("&"));
+        return ATTRIBUTES_PATH + "?" + query;
+    }
+
+    private static String definitionPath(UUID uuid) {
+        return ATTRIBUTES_PATH + "/" + uuid;
+    }
+}

--- a/src/main/java/com/otilm/api/clients/mq/v2/AttributesApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/v2/AttributesApiClient.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  * {@link ProxyClient} implementation maps connector errors by raw HTTP status code and does not
  * reconstruct a {@code ConnectorProblemException} from the connector's {@code errorCode}. So a connector
  * 404 ({@code ATTRIBUTE_DEFINITION_NOT_FOUND}) over MQ surfaces without its error code. Restoring that
- * parity is tracked as a Core gate (#1622); #726 ships the transport only.</p>
+ * parity is tracked as a Core gate (core #1622/#1621); #726 ships the transport only.</p>
  *
  * <p>{@code ProxyClient} also has no notion of a query string, so the exploded {@code uuids} filter rides
  * inside the request path string (e.g. {@code /v2/attributes?uuids=a&uuids=b}); whether that survives the

--- a/src/main/java/com/otilm/api/clients/v2/AttributesApiClient.java
+++ b/src/main/java/com/otilm/api/clients/v2/AttributesApiClient.java
@@ -53,10 +53,10 @@ public class AttributesApiClient extends BaseApiClient implements AttributesSync
         URI uri = uriBuilder.build();
 
         WebClient.RequestBodySpec request = prepareRequest(HttpMethod.GET, connector, true).uri(uri);
-        return processRequest(r -> r
+        return processRequest(r -> requireBody(r
                         .retrieve()
-                        .bodyToMono(AttributeDefinitionsDto.class)
-                        .block(),
+                        .toEntity(AttributeDefinitionsDto.class),
+                "Attributes v2 list definitions"),
                 request,
                 connector);
     }
@@ -64,11 +64,11 @@ public class AttributesApiClient extends BaseApiClient implements AttributesSync
     @Override
     public BaseAttribute getDefinition(ApiClientConnectorInfo connector, UUID uuid) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
-        return processRequest(r -> r
+        return processRequest(r -> requireBody(r
                         .uri(connector.getUrl() + ATTRIBUTE_CONTEXT, uuid)
                         .retrieve()
-                        .bodyToMono(BaseAttribute.class)
-                        .block(),
+                        .toEntity(BaseAttribute.class),
+                "Attributes v2 get definition"),
                 request,
                 connector);
     }
@@ -76,12 +76,12 @@ public class AttributesApiClient extends BaseApiClient implements AttributesSync
     @Override
     public AttributeCallbackResponseDto callback(ApiClientConnectorInfo connector, AttributeCallbackRequestDto requestDto) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
-        return processRequest(r -> r
+        return processRequest(r -> requireBody(r
                         .uri(connector.getUrl() + CALLBACK_CONTEXT)
                         .body(Mono.just(requestDto), AttributeCallbackRequestDto.class)
                         .retrieve()
-                        .bodyToMono(AttributeCallbackResponseDto.class)
-                        .block(),
+                        .toEntity(AttributeCallbackResponseDto.class),
+                "Attributes v2 callback"),
                 request,
                 connector);
     }

--- a/src/main/java/com/otilm/api/clients/v2/AttributesApiClient.java
+++ b/src/main/java/com/otilm/api/clients/v2/AttributesApiClient.java
@@ -1,0 +1,88 @@
+package com.otilm.api.clients.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.BaseApiClient;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.interfaces.client.v2.AttributesSyncApiClient;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import javax.net.ssl.TrustManager;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * WebClient (HTTP) implementation of the Attributes v2 API client (common NG provider interface),
+ * mirroring the sibling MQ-based {@link com.otilm.api.clients.mq.v2.AttributesApiClient} and the
+ * Info/Health/Metrics v2 trio.
+ *
+ * <p>The path constants below are part of the v2 connector API contract — they describe the routes a
+ * connector implementation must expose, not URIs configurable per environment.</p>
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
+public class AttributesApiClient extends BaseApiClient implements AttributesSyncApiClient {
+
+    private static final String ATTRIBUTES_CONTEXT = "/v2/attributes";
+    private static final String ATTRIBUTE_CONTEXT = ATTRIBUTES_CONTEXT + "/{uuid}";
+    private static final String CALLBACK_CONTEXT = ATTRIBUTES_CONTEXT + "/callback";
+
+    private static final String UUIDS_QUERY_PARAM = "uuids";
+
+    public AttributesApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        super(webClient, defaultTrustManagers);
+    }
+
+    @Override
+    public AttributeDefinitionsDto listDefinitions(ApiClientConnectorInfo connector, List<UUID> uuids) throws ConnectorException {
+        UriBuilder uriBuilder = UriComponentsBuilder.fromUriString(connector.getUrl()).path(ATTRIBUTES_CONTEXT);
+        if (uuids != null && !uuids.isEmpty()) {
+            // Exploded form: one repeated `uuids` query parameter per UUID (matches the controller's
+            // Explode.TRUE), NOT a single CSV value.
+            for (UUID uuid : uuids) {
+                uriBuilder.queryParam(UUIDS_QUERY_PARAM, uuid);
+            }
+        }
+        URI uri = uriBuilder.build();
+
+        WebClient.RequestBodySpec request = prepareRequest(HttpMethod.GET, connector, true).uri(uri);
+        return processRequest(r -> r
+                        .retrieve()
+                        .bodyToMono(AttributeDefinitionsDto.class)
+                        .block(),
+                request,
+                connector);
+    }
+
+    @Override
+    public BaseAttribute getDefinition(ApiClientConnectorInfo connector, UUID uuid) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
+        return processRequest(r -> r
+                        .uri(connector.getUrl() + ATTRIBUTE_CONTEXT, uuid)
+                        .retrieve()
+                        .bodyToMono(BaseAttribute.class)
+                        .block(),
+                request,
+                connector);
+    }
+
+    @Override
+    public AttributeCallbackResponseDto callback(ApiClientConnectorInfo connector, AttributeCallbackRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+        return processRequest(r -> r
+                        .uri(connector.getUrl() + CALLBACK_CONTEXT)
+                        .body(Mono.just(requestDto), AttributeCallbackRequestDto.class)
+                        .retrieve()
+                        .bodyToMono(AttributeCallbackResponseDto.class)
+                        .block(),
+                request,
+                connector);
+    }
+}

--- a/src/main/java/com/otilm/api/interfaces/client/v2/AttributesSyncApiClient.java
+++ b/src/main/java/com/otilm/api/interfaces/client/v2/AttributesSyncApiClient.java
@@ -1,0 +1,37 @@
+package com.otilm.api.interfaces.client.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Sync interface for the Attributes v2 API client (the common NG provider interface, alongside
+ * {@link InfoSyncApiClient}). Implemented by both the REST and the MQ client.
+ *
+ * <p>Mirrors the three endpoints of
+ * {@code com.otilm.api.interfaces.connector.common.v2.AttributesController}:
+ * <ul>
+ *   <li>{@code GET /v2/attributes} — list the attribute-definition registry (optionally filtered);</li>
+ *   <li>{@code GET /v2/attributes/{uuid}} — fetch a single definition;</li>
+ *   <li>{@code POST /v2/attributes/callback} — resolve dynamic attribute content.</li>
+ * </ul>
+ */
+public interface AttributesSyncApiClient {
+
+    /**
+     * List attribute definitions. When {@code uuids} is {@code null} or empty, the full registry is
+     * returned ({@code GET /v2/attributes}); otherwise only the matching definitions are returned via
+     * the exploded query {@code ?uuids=a&uuids=b} (one repeated parameter per UUID, NOT a CSV value).
+     */
+    AttributeDefinitionsDto listDefinitions(ApiClientConnectorInfo connector, List<UUID> uuids) throws ConnectorException;
+
+    BaseAttribute getDefinition(ApiClientConnectorInfo connector, UUID uuid) throws ConnectorException;
+
+    AttributeCallbackResponseDto callback(ApiClientConnectorInfo connector, AttributeCallbackRequestDto request) throws ConnectorException;
+}

--- a/src/test/java/com/otilm/api/clients/mq/v2/AttributesApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/v2/AttributesApiClientMqTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
  * implementation maps connector errors by raw HTTP status code and never reconstructs a
  * {@code ConnectorProblemException} from the connector's {@code errorCode}, so a connector 404
  * ({@code ATTRIBUTE_DEFINITION_NOT_FOUND}) over MQ loses its error code. That parity fix is tracked as a
- * Core gate (#1622), not #726, so this suite does NOT assert error mapping over MQ. Note too that
+ * Core gate (core #1622/#1621), not #726, so this suite does NOT assert error mapping over MQ. Note too that
  * {@code ProxyClient} has no query-string notion — the exploded {@code uuids} string rides in the path
  * (verified below); whether it survives the bus is a separate Core/MQ gate.</p>
  */
@@ -133,6 +133,46 @@ class AttributesApiClientMqTest {
         Assertions.assertEquals("GET", proxyClient.method);
         Assertions.assertNull(proxyClient.body);
         Assertions.assertEquals(BaseAttribute.class, proxyClient.responseType);
+    }
+
+    @Test
+    void listDefinitionsAsync_withUuids_delegatesExplodedPath() {
+        UUID a = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID b = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        AttributeDefinitionsDto expected = new AttributeDefinitionsDto();
+        proxyClient.asyncResponse = CompletableFuture.completedFuture(expected);
+
+        CompletableFuture<AttributeDefinitionsDto> result =
+                client.listDefinitionsAsync(connector, List.of(a, b));
+
+        Assertions.assertSame(expected, result.join());
+        // The exploded-uuids path build is the only async logic that differs from the sync path.
+        Assertions.assertEquals(ATTRIBUTES_PATH + "?uuids=" + a + "&uuids=" + b, proxyClient.path);
+        Assertions.assertEquals("GET", proxyClient.method);
+        Assertions.assertNull(proxyClient.body);
+        Assertions.assertEquals(AttributeDefinitionsDto.class, proxyClient.responseType);
+    }
+
+    @Test
+    void callbackAsync_delegatesPostWithBody() {
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        request.setConnectorInterface(ConnectorInterface.AUTHORITY);
+        request.setInterfaceVersion("v3");
+        request.setAttributeUuid(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        request.setAttributeName("someAttr");
+        request.setContextAttributes(List.of());
+        request.setCurrentAttributes(List.of());
+
+        AttributeCallbackResponseDto expected = new AttributeCallbackResponseDto();
+        proxyClient.asyncResponse = CompletableFuture.completedFuture(expected);
+
+        CompletableFuture<AttributeCallbackResponseDto> result = client.callbackAsync(connector, request);
+
+        Assertions.assertSame(expected, result.join());
+        Assertions.assertEquals(ATTRIBUTES_PATH + "/callback", proxyClient.path);
+        Assertions.assertEquals("POST", proxyClient.method);
+        Assertions.assertSame(request, proxyClient.body);
+        Assertions.assertEquals(AttributeCallbackResponseDto.class, proxyClient.responseType);
     }
 
     /**

--- a/src/test/java/com/otilm/api/clients/mq/v2/AttributesApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/v2/AttributesApiClientMqTest.java
@@ -1,0 +1,205 @@
+package com.otilm.api.clients.mq.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.mq.ProxyClient;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.model.client.connector.v2.ConnectorInterface;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.v3.InfoAttributeV3;
+import com.otilm.api.model.core.connector.ConnectorDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Delegation tests for the MQ-based Attributes v2 client. Verifies each method calls
+ * {@link ProxyClient#sendRequest} (or its async variant) with the right path / HTTP method / body /
+ * response type and returns the proxy's value.
+ *
+ * <p>No mocking framework (Mockito etc.) is on this project's test classpath — only JUnit Jupiter and
+ * WireMock — so the proxy is a hand-written recording fake.</p>
+ *
+ * <p><b>Out of scope — AC5 / MQ error parity is a Core concern.</b> The {@link ProxyClient}
+ * implementation maps connector errors by raw HTTP status code and never reconstructs a
+ * {@code ConnectorProblemException} from the connector's {@code errorCode}, so a connector 404
+ * ({@code ATTRIBUTE_DEFINITION_NOT_FOUND}) over MQ loses its error code. That parity fix is tracked as a
+ * Core gate (#1622), not #726, so this suite does NOT assert error mapping over MQ. Note too that
+ * {@code ProxyClient} has no query-string notion — the exploded {@code uuids} string rides in the path
+ * (verified below); whether it survives the bus is a separate Core/MQ gate.</p>
+ */
+class AttributesApiClientMqTest {
+
+    private static final String ATTRIBUTES_PATH = "/v2/attributes";
+
+    private RecordingProxyClient proxyClient;
+    private AttributesApiClient client;
+    private ConnectorDto connector;
+
+    @BeforeEach
+    void setUp() {
+        proxyClient = new RecordingProxyClient();
+        client = new AttributesApiClient(proxyClient);
+        connector = new ConnectorDto();
+        connector.setUrl("http://localhost");
+    }
+
+    @Test
+    void listDefinitions_noUuids_delegatesGetFullRegistry() throws ConnectorException {
+        AttributeDefinitionsDto expected = new AttributeDefinitionsDto();
+        proxyClient.syncResponse = expected;
+
+        AttributeDefinitionsDto result = client.listDefinitions(connector, null);
+
+        Assertions.assertSame(expected, result);
+        Assertions.assertSame(connector, proxyClient.connector);
+        Assertions.assertEquals(ATTRIBUTES_PATH, proxyClient.path);
+        Assertions.assertEquals("GET", proxyClient.method);
+        Assertions.assertNull(proxyClient.body);
+        Assertions.assertEquals(AttributeDefinitionsDto.class, proxyClient.responseType);
+    }
+
+    @Test
+    void listDefinitions_withUuids_delegatesExplodedPath() throws ConnectorException {
+        UUID a = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID b = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        AttributeDefinitionsDto expected = new AttributeDefinitionsDto();
+        proxyClient.syncResponse = expected;
+
+        AttributeDefinitionsDto result = client.listDefinitions(connector, List.of(a, b));
+
+        Assertions.assertSame(expected, result);
+        // Exploded form (NOT csv) carried in the path string since the proxy has no query notion.
+        Assertions.assertEquals(ATTRIBUTES_PATH + "?uuids=" + a + "&uuids=" + b, proxyClient.path);
+        Assertions.assertEquals("GET", proxyClient.method);
+        Assertions.assertNull(proxyClient.body);
+    }
+
+    @Test
+    void getDefinition_delegatesGetByUuidPath() throws ConnectorException {
+        UUID uuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        BaseAttribute expected = new InfoAttributeV3();
+        proxyClient.syncResponse = expected;
+
+        BaseAttribute result = client.getDefinition(connector, uuid);
+
+        Assertions.assertSame(expected, result);
+        Assertions.assertEquals(ATTRIBUTES_PATH + "/" + uuid, proxyClient.path);
+        Assertions.assertEquals("GET", proxyClient.method);
+        Assertions.assertNull(proxyClient.body);
+        Assertions.assertEquals(BaseAttribute.class, proxyClient.responseType);
+    }
+
+    @Test
+    void callback_delegatesPostWithBody() throws ConnectorException {
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        request.setConnectorInterface(ConnectorInterface.AUTHORITY);
+        request.setInterfaceVersion("v3");
+        request.setAttributeUuid(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        request.setAttributeName("someAttr");
+        request.setContextAttributes(List.of());
+        request.setCurrentAttributes(List.of());
+
+        AttributeCallbackResponseDto expected = new AttributeCallbackResponseDto();
+        proxyClient.syncResponse = expected;
+
+        AttributeCallbackResponseDto result = client.callback(connector, request);
+
+        Assertions.assertSame(expected, result);
+        Assertions.assertEquals(ATTRIBUTES_PATH + "/callback", proxyClient.path);
+        Assertions.assertEquals("POST", proxyClient.method);
+        Assertions.assertSame(request, proxyClient.body);
+        Assertions.assertEquals(AttributeCallbackResponseDto.class, proxyClient.responseType);
+    }
+
+    @Test
+    void getDefinitionAsync_delegatesToAsyncProxy() {
+        UUID uuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        BaseAttribute expected = new InfoAttributeV3();
+        proxyClient.asyncResponse = CompletableFuture.completedFuture(expected);
+
+        CompletableFuture<BaseAttribute> result = client.getDefinitionAsync(connector, uuid);
+
+        Assertions.assertSame(expected, result.join());
+        Assertions.assertEquals(ATTRIBUTES_PATH + "/" + uuid, proxyClient.path);
+        Assertions.assertEquals("GET", proxyClient.method);
+        Assertions.assertNull(proxyClient.body);
+        Assertions.assertEquals(BaseAttribute.class, proxyClient.responseType);
+    }
+
+    /**
+     * Records the arguments of the single {@code sendRequest}/{@code sendRequestAsync} call under test and
+     * returns the preset response. Only the two overloads exercised by the client are implemented; the
+     * rest throw to surface any unexpected delegation.
+     */
+    private static final class RecordingProxyClient implements ProxyClient {
+        private ApiClientConnectorInfo connector;
+        private String path;
+        private String method;
+        private Object body;
+        private Class<?> responseType;
+
+        private Object syncResponse;
+        private CompletableFuture<?> asyncResponse;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType) {
+            this.connector = connector;
+            this.path = path;
+            this.method = method;
+            this.body = body;
+            this.responseType = responseType;
+            return (T) syncResponse;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType) {
+            this.connector = connector;
+            this.path = path;
+            this.method = method;
+            this.body = body;
+            this.responseType = responseType;
+            return (CompletableFuture<T>) asyncResponse;
+        }
+
+        @Override
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Map<String, String> pathVariables, Object body, Class<T> responseType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Map<String, String> pathVariables, Object body, Class<T> responseType, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendFireAndForget(ApiClientConnectorInfo connector, String path, String method, Object body) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendFireAndForget(ApiClientConnectorInfo connector, String path, String method, Object body, String messageType) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
@@ -1,0 +1,229 @@
+package com.otilm.api.clients.v2;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.clients.BaseApiClient;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.model.client.connector.v2.ConnectorInterface;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
+import com.otilm.api.model.common.attribute.v3.InfoAttributeV3;
+import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.core.connector.ConnectorDto;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+class AttributesApiClientTest {
+
+    private AttributesApiClient client;
+    private ConnectorDto connector;
+    private WireMockServer mockServer;
+
+    @BeforeEach
+    void setUp() {
+        client = new AttributesApiClient(BaseApiClient.prepareWebClient(), null);
+
+        mockServer = new WireMockServer(options().dynamicPort());
+        mockServer.start();
+        WireMock.configureFor("localhost", mockServer.port());
+
+        connector = new ConnectorDto();
+        connector.setUrl("http://localhost:" + mockServer.port());
+        connector.setStatus(ConnectorStatus.CONNECTED);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+    }
+
+    /**
+     * Full-registry list round-trips a NON-EMPTY, mixed attribute-schema v2/v3 definition list, proving
+     * the polymorphic {@code BaseAttribute} (de)serialization survives over the wire and the concrete
+     * subtypes (v2 DATA + v3 INFO) are reconstructed by version/type discriminator.
+     */
+    @Test
+    void listDefinitions_returnsDto() throws ConnectorException {
+        String json = """
+                {
+                  "connectorVersion": "1.2.3",
+                  "definitions": [
+                    {
+                      "uuid": "11111111-1111-1111-1111-111111111111",
+                      "name": "v2DataAttr",
+                      "type": "data",
+                      "contentType": "string",
+                      "version": 2
+                    },
+                    {
+                      "uuid": "22222222-2222-2222-2222-222222222222",
+                      "name": "v3InfoAttr",
+                      "type": "info",
+                      "contentType": "string",
+                      "version": 3
+                    }
+                  ]
+                }
+                """;
+        mockServer.stubFor(WireMock.get("/v2/attributes")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(json)));
+
+        AttributeDefinitionsDto dto = client.listDefinitions(connector, null);
+
+        Assertions.assertEquals("1.2.3", dto.getConnectorVersion());
+        Assertions.assertEquals(2, dto.getDefinitions().size());
+
+        BaseAttribute first = dto.getDefinitions().get(0);
+        BaseAttribute second = dto.getDefinitions().get(1);
+
+        Assertions.assertInstanceOf(DataAttributeV2.class, first);
+        Assertions.assertEquals(2, first.getVersion());
+        Assertions.assertEquals(AttributeType.DATA, first.getType());
+
+        Assertions.assertInstanceOf(InfoAttributeV3.class, second);
+        Assertions.assertEquals(3, second.getVersion());
+        Assertions.assertEquals(AttributeType.INFO, second.getType());
+    }
+
+    /**
+     * With a non-empty uuid list the outgoing request MUST be the exploded form
+     * {@code ?uuids=a&uuids=b} (matching the controller's {@code Explode.TRUE}), NOT a single CSV value.
+     */
+    @Test
+    void listDefinitions_emitsExplodedUuidsQuery() throws ConnectorException {
+        UUID a = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID b = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        mockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/v2/attributes"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"connectorVersion\":\"1.0\",\"definitions\":[]}")));
+
+        client.listDefinitions(connector, List.of(a, b));
+
+        // Each uuid is its own repeated query parameter; a CSV value "a,b" would NOT match these.
+        mockServer.verify(WireMock.getRequestedFor(WireMock.urlPathEqualTo("/v2/attributes"))
+                .withQueryParam("uuids", WireMock.equalTo(a.toString()))
+                .withQueryParam("uuids", WireMock.equalTo(b.toString())));
+
+        // And explicitly reject the CSV form.
+        mockServer.verify(0, WireMock.getRequestedFor(WireMock.urlPathEqualTo("/v2/attributes"))
+                .withQueryParam("uuids", WireMock.equalTo(a + "," + b)));
+    }
+
+    @Test
+    void getDefinition_returnsBaseAttribute() throws ConnectorException {
+        UUID uuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        String json = """
+                {
+                  "uuid": "11111111-1111-1111-1111-111111111111",
+                  "name": "v3InfoAttr",
+                  "type": "info",
+                  "contentType": "string",
+                  "version": 3
+                }
+                """;
+        mockServer.stubFor(WireMock.get("/v2/attributes/" + uuid)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(json)));
+
+        BaseAttribute attr = client.getDefinition(connector, uuid);
+
+        Assertions.assertInstanceOf(InfoAttributeV3.class, attr);
+        Assertions.assertEquals(3, attr.getVersion());
+        Assertions.assertEquals(AttributeType.INFO, attr.getType());
+    }
+
+    /**
+     * A connector 404 carrying an RFC 9457 {@code application/problem+json} body with
+     * {@code errorCode=ATTRIBUTE_DEFINITION_NOT_FOUND} surfaces as {@link ConnectorProblemException}
+     * (via {@code BaseApiClient.handleHttpExceptions}), preserving the error code — the in-repo half of AC5.
+     */
+    @Test
+    void getDefinition_unknownUuid_mapsProblem() {
+        UUID uuid = UUID.fromString("99999999-9999-9999-9999-999999999999");
+        String problemJson = """
+                {
+                  "type": "https://docs.otilm.com/problems/connector/ATTRIBUTE_DEFINITION_NOT_FOUND",
+                  "title": "Attribute definition not found",
+                  "status": 404,
+                  "detail": "No definition for 99999999-9999-9999-9999-999999999999",
+                  "errorCode": "ATTRIBUTE_DEFINITION_NOT_FOUND",
+                  "timestamp": "2026-06-24T10:00:00Z",
+                  "correlationId": "test-corr-404",
+                  "retryable": false
+                }
+                """;
+        mockServer.stubFor(WireMock.get("/v2/attributes/" + uuid)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(problemJson)));
+
+        ConnectorProblemException ex = Assertions.assertThrows(
+                ConnectorProblemException.class,
+                () -> client.getDefinition(connector, uuid));
+
+        Assertions.assertEquals(ErrorCode.ATTRIBUTE_DEFINITION_NOT_FOUND, ex.getProblemDetail().getErrorCode());
+        Assertions.assertEquals(404, ex.getProblemDetail().getStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * POST body round-trips and the response {@code content} arm (attribute schema v3) deserializes.
+     */
+    @Test
+    void callback_contentArm_returnsResponse() throws ConnectorException {
+        String responseJson = """
+                {
+                  "content": [
+                    { "reference": "opt-1", "contentType": "string", "data": "value-1" }
+                  ],
+                  "totalItems": 1
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/attributes/callback")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(responseJson)));
+
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        request.setConnectorInterface(ConnectorInterface.AUTHORITY);
+        request.setInterfaceVersion("v3");
+        request.setAttributeUuid(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        request.setAttributeName("someAttr");
+        request.setContextAttributes(List.of());
+        request.setCurrentAttributes(List.of());
+
+        AttributeCallbackResponseDto response = client.callback(connector, request);
+
+        Assertions.assertNotNull(response.getContent());
+        Assertions.assertEquals(1, response.getContent().size());
+        Assertions.assertEquals(1L, response.getTotalItems());
+        Assertions.assertNull(response.getAttributes());
+
+        mockServer.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/v2/attributes/callback"))
+                .withRequestBody(WireMock.matchingJsonPath("$.attributeName", WireMock.equalTo("someAttr"))));
+    }
+}

--- a/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
@@ -12,6 +12,7 @@ import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.InfoAttributeV3;
 import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.core.connector.ConnectorDto;
@@ -276,5 +277,42 @@ class AttributesApiClientTest {
                 () -> client.callback(connector, request));
 
         Assertions.assertTrue(ex.getMessage().contains("Attributes v2 callback"));
+    }
+
+    /**
+     * Callback GROUP arm: the connector returns runtime-injected GROUP children as the {@code attributes}
+     * arm (polymorphic {@code BaseAttribute} definitions), with the {@code content} arm absent. Exercises
+     * the second response arm's Jackson wiring, which the DATA-arm test does not.
+     */
+    @Test
+    void callback_attributesArm_returnsGroupChildren() throws ConnectorException {
+        String responseJson = """
+                {
+                  "attributes": [
+                    { "type": "data", "version": 3, "name": "childAttr", "contentType": "string", "content": [] }
+                  ]
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/attributes/callback")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(responseJson)));
+
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        request.setConnectorInterface(ConnectorInterface.AUTHORITY);
+        request.setInterfaceVersion("v3");
+        request.setAttributeUuid(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        request.setAttributeName("groupAttr");
+        request.setContextAttributes(List.of());
+        request.setCurrentAttributes(List.of());
+
+        AttributeCallbackResponseDto response = client.callback(connector, request);
+
+        Assertions.assertNull(response.getContent());
+        Assertions.assertNotNull(response.getAttributes());
+        Assertions.assertEquals(1, response.getAttributes().size());
+        Assertions.assertInstanceOf(DataAttributeV3.class, response.getAttributes().get(0));
+        Assertions.assertEquals("childAttr", ((DataAttributeV3) response.getAttributes().get(0)).getName());
     }
 }

--- a/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/v2/AttributesApiClientTest.java
@@ -130,6 +130,20 @@ class AttributesApiClientTest {
     }
 
     @Test
+    void listDefinitions_successWithEmptyBody_failsClearly() {
+        mockServer.stubFor(WireMock.get("/v2/attributes")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)));
+
+        IllegalStateException ex = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> client.listDefinitions(connector, null));
+
+        Assertions.assertTrue(ex.getMessage().contains("Attributes v2 list definitions"));
+    }
+
+    @Test
     void getDefinition_returnsBaseAttribute() throws ConnectorException {
         UUID uuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
         String json = """
@@ -152,6 +166,21 @@ class AttributesApiClientTest {
         Assertions.assertInstanceOf(InfoAttributeV3.class, attr);
         Assertions.assertEquals(3, attr.getVersion());
         Assertions.assertEquals(AttributeType.INFO, attr.getType());
+    }
+
+    @Test
+    void getDefinition_successWithEmptyBody_failsClearly() {
+        UUID uuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockServer.stubFor(WireMock.get("/v2/attributes/" + uuid)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)));
+
+        IllegalStateException ex = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> client.getDefinition(connector, uuid));
+
+        Assertions.assertTrue(ex.getMessage().contains("Attributes v2 get definition"));
     }
 
     /**
@@ -225,5 +254,27 @@ class AttributesApiClientTest {
 
         mockServer.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/v2/attributes/callback"))
                 .withRequestBody(WireMock.matchingJsonPath("$.attributeName", WireMock.equalTo("someAttr"))));
+    }
+
+    @Test
+    void callback_successWithEmptyBody_failsClearly() {
+        mockServer.stubFor(WireMock.post("/v2/attributes/callback")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)));
+
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        request.setConnectorInterface(ConnectorInterface.AUTHORITY);
+        request.setInterfaceVersion("v3");
+        request.setAttributeUuid(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        request.setAttributeName("someAttr");
+        request.setContextAttributes(List.of());
+        request.setCurrentAttributes(List.of());
+
+        IllegalStateException ex = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> client.callback(connector, request));
+
+        Assertions.assertTrue(ex.getMessage().contains("Attributes v2 callback"));
     }
 }


### PR DESCRIPTION
Fixes #726

## What
Add Attributes v2 API client trio. Sync interface + HTTP + MQ. Mirror common-v2 Info/Health/Metrics. Three endpoints:
- `GET /v2/attributes` — list defs, exploded `?uuids=a&uuids=b`
- `GET /v2/attributes/{uuid}` — one def
- `POST /v2/attributes/callback` — callback envelope

## Where
- `interfaces.client.v2.AttributesSyncApiClient` — contract
- `clients.v2.AttributesApiClient` — HTTP (`extends BaseApiClient`; `requireBody` so empty 2xx fails clear, not null-NPE)
- `clients.mq.v2.AttributesApiClient` — MQ (`ProxyClient`), sync + async

## Tests
WireMock HTTP: exploded uuids (CSV rejected), 404 → `ConnectorProblemException` (code asserted), both callback arms (`content` + GROUP `attributes`), empty-body fail-fast. MQ delegation test (hand-rolled recording fake — no Mockito on classpath). 328 tests green.

## Not here (on purpose)
MQ error parity (`ProblemDetailExtended` → `ConnectorProblemException`) = Core job, tracked core #1622/#1621. Exploded uuids over MQ ride in path string — Core/MQ verify-item, flagged not assumed. No shared infra touched.

## Review
Built TDD. Reviewed by fan-out agents — correctness, conventions, per-AC, adversarial — all SHIP. Plus **Copilot deep "ultra-hard, think-twice" review** (two-pass, gpt-5.5 + haiku explore): production confidence good, no blockers; only low-likelihood null-UUID edge cases, left as-is since sibling clients don't guard either (non-null contract). Human reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
