### PR TITLE
Add challenge-password toggle to SCEP profile DTOs

### DIFF
--- a/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
@@ -60,6 +60,27 @@ public class BaseScepProfileRequestDto {
     @Schema(description = "Challenge Password for the SCEP Request")
     private String challengePassword;
 
+    /**
+     * Tri-state toggle governing the write-only {@link #challengePassword}. The form does not prefill the
+     * secret, so a blank value must never be treated as "clear".
+     * <ul>
+     *   <li>{@code null} (field absent) — keep the stored password unchanged; on create this means no password
+     *       unless a value is supplied (legacy / opt-out behavior).</li>
+     *   <li>{@code true} + non-blank {@code challengePassword} — set the new password.</li>
+     *   <li>{@code true} + blank {@code challengePassword} — keep the stored password; rejected when none is stored.</li>
+     *   <li>{@code false} — clear / do not set a challenge password.</li>
+     * </ul>
+     * MUST stay nullable and MUST mean keep-when-null. Do NOT normalize it with {@code Boolean.TRUE.equals(...)}
+     * like {@code enableIntune}: that would turn an absent toggle into {@code false} and silently wipe stored
+     * passwords for clients that do not send the field.
+     */
+    @Schema(
+            description = "Challenge password protection toggle. Omit to keep the stored password unchanged; "
+                    + "true to set/keep; false to remove it.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private Boolean enableChallengePassword;
+
     @Schema(description = "Status of Intune")
     private Boolean enableIntune;
 

--- a/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
@@ -1,10 +1,12 @@
 package com.otilm.api.model.client.scep;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Data;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -57,7 +59,10 @@ public class BaseScepProfileRequestDto {
     )
     private boolean includeCaCertificateChain;
 
-    @Schema(description = "Challenge Password for the SCEP Request")
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Schema(description = "Challenge Password for the SCEP Request (write-only).",
+            accessMode = Schema.AccessMode.WRITE_ONLY)
     private String challengePassword;
 
     /**
@@ -76,7 +81,7 @@ public class BaseScepProfileRequestDto {
      */
     @Schema(
             description = "Challenge password protection toggle. Omit to keep the stored password unchanged; "
-                    + "true to set/keep; false to remove it.",
+                    + "true to set a new password (or keep the existing one if left blank); false to remove it.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private Boolean enableChallengePassword;
@@ -90,7 +95,10 @@ public class BaseScepProfileRequestDto {
     @Schema(description = "Intune Application ID")
     private String intuneApplicationId;
 
-    @Schema(description = "Intune Application Key")
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Schema(description = "Intune Application Key (write-only).",
+            accessMode = Schema.AccessMode.WRITE_ONLY)
     private String intuneApplicationKey;
 
     @Valid

--- a/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
@@ -27,4 +27,9 @@ public class ScepProfileDto extends NameAndUuidDto {
 
     @Schema(description = "Status of Intune")
     private boolean enableIntune;
+
+    @Schema(description = "Whether a challenge password is currently set for the SCEP Profile. The password value "
+            + "itself is write-only and never returned; this flag lets clients reflect the current state.",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean enableChallengePassword;
 }


### PR DESCRIPTION
## Why

Supports the Core fix in OmniTrustILM/core#1662 (issue OmniTrustILM/core#1663, part of OmniTrustILM/ilm#238). The SCEP edit form does not prefill secrets, so the challenge password needs an explicit keep/set/clear signal on the wire, plus a way for clients to know whether a password is currently set.

## Changes

**`BaseScepProfileRequestDto`** — new `Boolean enableChallengePassword` (request toggle):

| toggle | behavior |
|---|---|
| `null` (absent) | keep stored (legacy/opt-out; no wipe) |
| `true` + value | set |
| `true` + blank | keep stored, or 400 if none stored |
| `false` | clear |

Nullable on purpose: an absent toggle must mean **keep**, so existing clients that don't send it never wipe a password. Javadoc explicitly warns against normalizing it with `Boolean.TRUE.equals(...)` the way `enableIntune` is handled. Placed on the base DTO (shared by create + edit) to keep the FE's single profile form uniform and mirror `enableIntune`'s placement.

**`ScepProfileDto`** — new `boolean enableChallengePassword` (response presence flag). The password value itself stays write-only and is never returned; this flag lets the FE initialize the "challenge password" switch, exactly as `enableIntune` already does.

## Coordination

Core PR OmniTrustILM/core#1662 consumes these fields. This snapshot (`2.18.1-SNAPSHOT`) must publish before core's CI gate goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)