### PR TITLE
Add ATTRIBUTES interface code and classify interfaces (common/functional)

### DIFF
--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -24,7 +24,8 @@ public enum ConnectorInterface implements IPlatformEnum {
     NOTIFICATION("notification", "Notification"),
     SECRET("secret", "Secret"),
     SIGNATURE_FORMATTING("signatureFormatting", "Signature Formatting"),
-    SIGNING("signing", "Signing");
+    SIGNING("signing", "Signing"),
+    ATTRIBUTES("attributes", "Attributes");
 
     private static final ConnectorInterface[] VALUES;
 

--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -16,6 +16,7 @@ public enum ConnectorInterface implements IPlatformEnum {
     INFO("info", "Info"),
     HEALTH("health", "Health"),
     METRICS("metrics", "Metrics"),
+    ATTRIBUTES("attributes", "Attributes"),
     AUTHORITY("authority", "Authority"),
     DISCOVERY("discovery", "Discovery"),
     ENTITY("entity", "Entity"),
@@ -24,8 +25,7 @@ public enum ConnectorInterface implements IPlatformEnum {
     NOTIFICATION("notification", "Notification"),
     SECRET("secret", "Secret"),
     SIGNATURE_FORMATTING("signatureFormatting", "Signature Formatting"),
-    SIGNING("signing", "Signing"),
-    ATTRIBUTES("attributes", "Attributes");
+    SIGNING("signing", "Signing");
 
     private static final ConnectorInterface[] VALUES;
 

--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -13,19 +13,31 @@ import java.util.Arrays;
 @Schema(enumAsRef = true)
 public enum ConnectorInterface implements IPlatformEnum {
 
-    INFO("info", "Info"),
-    HEALTH("health", "Health"),
-    METRICS("metrics", "Metrics"),
-    ATTRIBUTES("attributes", "Attributes"),
-    AUTHORITY("authority", "Authority"),
-    DISCOVERY("discovery", "Discovery"),
-    ENTITY("entity", "Entity"),
-    COMPLIANCE("compliance", "Compliance"),
-    CRYPTOGRAPHY("cryptography", "Cryptography"),
-    NOTIFICATION("notification", "Notification"),
-    SECRET("secret", "Secret"),
-    SIGNATURE_FORMATTING("signatureFormatting", "Signature Formatting"),
-    SIGNING("signing", "Signing");
+    // Common interfaces — every NG connector implements these (INFO/HEALTH/METRICS mandatory; ATTRIBUTES optional).
+    INFO("info", "Info", InterfaceCategory.COMMON),
+    HEALTH("health", "Health", InterfaceCategory.COMMON),
+    METRICS("metrics", "Metrics", InterfaceCategory.COMMON),
+    ATTRIBUTES("attributes", "Attributes", InterfaceCategory.COMMON),
+    // Functional interfaces — a connector implements one or more to provide actual capabilities.
+    AUTHORITY("authority", "Authority", InterfaceCategory.FUNCTIONAL),
+    DISCOVERY("discovery", "Discovery", InterfaceCategory.FUNCTIONAL),
+    ENTITY("entity", "Entity", InterfaceCategory.FUNCTIONAL),
+    COMPLIANCE("compliance", "Compliance", InterfaceCategory.FUNCTIONAL),
+    CRYPTOGRAPHY("cryptography", "Cryptography", InterfaceCategory.FUNCTIONAL),
+    NOTIFICATION("notification", "Notification", InterfaceCategory.FUNCTIONAL),
+    SECRET("secret", "Secret", InterfaceCategory.FUNCTIONAL),
+    SIGNATURE_FORMATTING("signatureFormatting", "Signature Formatting", InterfaceCategory.FUNCTIONAL),
+    SIGNING("signing", "Signing", InterfaceCategory.FUNCTIONAL);
+
+    /**
+     * Whether an interface is a common baseline interface (implemented by every NG connector) or a
+     * functional/operational one (the capabilities a connector actually provides). A connector must
+     * implement the mandatory common interfaces plus at least one functional interface.
+     */
+    public enum InterfaceCategory {
+        COMMON,
+        FUNCTIONAL
+    }
 
     private static final ConnectorInterface[] VALUES;
 
@@ -38,14 +50,16 @@ public enum ConnectorInterface implements IPlatformEnum {
     private final String code;
     private final String label;
     private final String description;
+    private final InterfaceCategory category;
 
-    ConnectorInterface(String code, String label) {
-        this(code, label, null);
+    ConnectorInterface(String code, String label, InterfaceCategory category) {
+        this(code, label, category, null);
     }
 
-    ConnectorInterface(String code, String label, String description) {
+    ConnectorInterface(String code, String label, InterfaceCategory category, String description) {
         this.code = code;
         this.label = label;
+        this.category = category;
         this.description = description;
     }
 
@@ -63,6 +77,10 @@ public enum ConnectorInterface implements IPlatformEnum {
     @Override
     public String getDescription() {
         return this.description;
+    }
+
+    public InterfaceCategory getCategory() {
+        return this.category;
     }
 
     @JsonCreator

--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -47,7 +47,7 @@ public enum ConnectorInterface implements IPlatformEnum {
     }
 
     @Schema(description = "Connector interface code",
-            examples = {"credentialProvider"}, requiredMode = Schema.RequiredMode.REQUIRED)
+            examples = {"authority"}, requiredMode = Schema.RequiredMode.REQUIRED)
     private final String code;
     private final String label;
     private final InterfaceCategory category;

--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -13,12 +13,12 @@ import java.util.Arrays;
 @Schema(enumAsRef = true)
 public enum ConnectorInterface implements IPlatformEnum {
 
-    // Common interfaces — the shared baseline (info/health/metrics/attributes), as opposed to the functional providers below.
+    // Common interfaces
     INFO("info", "Info", InterfaceCategory.COMMON),
     HEALTH("health", "Health", InterfaceCategory.COMMON),
     METRICS("metrics", "Metrics", InterfaceCategory.COMMON),
     ATTRIBUTES("attributes", "Attributes", InterfaceCategory.COMMON),
-    // Functional interfaces — a connector implements one or more to provide actual capabilities.
+    // Functional interfaces
     AUTHORITY("authority", "Authority", InterfaceCategory.FUNCTIONAL),
     DISCOVERY("discovery", "Discovery", InterfaceCategory.FUNCTIONAL),
     ENTITY("entity", "Entity", InterfaceCategory.FUNCTIONAL),

--- a/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
+++ b/src/main/java/com/otilm/api/model/client/connector/v2/ConnectorInterface.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 @Schema(enumAsRef = true)
 public enum ConnectorInterface implements IPlatformEnum {
 
-    // Common interfaces — every NG connector implements these (INFO/HEALTH/METRICS mandatory; ATTRIBUTES optional).
+    // Common interfaces — the shared baseline (info/health/metrics/attributes), as opposed to the functional providers below.
     INFO("info", "Info", InterfaceCategory.COMMON),
     HEALTH("health", "Health", InterfaceCategory.COMMON),
     METRICS("metrics", "Metrics", InterfaceCategory.COMMON),
@@ -30,9 +30,10 @@ public enum ConnectorInterface implements IPlatformEnum {
     SIGNING("signing", "Signing", InterfaceCategory.FUNCTIONAL);
 
     /**
-     * Whether an interface is a common baseline interface (implemented by every NG connector) or a
-     * functional/operational one (the capabilities a connector actually provides). A connector must
-     * implement the mandatory common interfaces plus at least one functional interface.
+     * Groups a connector interface as a common baseline interface (info/health/metrics/attributes) or a
+     * functional/operational provider (the capabilities a connector supplies). This is a grouping only —
+     * which specific interfaces are required for a connector to register is enforced by Core, independently
+     * of this category.
      */
     public enum InterfaceCategory {
         COMMON,
@@ -49,8 +50,8 @@ public enum ConnectorInterface implements IPlatformEnum {
             examples = {"credentialProvider"}, requiredMode = Schema.RequiredMode.REQUIRED)
     private final String code;
     private final String label;
-    private final String description;
     private final InterfaceCategory category;
+    private final String description;
 
     ConnectorInterface(String code, String label, InterfaceCategory category) {
         this(code, label, category, null);

--- a/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
+++ b/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
@@ -1,0 +1,29 @@
+package com.otilm.api.model.client.connector.v2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ConnectorInterfaceCategoryTest {
+
+    @Test
+    void everyInterfaceDeclaresCategory() {
+        for (ConnectorInterface iface : ConnectorInterface.values()) {
+            assertNotNull(iface.getCategory(),
+                "ConnectorInterface " + iface + " must declare an InterfaceCategory");
+        }
+    }
+
+    @Test
+    void existingInterfacesClassifiedCorrectly() {
+        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.INFO.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.HEALTH.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.METRICS.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.ATTRIBUTES.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.AUTHORITY.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.DISCOVERY.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.SECRET.getCategory());
+        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.SIGNING.getCategory());
+    }
+}

--- a/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
+++ b/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
@@ -2,10 +2,19 @@ package com.otilm.api.model.client.connector.v2;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ConnectorInterfaceCategoryTest {
+
+    private static final Set<ConnectorInterface> COMMON = EnumSet.of(
+        ConnectorInterface.INFO,
+        ConnectorInterface.HEALTH,
+        ConnectorInterface.METRICS,
+        ConnectorInterface.ATTRIBUTES);
 
     @Test
     void everyInterfaceDeclaresCategory() {
@@ -16,14 +25,19 @@ class ConnectorInterfaceCategoryTest {
     }
 
     @Test
-    void existingInterfacesClassifiedCorrectly() {
-        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.INFO.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.HEALTH.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.METRICS.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.COMMON, ConnectorInterface.ATTRIBUTES.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.AUTHORITY.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.DISCOVERY.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.SECRET.getCategory());
-        assertEquals(ConnectorInterface.InterfaceCategory.FUNCTIONAL, ConnectorInterface.SIGNING.getCategory());
+    void everyInterfaceIsCategorizedCorrectly() {
+        for (ConnectorInterface iface : ConnectorInterface.values()) {
+            ConnectorInterface.InterfaceCategory expected = COMMON.contains(iface)
+                ? ConnectorInterface.InterfaceCategory.COMMON
+                : ConnectorInterface.InterfaceCategory.FUNCTIONAL;
+            assertEquals(expected, iface.getCategory(), iface.name());
+        }
+    }
+
+    @Test
+    void findByCodeRoundTripsAllValues() {
+        for (ConnectorInterface iface : ConnectorInterface.values()) {
+            assertEquals(iface, ConnectorInterface.findByCode(iface.getCode()), iface.name());
+        }
     }
 }

--- a/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
+++ b/src/test/java/com/otilm/api/model/client/connector/v2/ConnectorInterfaceCategoryTest.java
@@ -6,7 +6,6 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ConnectorInterfaceCategoryTest {
 
@@ -15,14 +14,6 @@ class ConnectorInterfaceCategoryTest {
         ConnectorInterface.HEALTH,
         ConnectorInterface.METRICS,
         ConnectorInterface.ATTRIBUTES);
-
-    @Test
-    void everyInterfaceDeclaresCategory() {
-        for (ConnectorInterface iface : ConnectorInterface.values()) {
-            assertNotNull(iface.getCategory(),
-                "ConnectorInterface " + iface + " must declare an InterfaceCategory");
-        }
-    }
 
     @Test
     void everyInterfaceIsCategorizedCorrectly() {


### PR DESCRIPTION
Adds the `ATTRIBUTES` value to `ConnectorInterface` so NG connectors can declare the Attributes v2 common interface (`/v2/attributes`) in their `/v2/info` response.

- **Additive / non-breaking.** No exhaustive `switch`, `.values()` iteration, or hardcoded interface-code list depends on the enum set; `@Schema(enumAsRef=true)` picks the value up by reflection; the connector-interface DB column is plain text (no migration).
- **Kept optional in Core** — deliberately *not* added to `ConnectorV2Adapter`'s mandatory-interface set. Core's Attributes v2 dispatch is gated per attribute-definition on data shape (`dependsOn`), with the legacy v1 callback path as fallback, so connectors that don't implement Attributes v2 are unaffected. Making it mandatory would reject existing connectors for no benefit.
- **Unblocks connectors that advertise `attributes`** (e.g. `ms-adcs-ng-connector`): `ConnectorInterface.findByCode` no longer throws on the code, so Core can parse their `/v2/info`.

Closes #754.
