### PR TITLE
Add CERTIFICATE_STATUS_POLLING feature flag

### DIFF
--- a/src/main/java/com/otilm/api/model/client/connector/v2/FeatureFlag.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/FeatureFlag.java
@@ -30,7 +30,8 @@ public enum FeatureFlag implements IPlatformEnum {
     SECRET_ROTATION("secretRotation", "Secret Rotation", "Supports triggering rotation of secrets", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.SECRET)),
     CONTENT_SIGNING("contentSigning", "Content Signing", "Supports content signing workflows", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.SIGNING, ConnectorInterface.SIGNATURE_FORMATTING)),
     TIMESTAMPING("timestamping", "Timestamping", "Supports timestamping of signatures", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.SIGNING, ConnectorInterface.SIGNATURE_FORMATTING)),
-    CERTIFICATE_REGISTRATION("certificateRegistration", "Certificate Registration", "Supports pre-registering a certificate's identity (Subject DN, SAN, extensions) at the upstream CA before a CSR exists", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.AUTHORITY));
+    CERTIFICATE_REGISTRATION("certificateRegistration", "Certificate Registration", "Supports pre-registering a certificate's identity (Subject DN, SAN, extensions) at the upstream CA before a CSR exists", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.AUTHORITY)),
+    CERTIFICATE_STATUS_POLLING("certificateStatusPolling", "Certificate Status Polling", "Supports being polled for asynchronous operation completion; the platform polls the status endpoint rather than relying on out-of-band/manual completion", FeatureFlagBehavior.ENFORCED, List.of(ConnectorInterface.AUTHORITY));
 
     public enum FeatureFlagBehavior {
         ENFORCED,

--- a/src/test/java/com/otilm/api/model/client/connector/v2/FeatureFlagBehaviorTest.java
+++ b/src/test/java/com/otilm/api/model/client/connector/v2/FeatureFlagBehaviorTest.java
@@ -24,5 +24,6 @@ class FeatureFlagBehaviorTest {
         assertEquals(FeatureFlag.FeatureFlagBehavior.ENFORCED, FeatureFlag.CONTENT_SIGNING.getBehavior());
         assertEquals(FeatureFlag.FeatureFlagBehavior.ENFORCED, FeatureFlag.TIMESTAMPING.getBehavior());
         assertEquals(FeatureFlag.FeatureFlagBehavior.ENFORCED, FeatureFlag.CERTIFICATE_REGISTRATION.getBehavior());
+        assertEquals(FeatureFlag.FeatureFlagBehavior.ENFORCED, FeatureFlag.CERTIFICATE_STATUS_POLLING.getBehavior());
     }
 }

--- a/src/test/java/com/otilm/api/model/client/connector/v2/FeatureFlagTest.java
+++ b/src/test/java/com/otilm/api/model/client/connector/v2/FeatureFlagTest.java
@@ -17,6 +17,13 @@ class FeatureFlagTest {
     }
 
     @Test
+    void certificateStatusPollingFlagExists() {
+        FeatureFlag flag = FeatureFlag.CERTIFICATE_STATUS_POLLING;
+        assertEquals("certificateStatusPolling", flag.getCode());
+        assertEquals(List.of(ConnectorInterface.AUTHORITY), flag.getApplicableInterfaces());
+    }
+
+    @Test
     void findByCodeRoundTripsAllEntries() {
         for (FeatureFlag f : FeatureFlag.values()) {
             assertEquals(f, FeatureFlag.findByCode(f.getCode()));


### PR DESCRIPTION
Adds an `ENFORCED` feature flag on the `AUTHORITY` interface advertising that an authority connector supports being **polled for asynchronous operation completion** — the platform polls the connector's status endpoint rather than relying on out-of-band / manual completion.

Because the flag is `ENFORCED` (opt-in), the platform schedules a status poll only for connectors that advertise it; a connector that returns `202` but does not advertise polling is left for manual/out-of-band completion and is never polled.

Sits alongside the existing `CERTIFICATE_REGISTRATION` flag as part of the authority-provider-v3 work.

**Consumer:** the core service-layer capability gate (`ConnectorCapabilityService`) — see `OmniTrustILM/core#1638`.