### PR TITLE
Add v3 authority instance attribute listing endpoint

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -96,6 +96,18 @@ public interface AuthorityInstanceController extends AuthProtectedController {
     List<NameAndIdDto> listCAsInProfile(@Parameter(description = "Authority instance UUID") @PathVariable String uuid, @PathVariable Integer endEntityProfileId)
             throws ConnectorException, NotFoundException;
 
+    @Operation(summary = "List Authority Instance Attributes",
+            description = "Authority attribute schema for a stateless v3 (NG) authority connector, keyed by connector UUID.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority instance attributes retrieved")})
+    @GetMapping(path = "/{connectorUuid}/attributes", produces = {"application/json"})
+    List<BaseAttribute> listAuthorityInstanceAttributes(
+            @Parameter(description = "Connector UUID") @PathVariable String connectorUuid,
+            @Parameter(description = "AUTHORITY interface UUID; disambiguates when the connector exposes more "
+                    + "than one AUTHORITY interface version (e.g. v2 and v3). Optional when a single AUTHORITY "
+                    + "interface exists.")
+            @RequestParam(required = false) String interfaceUuid)
+            throws ConnectorException, NotFoundException, AttributeException;
+
     @Operation(summary = "List RA Profile Attributes")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attribute information retrieved")})
     @GetMapping(path = "/{uuid}/attributes/raProfile", produces = {"application/json"})

--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -98,7 +98,9 @@ public interface AuthorityInstanceController extends AuthProtectedController {
 
     @Operation(summary = "List Authority Instance Attributes",
             description = "Authority attribute schema for a stateless v3 (NG) authority connector, keyed by connector UUID.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority instance attributes retrieved")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority instance attributes retrieved"),
+            @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
     @GetMapping(path = "/{connectorUuid}/attributes", produces = {"application/json"})
     List<BaseAttribute> listAuthorityInstanceAttributes(
             @Parameter(description = "Connector UUID") @PathVariable String connectorUuid,

--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -96,9 +96,9 @@ public interface AuthorityInstanceController extends AuthProtectedController {
     List<NameAndIdDto> listCAsInProfile(@Parameter(description = "Authority instance UUID") @PathVariable String uuid, @PathVariable Integer endEntityProfileId)
             throws ConnectorException, NotFoundException;
 
-    @Operation(summary = "List Authority Instance Attributes",
-            description = "Authority attribute schema for a stateless v3 (NG) authority connector, keyed by connector UUID.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority instance attributes retrieved"),
+    @Operation(summary = "List authority attributes for a connector",
+            description = "Connector-scoped authority attribute schema for a stateless authority connector, keyed by connector UUID.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Authority attributes retrieved"),
             @ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
                     examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
     @GetMapping(path = "/{connectorUuid}/attributes", produces = {"application/json"})


### PR DESCRIPTION
## What

Adds the operator-facing endpoint that lists a stateless **v3 (NG) authority connector**'s attribute schema for the create-authority UI, mirroring `VaultInstanceController.listVaultInstanceAttributes`:

```
GET /v1/authorities/{connectorUuid}/attributes?interfaceUuid={authorityInterfaceUuid} -> List<BaseAttribute>
```

- Keyed by **connector UUID** (no authority instance exists yet), like the Vault flow.
- Optional `interfaceUuid` disambiguates when a connector exposes more than one AUTHORITY interface (e.g. v2 + v3).
- Annotated for the springdoc OpenAPI spec (200 + 422; 404/502/503 inherited from the class-level `@ApiResponses`).

## Why

v3 authority connectors are stateless and kind-less; the existing function-group `GET /v1/connectors/{uuid}/attributes/{functionGroup}/{kind}` path cannot serve them. This is the authority-side analog of `VaultInstanceController` for the secret provider. Part of the Authority Provider v3 epic (OmniTrustILM/ilm#110).

## Coordination

⚠️ **Paired with OmniTrustILM/core#1699 — the two must be merged / version-bumped together**, or `core` fails to compile against a new `interfaces` release. Frontend wiring is tracked in OmniTrustILM/fe-administrator#1796.

## Testing

`mvn clean verify` — BUILD SUCCESS, 395 tests, 0 failures.
