### PR TITLE
Rename Signature Formatter -> Signature Formatting Provider

### DIFF
--- a/src/main/java/com/otilm/api/clients/mq/signing/SignatureFormattingApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/signing/SignatureFormattingApiClient.java
@@ -2,18 +2,18 @@ package com.otilm.api.clients.mq.signing;
 
 import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.exception.ConnectorException;
-import com.otilm.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
+import com.otilm.api.interfaces.client.v1.signing.SignatureFormattingSyncApiClient;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatResponseRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
 import com.otilm.api.clients.mq.ProxyClient;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class SignatureFormatterApiClient implements SignatureFormatterSyncApiClient {
+public class SignatureFormattingApiClient implements SignatureFormattingSyncApiClient {
 
     private static final String BASE_PATH = "/v1/signatureProvider/formatting";
     private static final String HTTP_METHOD_GET = "GET";
@@ -21,12 +21,12 @@ public class SignatureFormatterApiClient implements SignatureFormatterSyncApiCli
 
     private final ProxyClient proxyClient;
 
-    public SignatureFormatterApiClient(ProxyClient proxyClient) {
+    public SignatureFormattingApiClient(ProxyClient proxyClient) {
         this.proxyClient = proxyClient;
     }
 
     @Override
-    public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+    public List<BaseAttribute> listFormattingAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
         String path = BASE_PATH + "/attributes";
         BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null, BaseAttribute[].class);
         return result == null ? List.of() : Arrays.asList(result);

--- a/src/main/java/com/otilm/api/clients/signing/SignatureFormattingApiClient.java
+++ b/src/main/java/com/otilm/api/clients/signing/SignatureFormattingApiClient.java
@@ -3,12 +3,12 @@ package com.otilm.api.clients.signing;
 import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.clients.BaseApiClient;
 import com.otilm.api.exception.ConnectorException;
-import com.otilm.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
+import com.otilm.api.interfaces.client.v1.signing.SignatureFormattingSyncApiClient;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatResponseRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -16,19 +16,19 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.TrustManager;
 import java.util.List;
 
-public class SignatureFormatterApiClient extends BaseApiClient implements SignatureFormatterSyncApiClient {
+public class SignatureFormattingApiClient extends BaseApiClient implements SignatureFormattingSyncApiClient {
 
     private static final String ATTRIBUTES_CONTEXT = "/v1/signatureProvider/formatting/attributes";
     private static final String DTBS_CONTEXT = "/v1/signatureProvider/formatting/formatDtbs";
     private static final String RESPONSE_CONTEXT = "/v1/signatureProvider/formatting/formatResponse";
 
-    public SignatureFormatterApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
+    public SignatureFormattingApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         this.webClient = webClient;
         this.defaultTrustManagers = defaultTrustManagers;
     }
 
     @Override
-    public List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+    public List<BaseAttribute> listFormattingAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
         WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> {

--- a/src/main/java/com/otilm/api/interfaces/client/v1/signing/SignatureFormattingSyncApiClient.java
+++ b/src/main/java/com/otilm/api/interfaces/client/v1/signing/SignatureFormattingSyncApiClient.java
@@ -3,16 +3,16 @@ package com.otilm.api.interfaces.client.v1.signing;
 import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatResponseRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
 
 import java.util.List;
 
-public interface SignatureFormatterSyncApiClient {
+public interface SignatureFormattingSyncApiClient {
 
-    List<BaseAttribute> listFormatterAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
+    List<BaseAttribute> listFormattingAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
 
     FormatDtbsResponseDto formatDtbs(ApiClientConnectorInfo connector, FormatDtbsRequestDto requestDto) throws ConnectorException;
 

--- a/src/main/java/com/otilm/api/interfaces/connector/signing/SignatureFormattingController.java
+++ b/src/main/java/com/otilm/api/interfaces/connector/signing/SignatureFormattingController.java
@@ -3,10 +3,10 @@ package com.otilm.api.interfaces.connector.signing;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.interfaces.connector.common.v2.AuthProtectedConnectorController;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.FormatResponseRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -22,16 +22,16 @@ import java.util.List;
 
 @RequestMapping("/v1/signatureProvider/formatting")
 @Tag(
-        name = "Signature Formatter",
-        description = "Signature Formatter API defines operations for protocol-specific formatting of digital signing requests. " +
-                "The formatter is stateless and handles the conversion between raw signing material and " +
+        name = "Signature Formatting Provider",
+        description = "Signature Formatting Provider API defines operations for protocol-specific formatting of digital signing requests. " +
+                "The provider is stateless and handles the conversion between raw signing material and " +
                 "protocol-specific formats (e.g. TSA TimeStampToken, AdES signature containers)."
 )
-public interface SignatureFormatterController extends AuthProtectedConnectorController {
+public interface SignatureFormattingController extends AuthProtectedConnectorController {
 
     @Operation(
-            summary = "List Formatter Attributes",
-            operationId = "listFormatterAttributes"
+            summary = "List Formatting Attributes",
+            operationId = "listFormattingAttributes"
     )
     @ApiResponses(
             value = {
@@ -45,7 +45,7 @@ public interface SignatureFormatterController extends AuthProtectedConnectorCont
             path = "/attributes",
             produces = {"application/json"}
     )
-    List<BaseAttribute> listFormatterAttributes();
+    List<BaseAttribute> listFormattingAttributes();
 
     @Operation(
             summary = "Compute data-to-be-signed bytes",

--- a/src/main/java/com/otilm/api/interfaces/core/web/SigningProfileController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/SigningProfileController.java
@@ -164,18 +164,18 @@ public interface SigningProfileController extends AuthProtectedController {
             @Parameter(description = "Certificate UUID") @PathVariable UUID certificateUuid) throws NotFoundException;
 
     @Operation(
-            operationId = "listSignatureFormatterConnectorAttributes",
-            summary = "Get formatter attribute descriptors from a Signature Formatter Connector",
-            description = "Queries the Signature Formatter Connector for its available formatter attribute descriptors with connector default values. " +
+            operationId = "listSignatureFormattingConnectorAttributes",
+            summary = "Get formatting attribute descriptors from a Signature Formatting Provider",
+            description = "Queries the Signature Formatting Provider for its available formatting attribute descriptors with connector default values. " +
                     "The signingProfileUuid parameter is used for authorization only and does not affect the returned descriptors."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Formatter attribute descriptors retrieved"),
+            @ApiResponse(responseCode = "200", description = "Formatting attribute descriptors retrieved"),
             @ApiResponse(responseCode = "404", description = "Connector or Signing Profile not found", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))
     })
-    @GetMapping(path = "/signatureFormatterConnectors/{connectorUuid}/formatterAttributes", produces = MediaType.APPLICATION_JSON_VALUE)
-    List<BaseAttribute> listSignatureFormatterConnectorAttributes(
-            @Parameter(description = "Signature Formatter Connector UUID") @PathVariable UUID connectorUuid,
+    @GetMapping(path = "/signatureFormattingConnectors/{connectorUuid}/formattingAttributes", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<BaseAttribute> listSignatureFormattingConnectorAttributes(
+            @Parameter(description = "Signature Formatting Provider UUID") @PathVariable UUID connectorUuid,
             @Parameter(description = "Signing Profile UUID — used for authorization purposes only", in = ParameterIn.QUERY) @RequestParam(required = false) UUID signingProfileUuid) throws AttributeException, ConnectorException, NotFoundException;
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/src/main/java/com/otilm/api/model/client/signing/profile/SigningProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/SigningProfileRequestDto.java
@@ -4,7 +4,7 @@ import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.signing.profile.record.SigningRecordPolicyRequestDto;
 import com.otilm.api.model.client.signing.profile.record.validation.ValidSigningRecordPolicy;
 import com.otilm.api.model.client.signing.profile.scheme.SigningSchemeRequestDto;
-import com.otilm.api.model.client.signing.profile.validation.ValidManagedSigningFormatterConnector;
+import com.otilm.api.model.client.signing.profile.validation.ValidManagedSignatureFormattingConnector;
 import com.otilm.api.model.client.signing.profile.workflow.WorkflowRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.otilm.api.model.common.validation.ValidName;
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Data
 @Schema(name = "SigningProfileRequestDto", description = "Request to create or update a Signing Profile")
-@ValidManagedSigningFormatterConnector
+@ValidManagedSignatureFormattingConnector
 @ValidSigningRecordPolicy
 public class SigningProfileRequestDto {
     @NotBlank

--- a/src/main/java/com/otilm/api/model/client/signing/profile/validation/ManagedSignatureFormattingConnectorValidator.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/validation/ManagedSignatureFormattingConnectorValidator.java
@@ -9,7 +9,7 @@ import jakarta.validation.ConstraintValidatorContext;
 
 import java.util.UUID;
 
-public class ManagedSigningFormatterConnectorValidator implements ConstraintValidator<ValidManagedSigningFormatterConnector, SigningProfileRequestDto> {
+public class ManagedSignatureFormattingConnectorValidator implements ConstraintValidator<ValidManagedSignatureFormattingConnector, SigningProfileRequestDto> {
 
     @Override
     public boolean isValid(SigningProfileRequestDto dto, ConstraintValidatorContext context) {
@@ -22,10 +22,10 @@ public class ManagedSigningFormatterConnectorValidator implements ConstraintVali
 
         boolean valid = true;
 
-        UUID formatterConnectorUuid = null;
+        UUID formattingConnectorUuid = null;
 
         if (dto.getWorkflow() instanceof TimestampingWorkflowRequestDto tsw) {
-            formatterConnectorUuid = tsw.getSignatureFormatterConnectorUuid();
+            formattingConnectorUuid = tsw.getSignatureFormattingConnectorUuid();
             if (Boolean.TRUE.equals(tsw.getQualifiedTimestamp()) && tsw.getTimeQualityConfigurationUuid() == null) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate("timeQualityConfigurationUuid must be provided when qualifiedTimestamp is true")
@@ -34,15 +34,15 @@ public class ManagedSigningFormatterConnectorValidator implements ConstraintVali
                 valid = false;
             }
         } else if (dto.getWorkflow() instanceof ContentSigningWorkflowRequestDto csw) {
-            formatterConnectorUuid = csw.getSignatureFormatterConnectorUuid();
+            formattingConnectorUuid = csw.getSignatureFormattingConnectorUuid();
         } else {
             return true;
         }
 
-        if (formatterConnectorUuid == null) {
+        if (formattingConnectorUuid == null) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
-                    .addPropertyNode("workflow").addPropertyNode("signatureFormatterConnectorUuid")
+                    .addPropertyNode("workflow").addPropertyNode("signatureFormattingConnectorUuid")
                     .addConstraintViolation();
             valid = false;
         }

--- a/src/main/java/com/otilm/api/model/client/signing/profile/validation/ValidManagedSignatureFormattingConnector.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/validation/ValidManagedSignatureFormattingConnector.java
@@ -10,15 +10,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Class-level constraint that ensures {@code workflow.signatureFormatterConnectorUuid} is non-null
+ * Class-level constraint that ensures {@code workflow.signatureFormattingConnectorUuid} is non-null
  * whenever the signing profile uses ILM-managed signing with a Timestamping or Content Signing workflow.
  */
-@Constraint(validatedBy = ManagedSigningFormatterConnectorValidator.class)
+@Constraint(validatedBy = ManagedSignatureFormattingConnectorValidator.class)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ValidManagedSigningFormatterConnector {
-    String message() default "signatureFormatterConnectorUuid must be provided when using ILM-managed signing with a Timestamping or Content Signing workflow";
+public @interface ValidManagedSignatureFormattingConnector {
+    String message() default "signatureFormattingConnectorUuid must be provided when using ILM-managed signing with a Timestamping or Content Signing workflow";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/ContentSigningWorkflowDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/ContentSigningWorkflowDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Content signing workflow configuration embedded in a {@code SigningProfileDto}.
  *
- * <p>Contains Signature Formatter Connector properties used by ILM-managed signing to construct the data-to-be-signed (DTBS) for content signing operations.
+ * <p>Contains Signature Formatting Provider properties used by ILM-managed signing to construct the data-to-be-signed (DTBS) for content signing operations.
  * Both fields are null when delegated signing is used.</p>
  */
 @Data
@@ -23,17 +23,17 @@ import java.util.List;
 public class ContentSigningWorkflowDto extends WorkflowDto {
 
     @Schema(
-            description = "Signature Formatter Connector that constructs the data-to-be-signed (DTBS) for Content signing. " +
+            description = "Signature Formatting Provider that constructs the data-to-be-signed (DTBS) for Content signing. " +
                           "Present only when ILM-managed signing is used; null for delegated signing.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private NameAndUuidDto signatureFormatterConnector;
+    private NameAndUuidDto signatureFormattingConnector;
 
     @Schema(
-            description = "Attributes configured on the Signature Formatter Connector that control DTBS construction " +
+            description = "Attributes configured on the Signature Formatting Provider that control DTBS construction " +
                           "for the content signing workflow. " +
                           "Applicable only when ILM-managed signing is used.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<ResponseAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private List<ResponseAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
 
     public ContentSigningWorkflowDto() {
         super(SigningWorkflowType.CONTENT_SIGNING);

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/ContentSigningWorkflowRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/ContentSigningWorkflowRequestDto.java
@@ -22,17 +22,17 @@ import java.util.UUID;
 public class ContentSigningWorkflowRequestDto extends WorkflowRequestDto {
 
     @Schema(
-            description = "UUID of the Signature Formatter Connector that constructs the data-to-be-signed (DTBS) for Content signing. " +
+            description = "UUID of the Signature Formatting Provider that constructs the data-to-be-signed (DTBS) for Content signing. " +
                           "Required for ILM-managed signing; must be omitted for delegated signing.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private UUID signatureFormatterConnectorUuid;
+    private UUID signatureFormattingConnectorUuid;
 
     @Schema(
-            description = "Attributes for the Signature Formatter Connector that control DTBS construction " +
+            description = "Attributes for the Signature Formatting Provider that control DTBS construction " +
                           "for the content signing workflow. " +
                           "Applicable only when ILM-managed signing is used.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<RequestAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private List<RequestAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
 
     public ContentSigningWorkflowRequestDto() {
         super(SigningWorkflowType.CONTENT_SIGNING);

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/RawSigningWorkflowDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/RawSigningWorkflowDto.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Raw signing workflow configuration embedded in a {@code SigningProfileDto}.
  *
- * <p>Raw signing requires no Signature Formatter Connector and currently has no workflow-specific validation properties.</p>
+ * <p>Raw signing requires no Signature Formatting Provider and currently has no workflow-specific validation properties.</p>
  */
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/RawSigningWorkflowRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/RawSigningWorkflowRequestDto.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Raw signing workflow configuration request embedded in a Signing Profile create/update request.
  *
- * <p>Raw signing requires no Signature Formatter Connector and currently has no workflow-specific validation properties.</p>
+ * <p>Raw signing requires no Signature Formatting Provider and currently has no workflow-specific validation properties.</p>
  */
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/TimestampingWorkflowDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/TimestampingWorkflowDto.java
@@ -32,17 +32,17 @@ public class TimestampingWorkflowDto extends WorkflowDto {
     // --------------------------------------------------------------------------------
 
     @Schema(
-            description = "Signature Formatter Connector that constructs the data-to-be-signed (DTBS) for Timestamping. " +
+            description = "Signature Formatting Provider that constructs the data-to-be-signed (DTBS) for Timestamping. " +
                     "Present only when ILM-managed signing is used; null for delegated signing.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private NameAndUuidDto signatureFormatterConnector;
+    private NameAndUuidDto signatureFormattingConnector;
 
     @Schema(
-            description = "Attributes configured on the Signature Formatter Connector that control DTBS construction " +
+            description = "Attributes configured on the Signature Formatting Provider that control DTBS construction " +
                     "(e.g. serial number generation strategy, whether to include signing time attribute). " +
                     "Applicable only when ILM-managed signing is used.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<ResponseAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private List<ResponseAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
 
     @Schema(
             description = "ETSI qualified electronic timestamp. " +

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/TimestampingWorkflowRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/TimestampingWorkflowRequestDto.java
@@ -35,17 +35,17 @@ public class TimestampingWorkflowRequestDto extends WorkflowRequestDto {
     // --------------------------------------------------------------------------------
 
     @Schema(
-            description = "UUID of the Signature Formatter Connector that constructs the data-to-be-signed (DTBS) for Timestamping. " +
+            description = "UUID of the Signature Formatting Provider that constructs the data-to-be-signed (DTBS) for Timestamping. " +
                     "Required for ILM-managed signing; must be omitted for delegated signing.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private UUID signatureFormatterConnectorUuid;
+    private UUID signatureFormattingConnectorUuid;
 
     @Schema(
-            description = "Attributes for the Signature Formatter Connector that control DTBS construction " +
+            description = "Attributes for the Signature Formatting Provider that control DTBS construction " +
                     "(e.g. serial number generation strategy, whether to include signing time attribute). " +
                     "Applicable only when ILM-managed signing is used.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<RequestAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private List<RequestAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
 
     @Schema(
             description = "ETSI qualified electronic timestamp. " +

--- a/src/main/java/com/otilm/api/model/client/signing/profile/workflow/WorkflowDto.java
+++ b/src/main/java/com/otilm/api/model/client/signing/profile/workflow/WorkflowDto.java
@@ -13,7 +13,7 @@ import lombok.Data;
  * <p>Workflow configuration is split into two logical categories (expressed as flat fields
  * on each concrete subtype):</p>
  * <ul>
- *   <li><b>Signature Formatter Connector properties</b> — the connector UUID and its
+ *   <li><b>Signature Formatting Provider properties</b> — the connector UUID and its
  *       dynamically fetched attributes that control construction of the data-to-be-signed (DTBS).
  *       Present only for ILM-managed signing; absent (null) for delegated signing and for
  *       {@code RAW_SIGNING} (which requires no DTBS formatting).</li>

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/ContentSigningFormatDtbsRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/ContentSigningFormatDtbsRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/ContentSigningFormatResponseRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/ContentSigningFormatResponseRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/ExtensionDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/ExtensionDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.validation.ValidOid;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsInterface.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsInterface.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
@@ -11,7 +11,7 @@ import java.io.Serializable;
  *
  * <p>The concrete subtype is determined by the {@code type} discriminator
  * ({@link SigningWorkflowType}). {@code RAW_SIGNING} is excluded — raw signing
- * does not invoke a Signature Formatter Connector.</p>
+ * does not invoke a Signature Formatting Provider.</p>
  */
 @Schema(
         name = "FormatDtbsInterface",

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -43,7 +43,7 @@ public abstract class FormatDtbsRequestDto implements FormatDtbsInterface {
 
     @NotNull
     @Schema(
-            description = "Formatter-specific parameters (e.g. message imprint hash and algorithm, nonce, policy OID for TSA)",
+            description = "Formatting-specific parameters (e.g. message imprint hash and algorithm, nonce, policy OID for TSA)",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttribute> formatAttributes;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsResponseDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatDtbsResponseDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatResponseInterface.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatResponseInterface.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
@@ -11,7 +11,7 @@ import java.io.Serializable;
  *
  * <p>The concrete subtype is determined by the {@code type} discriminator
  * ({@link SigningWorkflowType}). {@code RAW_SIGNING} is excluded — raw signing
- * does not invoke a Signature Formatter Connector.</p>
+ * does not invoke a Signature Formatting Provider.</p>
  */
 @Schema(
         name = "FormatResponseInterface",

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatResponseRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormatResponseRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -50,7 +50,7 @@ public abstract class FormatResponseRequestDto implements FormatResponseInterfac
 
     @NotNull
     @Schema(
-            description = "Formatter-specific parameters, same attributes as passed to formatDtbs",
+            description = "Formatting-specific parameters, same attributes as passed to formatDtbs",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttribute> formatAttributes;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormattedResponseDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/FormattedResponseDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/TimestampingFormatDtbsRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/TimestampingFormatDtbsRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;

--- a/src/main/java/com/otilm/api/model/connector/signatures/formatting/TimestampingFormatResponseRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/signatures/formatting/TimestampingFormatResponseRequestDto.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;

--- a/src/test/java/com/otilm/api/model/client/signing/PolymorphicSerializationTest.java
+++ b/src/test/java/com/otilm/api/model/client/signing/PolymorphicSerializationTest.java
@@ -142,16 +142,16 @@ class PolymorphicSerializationTest {
     }
 
     @Test
-    void timestampingWorkflowConfigRequestDto_withFormatterConnector_roundTrip() throws Exception {
+    void timestampingWorkflowConfigRequestDto_withFormattingConnector_roundTrip() throws Exception {
         TimestampingWorkflowRequestDto original = new TimestampingWorkflowRequestDto();
-        original.setSignatureFormatterConnectorUuid(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        original.setSignatureFormattingConnectorUuid(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
 
         String json = mapper.writeValueAsString(original);
         WorkflowRequestDto deserialized = mapper.readValue(json, WorkflowRequestDto.class);
 
         assertInstanceOf(TimestampingWorkflowRequestDto.class, deserialized);
         TimestampingWorkflowRequestDto result = (TimestampingWorkflowRequestDto) deserialized;
-        assertEquals(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), result.getSignatureFormatterConnectorUuid());
+        assertEquals(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), result.getSignatureFormattingConnectorUuid());
     }
 
     // -------------------------------------------------------------------------
@@ -184,7 +184,7 @@ class PolymorphicSerializationTest {
     @Test
     void contentSigningWorkflowConfigRequestDto_serializesDiscriminator() throws Exception {
         ContentSigningWorkflowRequestDto dto = new ContentSigningWorkflowRequestDto();
-        dto.setSignatureFormatterConnectorUuid(UUID.fromString("11111111-2222-3333-4444-555555555555"));
+        dto.setSignatureFormattingConnectorUuid(UUID.fromString("11111111-2222-3333-4444-555555555555"));
 
         JsonNode json = mapper.valueToTree(dto);
 
@@ -194,7 +194,7 @@ class PolymorphicSerializationTest {
     @Test
     void contentSigningWorkflowConfigRequestDto_roundTrip() throws Exception {
         ContentSigningWorkflowRequestDto original = new ContentSigningWorkflowRequestDto();
-        original.setSignatureFormatterConnectorUuid(UUID.fromString("11111111-2222-3333-4444-555555555555"));
+        original.setSignatureFormattingConnectorUuid(UUID.fromString("11111111-2222-3333-4444-555555555555"));
 
         String json = mapper.writeValueAsString(original);
         WorkflowRequestDto deserialized = mapper.readValue(json, WorkflowRequestDto.class);
@@ -208,7 +208,7 @@ class PolymorphicSerializationTest {
         String json = """
                 {
                   "type": "content_signing",
-                  "signatureFormatterConnectorUuid": "11111111-2222-3333-4444-555555555555"
+                  "signatureFormattingConnectorUuid": "11111111-2222-3333-4444-555555555555"
                 }
                 """;
 
@@ -217,7 +217,7 @@ class PolymorphicSerializationTest {
         assertInstanceOf(ContentSigningWorkflowRequestDto.class, base);
         ContentSigningWorkflowRequestDto result = (ContentSigningWorkflowRequestDto) base;
         assertEquals(SigningWorkflowType.CONTENT_SIGNING, result.getType());
-        assertEquals(UUID.fromString("11111111-2222-3333-4444-555555555555"), result.getSignatureFormatterConnectorUuid());
+        assertEquals(UUID.fromString("11111111-2222-3333-4444-555555555555"), result.getSignatureFormattingConnectorUuid());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/otilm/api/model/client/signing/profile/validation/SigningProfileConstraintValidatorsTest.java
+++ b/src/test/java/com/otilm/api/model/client/signing/profile/validation/SigningProfileConstraintValidatorsTest.java
@@ -60,47 +60,47 @@ class SigningProfileConstraintValidatorsTest {
         return dto;
     }
 
-    // --- ManagedSigningFormatterConnectorValidator ---
+    // --- ManagedSignatureFormattingConnectorValidator ---
 
     @Test
-    void managedTimestampingNullFormatterUuid_producesViolation() {
+    void managedTimestampingNullFormattingUuid_producesViolation() {
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
         assertTrue(hasViolationOn(validator.validate(profileRequest(managedScheme(), workflow)),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
-    void managedTimestampingWithFormatterUuid_noFormatterViolation() {
+    void managedTimestampingWithFormattingUuid_noFormattingViolation() {
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(UUID.randomUUID());
+        workflow.setSignatureFormattingConnectorUuid(UUID.randomUUID());
         assertFalse(hasViolationOn(validator.validate(profileRequest(managedScheme(), workflow)),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
-    void delegatedTimestampingNullFormatterUuid_noFormatterViolation() {
+    void delegatedTimestampingNullFormattingUuid_noFormattingViolation() {
         assertFalse(hasViolationOn(validator.validate(profileRequest(delegatedScheme(), new TimestampingWorkflowRequestDto())),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
-    void managedContentSigningNullFormatterUuid_producesViolation() {
+    void managedContentSigningNullFormattingUuid_producesViolation() {
         assertTrue(hasViolationOn(validator.validate(profileRequest(managedScheme(), new ContentSigningWorkflowRequestDto())),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
-    void managedContentSigningWithFormatterUuid_noFormatterViolation() {
+    void managedContentSigningWithFormattingUuid_noFormattingViolation() {
         ContentSigningWorkflowRequestDto workflow = new ContentSigningWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(UUID.randomUUID());
+        workflow.setSignatureFormattingConnectorUuid(UUID.randomUUID());
         assertFalse(hasViolationOn(validator.validate(profileRequest(managedScheme(), workflow)),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
-    void managedRawSigningNullFormatterUuid_noFormatterViolation() {
+    void managedRawSigningNullFormattingUuid_noFormattingViolation() {
         assertFalse(hasViolationOn(validator.validate(profileRequest(managedScheme(), new RawSigningWorkflowRequestDto())),
-                "workflow.signatureFormatterConnectorUuid"));
+                "workflow.signatureFormattingConnectorUuid"));
     }
 
     @Test
@@ -114,7 +114,7 @@ class SigningProfileConstraintValidatorsTest {
     @Test
     void managedTimestampingQualifiedTimestampTrueWithTqcUuid_noQualificationViolation() {
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(UUID.randomUUID());
+        workflow.setSignatureFormattingConnectorUuid(UUID.randomUUID());
         workflow.setQualifiedTimestamp(true);
         workflow.setTimeQualityConfigurationUuid(UUID.randomUUID());
         assertFalse(hasViolationOn(validator.validate(profileRequest(managedScheme(), workflow)),
@@ -267,7 +267,7 @@ class SigningProfileConstraintValidatorsTest {
     @Test
     void defaultPolicyNotInAllowedPolicies_violationSurfacesThroughProfileRequest() {
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(UUID.randomUUID());
+        workflow.setSignatureFormattingConnectorUuid(UUID.randomUUID());
         workflow.setDefaultPolicyId("1.2.3.4.7");
         workflow.setAllowedPolicyIds(java.util.List.of("1.2.3.4.5"));
         assertTrue(hasViolationOn(validator.validate(profileRequest(managedScheme(), workflow)),

--- a/src/test/java/com/otilm/api/model/connector/signatures/formatting/FormattingPolymorphicSerializationTest.java
+++ b/src/test/java/com/otilm/api/model/connector/signatures/formatting/FormattingPolymorphicSerializationTest.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class FormatterPolymorphicSerializationTest {
+class FormattingPolymorphicSerializationTest {
 
     private ObjectMapper mapper;
 

--- a/src/test/java/com/otilm/api/model/connector/signatures/formatting/TimestampingDtoFieldParityTest.java
+++ b/src/test/java/com/otilm/api/model/connector/signatures/formatting/TimestampingDtoFieldParityTest.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.connector.signatures.formatter;
+package com.otilm.api.model.connector.signatures.formatting;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Summary

Renames the connector SPI interface **Signature Formatter → Signature Formatting Provider** in `interfaces`, per the cross-repo tracker OmniTrustILM/ilm#258. Closes OmniTrustILM/interfaces#746.

Naming was derived from existing repo convention (weighted to recent additions), not invented:

| Decision | Result | Basis |
|---|---|---|
| REST route namespace | **unchanged** `/v1/signatureProvider/formatting` | already matches `<capability>Provider` (cf. `discoveryProvider`, `complianceProvider`, `secretProvider`, `authorityProvider`) |
| Controller / API-client classes | capability, no `Provider` suffix | `DiscoveryController`, `ComplianceController` precedent |
| `@Tag` name + description | "Signature Formatting Provider" | #258 canonical name |
| Connector-reference DTO fields | keep `<capability>Connector` | `discoveryConnectorUuid` precedent |

## Changes

**SPI / clients**
- `SignatureFormatterController` → `SignatureFormattingController`
- `SignatureFormatterApiClient` (×2: `clients/signing`, `clients/mq/signing`) → `SignatureFormattingApiClient`
- `SignatureFormatterSyncApiClient` → `SignatureFormattingSyncApiClient`
- `@Tag(name="Signature Formatter")` → `name="Signature Formatting Provider"` (+ description)
- op `listFormatterAttributes` → `listFormattingAttributes`

**DTO fields (wire contract)**
- `signatureFormatterConnector{,Uuid,Attributes}` → `signatureFormattingConnector{,Uuid,Attributes}`

**Validators**
- `ValidManagedSigningFormatterConnector` → `ValidManagedSignatureFormattingConnector`
- `ManagedSigningFormatterConnectorValidator` → `ManagedSignatureFormattingConnectorValidator`
  (also fixes the latent `Signing`→`Signature` inconsistency)

**Core web controller**
- route segment `/signatureFormatterConnectors/{uuid}/formatterAttributes` → `/signatureFormattingConnectors/{uuid}/formattingAttributes`
- op `listSignatureFormatterConnectorAttributes` → `listSignatureFormattingConnectorAttributes`

**Other**
- package `model.connector.signatures.formatter` → `…formatting`
- all user-facing `@Schema`/javadoc prose → "Signature Formatting Provider"

## ⚠️ Breaking change

Consumers must absorb, in lockstep:
- renamed SPI types + package import path,
- the JSON field tokens `signatureFormattingConnector*`,
- the core route segment `/signatureFormattingConnectors/.../formattingAttributes`.

The **connector-facing route namespace `/v1/signatureProvider/formatting` is unchanged**, so deployed connectors' formatting endpoints are unaffected. Coordinated with: core OmniTrustILM/core#1672, the connector, fe-administrator, and dev-env OmniTrustILM/development-environment#26.

## Verification

`mvn -Dmaven.compiler.proc=full clean test` → **BUILD SUCCESS, 366 tests, 0 failures** (incl. the renamed/moved serialization + constraint-validator tests). Repo-wide grep confirms zero remaining `Signature Formatter` / `signatureFormatter` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
