### PR TITLE
Trigger OpenAPI docs regeneration after publish, not during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,22 +59,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B verify -f pom.xml
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: interfaces-docs-app-token
-        with:
-          app-id: ${{ vars.INTERFACES_DOCS_APP_ID }}
-          private-key: ${{ secrets.INTERFACES_DOCS_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            interface-documentation
-      - name: Trigger build OpenAPI
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.interfaces-docs-app-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: 'interface-documentation',
-              workflow_id: 'publish.yml',
-              ref: 'main',
-            })

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -87,3 +87,26 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Trigger docs regeneration only after the snapshot/release artifact is published above,
+      # so the docs build never resolves a stale interfaces version (the publish runs in a
+      # separate workflow and previously raced the build-workflow dispatch).
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: interfaces-docs-app-token
+        with:
+          app-id: ${{ vars.INTERFACES_DOCS_APP_ID }}
+          private-key: ${{ secrets.INTERFACES_DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            interface-documentation
+      - name: Trigger build OpenAPI
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.interfaces-docs-app-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'interface-documentation',
+              workflow_id: 'publish.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           github-token: ${{ steps.interfaces-docs-app-token.outputs.token }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
+            await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: 'interface-documentation',
               workflow_id: 'publish.yml',

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -91,6 +91,8 @@ jobs:
       # Trigger docs regeneration only after the snapshot/release artifact is published above,
       # so the docs build never resolves a stale interfaces version (the publish runs in a
       # separate workflow and previously raced the build-workflow dispatch).
+      # Tag (release) pushes also reach this step and intentionally refresh the `main` docs set
+      # (the dispatch targets ref: 'main'); per-tag versioned docs are not produced.
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: interfaces-docs-app-token
         with:


### PR DESCRIPTION
## Problem

OpenAPI docs regeneration was dispatched from the **build** workflow (`build.yml` → `build` job), which runs in parallel with the separate **publish-package** workflow on a push to `main`. The build job finishes `mvn verify` quickly and dispatches the docs workflow **before** the snapshot is actually deployed by publish-package.

Observed on the #743 merge:

| time | event |
|---|---|
| 09:58:26 | #743 merged to main |
| 09:58:29 | `publish-package` (snapshot deploy) starts |
| 09:59:11 | build job dispatches **Generate OpenAPI Docs** |
| **09:59:36** | docs build downloads `interfaces-2.18.1-20260625.033820-22.jar` — the **prior** snapshot |
| 10:00:55 | `publish-package` finishes (new snapshot, build #23) |

The docs build resolved the previous snapshot (`--update-snapshots` correctly fetched the latest *available*, which was still the old build), generated unchanged docs, and committed nothing. Result: merged DTO changes not reflected on the docs site.

## Fix

Move the `create-github-app-token` + `createWorkflowDispatch` steps **out of `build.yml`** and to the **end of the `publish-package.yml` publish job**, after the GitHub Packages deploy. Docs are now dispatched only once the new artifact is live, eliminating the race.

Side effect (intended): `publish-package` also runs on **tags**, so release publishes now regenerate docs too — the build workflow never triggered on tags. Consistent with the build workflow's existing non-differentiating behavior.

Reuses the existing `INTERFACES_DOCS_APP_ID` / `INTERFACES_DOCS_APP_PRIVATE_KEY` GitHub App credentials — no new secret.

## Note

The docs workflow's `--update-snapshots` flag stays as-is; it is the safeguard against a cached `~/.m2` serving a stale snapshot. The bug was ordering, not caching.