### PR TITLE
Fix credential attribute 422 from broken content-validation branch

### DIFF
--- a/src/main/java/com/otilm/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/otilm/core/util/AttributeDefinitionUtils.java
@@ -23,7 +23,6 @@ import com.otilm.api.model.common.attribute.v2.content.*;
 import com.otilm.api.model.common.attribute.common.content.data.CredentialAttributeContentData;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.*;
-import com.otilm.api.model.core.credential.CredentialDto;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -576,8 +575,9 @@ public class AttributeDefinitionUtils {
         }
 
         if (targetClass == CredentialAttributeContentV2.class) {
-            CredentialDto credentialDto = ATTRIBUTES_OBJECT_MAPPER.convertValue(content.getData(), CredentialDto.class);
-            if (credentialDto == null) {
+            CredentialAttributeContentData credentialData =
+                    ATTRIBUTES_OBJECT_MAPPER.convertValue(content.getData(), CredentialAttributeContentData.class);
+            if (credentialData == null) {
                 errors.add(wrongValueError);
             }
         }

--- a/src/main/java/com/otilm/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/otilm/core/util/AttributeDefinitionUtils.java
@@ -574,14 +574,6 @@ public class AttributeDefinitionUtils {
             return;
         }
 
-        if (targetClass == CredentialAttributeContentV2.class) {
-            CredentialAttributeContentData credentialData =
-                    ATTRIBUTES_OBJECT_MAPPER.convertValue(content.getData(), CredentialAttributeContentData.class);
-            if (credentialData == null) {
-                errors.add(wrongValueError);
-            }
-        }
-
         if (targetClass == FileAttributeContentV2.class || targetClass == FileAttributeContentV3.class) {
             try {
                 Base64.getDecoder().decode(((FileAttributeContentData) (content.getData())).getContent());

--- a/src/test/java/com/otilm/util/AttributeDefinitionUtilsTest.java
+++ b/src/test/java/com/otilm/util/AttributeDefinitionUtilsTest.java
@@ -699,6 +699,44 @@ class AttributeDefinitionUtilsTest {
     }
 
     @Test
+    void testValidateAttributes_credentialWithNestedProviderAttributes() {
+        // Mirrors what core injects before forwarding to a connector: the credential content
+        // carries the full credential, including its provider attributes as nested DataAttributeV2.
+        String attributeName = "credential";
+
+        DataAttributeV2 definition = new DataAttributeV2();
+        definition.setName(attributeName);
+        definition.setType(AttributeType.DATA);
+        definition.setContentType(AttributeContentType.CREDENTIAL);
+
+        DataAttributeV2 keyStoreType = new DataAttributeV2();
+        keyStoreType.setName("keyStoreType");
+        keyStoreType.setType(AttributeType.DATA);
+        keyStoreType.setContentType(AttributeContentType.STRING);
+        keyStoreType.setContent(List.of(new StringAttributeContentV2("PKCS12")));
+
+        DataAttributeV2 keyStorePassword = new DataAttributeV2();
+        keyStorePassword.setName("keyStorePassword");
+        keyStorePassword.setType(AttributeType.DATA);
+        keyStorePassword.setContentType(AttributeContentType.SECRET);
+        SecretAttributeContentData secret = new SecretAttributeContentData();
+        secret.setSecret("s3cr3t");
+        keyStorePassword.setContent(List.of(new SecretAttributeContentV2("pwd", secret)));
+
+        CredentialAttributeContentData credential = new CredentialAttributeContentData();
+        credential.setUuid("3ca21efc-75cc-42f0-b250-47fc722ec3f7");
+        credential.setName("ewgwefe");
+        credential.setKind("SoftKeyStore");
+        credential.setAttributes(List.of(keyStoreType, keyStorePassword));
+
+        RequestAttributeV2 attribute = new RequestAttributeV2();
+        attribute.setName(attributeName);
+        attribute.setContent(List.of(new CredentialAttributeContentV2("ewgwefe", credential)));
+
+        validateAttributes(List.of(definition), List.of(attribute));
+    }
+
+    @Test
     void testValidateAttributes_credentialFail() {
         String attributeName = "testAttribute1";
 


### PR DESCRIPTION
## Problem

Creating an authority (or any attribute set) with a v2 `CREDENTIAL` attribute fails with HTTP 422:

```
Attributes validation failed.
Attribute Credential of type DATA has wrong value.
```

once the credential is resolved with its provider attributes. Surfaced creating an EJBCA NG authority backed by a SoftKeyStore credential (`core#1664`).

## Root cause

`AttributeDefinitionUtils.validateAttributeContentByContentType` had a credential-specific branch that converted `content.getData()` to `CredentialDto` purely as a null-check:

```java
CredentialDto credentialDto = ATTRIBUTES_OBJECT_MAPPER.convertValue(content.getData(), CredentialDto.class);
```

But `CredentialDto.attributes` is `List<ResponseAttribute>` — a Jackson polymorphic type whose discriminator is `version` with names `v2`/`v3`. The credential content data carries `List<DataAttributeV2>`, and `DataAttributeV2` serializes `version` as the **int `2`**. The conversion throws:

```
InvalidTypeIdException: Could not resolve type id '2' as a subtype of ResponseAttribute:
known type ids = [v2, v3] (for POJO property 'attributes')
```

The exception is swallowed by the surrounding `catch` and rewritten to the generic *"Attribute … has wrong value"*, returned as 422. The thin reference form (`{uuid, name}`, no nested attributes) validates fine, which is why it only appears once core enriches the credential with its provider attributes before forwarding to the connector.

## Fix

Remove the credential-specific branch. It never performed meaningful validation: `content.getData()` is already confirmed non-null just above, and `convertValue` never returns null for non-null input — so the `== null` guard was dead and the branch only ever *threw* on enriched content. Credential content well-formedness is still covered by the shared non-null guard. The now-unused `CredentialDto` import is dropped.

## Impact

- Affects only the v2 `CREDENTIAL` validation path; v1 credential attributes never reach it.
- Among `com.otilm` connectors, only `ejbca-ng-connector` defines a v2 `CREDENTIAL` attribute. `ejbca-legacy-ca-connector` is on the separate `com.czertainly:interfaces` and is unaffected.

## Tests

Added `testValidateAttributes_credentialWithNestedProviderAttributes`, which mirrors the enriched content core forwards (credential data with nested `DataAttributeV2` provider attributes, including a SECRET). Fails before the change, passes after. Full module suite green.

Fixes OmniTrustILM/core#1664
