### PR TITLE
Rename certificate sign-request DTO to issue-request

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -178,7 +178,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(
-					description = "Sign request body. Required when cert state is REGISTERED (carries the operator's CSR + sign attributes); must be omitted when cert state is REQUESTED.",
+					description = "Issue request body. Required when cert state is REGISTERED (carries the operator's CSR or key-generation parameters plus the authorization secret); must be omitted when cert state is REQUESTED.",
 					required = false)
 			@RequestBody(required = false) @Valid ClientCertificateIssueRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException, AttributeException;
 

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -163,8 +163,8 @@ public interface ClientOperationController extends AuthProtectedController {
 					  a protocol layer such as ACME, SCEP, or CMP, or after an approval/compliance cycle).
 					  Issuance is triggered with the existing CSR.
 					- `REGISTERED` (body required): the certificate was pre-registered (v3 authorities with
-					  `CERTIFICATE_REGISTRATION` capability) and is now being finalized with an operator-
-					  supplied CSR. The CSR + sign attributes from the body are attached to the existing
+					  `CERTIFICATE_REGISTRATION` capability) and is now being finalized. The body carries the authorization secret plus either an operator-
+					  supplied CSR or platform key-generation parameters, which are attached to the existing
 					  certificate row, then issuance is triggered. The cert's identity (subject DN, SAN,
 					  extensions) and connector-supplied metadata from the registration are preserved.
 					"""

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -163,8 +163,8 @@ public interface ClientOperationController extends AuthProtectedController {
 					  a protocol layer such as ACME, SCEP, or CMP, or after an approval/compliance cycle).
 					  Issuance is triggered with the existing CSR.
 					- `REGISTERED` (body required): the certificate was pre-registered (v3 authorities with
-					  `CERTIFICATE_REGISTRATION` capability) and is now being finalized. The body carries the authorization secret plus either an operator-
-					  supplied CSR or platform key-generation parameters, which are attached to the existing
+					  `CERTIFICATE_REGISTRATION` capability) and is now being finalized with an operator-
+					  supplied CSR. The CSR + sign attributes and the authorization secret from the body are attached to the existing
 					  certificate row, then issuance is triggered. The cert's identity (subject DN, SAN,
 					  extensions) and connector-supplied metadata from the registration are preserved.
 					"""
@@ -178,7 +178,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(
-					description = "Issue request body. Required when cert state is REGISTERED (carries the operator's CSR or key-generation parameters plus the authorization secret); must be omitted when cert state is REQUESTED.",
+					description = "Issue request body. Required when cert state is REGISTERED (carries the operator's CSR + sign attributes plus the authorization secret); must be omitted when cert state is REQUESTED.",
 					required = false)
 			@RequestBody(required = false) @Valid ClientCertificateIssueRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException, AttributeException;
 

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -180,7 +180,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(
 					description = "Sign request body. Required when cert state is REGISTERED (carries the operator's CSR + sign attributes); must be omitted when cert state is REQUESTED.",
 					required = false)
-			@RequestBody(required = false) @Valid ClientCertificateSignRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException, AttributeException;
+			@RequestBody(required = false) @Valid ClientCertificateIssueRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException, AttributeException;
 
 	@Operation(
 			summary = "Issue certificate",
@@ -193,7 +193,7 @@ public interface ClientOperationController extends AuthProtectedController {
 	ClientCertificateDataResponseDto issueCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
-			@RequestBody ClientCertificateSignRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
+			@RequestBody ClientCertificateIssueRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
 
 	@Operation(
 			summary = "Renew certificate",

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
@@ -88,7 +88,6 @@ public class ClientCertificateIssueRequestDto {
     )
     private List<RequestAttribute> customAttributes;
 
-    @ToString.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(
             description = "One-time authorization secret proving the caller may complete a pre-registered "
@@ -97,6 +96,7 @@ public class ClientCertificateIssueRequestDto {
     )
     private String authorizationSecret;
 
+    // Deliberate allowlist — only non-sensitive fields. Never append request (the CSR) or authorizationSecret.
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.core.v2;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,10 +12,11 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Class representing a request to sign CSR from external clients
+ * Request to issue a certificate for an external client — by uploading a CSR or having the platform generate the
+ * key — including completing a pre-registered certificate, which additionally carries the authorization secret.
  */
 @Data
-public class ClientCertificateSignRequestDto {
+public class ClientCertificateIssueRequestDto {
 
     @Schema(
             description = "List of attributes to create CSR. Required if CSR is not provided"
@@ -85,6 +87,15 @@ public class ClientCertificateSignRequestDto {
             description = "List of Custom Attributes"
     )
     private List<RequestAttribute> customAttributes;
+
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Schema(
+            description = "One-time authorization secret proving the caller may complete a pre-registered "
+                    + "certificate. Write-only; ignored for certificates without an active registration.",
+            accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    private String authorizationSecret;
 
     @Override
     public String toString() {

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Request to issue a certificate for an external client — by uploading a CSR or having the platform generate the
- * key — including completing a pre-registered certificate, which additionally carries the authorization secret.
+ * Request to issue a certificate for an external client from a CSR, including completing a pre-registered
+ * certificate, which additionally carries the authorization secret.
  */
 @Data
 public class ClientCertificateIssueRequestDto {

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
@@ -75,12 +75,12 @@ public class ClientCertificateRekeyRequestDto {
     @Schema(
             description = "Signature Attributes. If not provided, existing attributes will be used to generate the new CSR"
     )
-    private List<RequestAttribute>signatureAttributes;
+    private List<RequestAttribute> signatureAttributes;
 
     @Schema(
             description = "Alternative Signature Attributes. If not provided, existing alternative attributes will be used to generate the new CSR"
     )
-    private List<RequestAttribute>altSignatureAttributes;
+    private List<RequestAttribute> altSignatureAttributes;
 
     @ToString.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.core.v2;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -7,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.UUID;
@@ -79,4 +81,13 @@ public class ClientCertificateRekeyRequestDto {
             description = "Alternative Signature Attributes. If not provided, existing alternative attributes will be used to generate the new CSR"
     )
     private List<RequestAttribute>altSignatureAttributes;
+
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Schema(
+            description = "One-time authorization secret for rekeying a certificate that has an active "
+                    + "registration. Write-only; ignored for certificates without one.",
+            accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    private String authorizationSecret;
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
@@ -1,0 +1,32 @@
+package com.otilm.api.model.core.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ClientCertificateIssueRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void authorizationSecretIsAcceptedOnInputButNeverSerialized() throws Exception {
+        ClientCertificateIssueRequestDto dto =
+                mapper.readValue("{\"authorizationSecret\":\"s3cret\"}", ClientCertificateIssueRequestDto.class);
+        assertEquals("s3cret", dto.getAuthorizationSecret());
+
+        dto.setRequest("Zm9v");
+        String json = mapper.writeValueAsString(dto);
+        assertFalse(json.contains("authorizationSecret"),
+                "write-only authorizationSecret must never be serialized back to a client");
+        assertFalse(json.contains("s3cret"));
+    }
+
+    @Test
+    void toStringOmitsAuthorizationSecret() {
+        ClientCertificateIssueRequestDto dto = new ClientCertificateIssueRequestDto();
+        dto.setAuthorizationSecret("s3cret");
+        assertFalse(dto.toString().contains("s3cret"), "authorizationSecret must not appear in toString");
+    }
+}

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClientCertificateIssueRequestDtoTest {
 
@@ -21,6 +22,7 @@ class ClientCertificateIssueRequestDtoTest {
         assertFalse(json.contains("authorizationSecret"),
                 "write-only authorizationSecret must never be serialized back to a client");
         assertFalse(json.contains("s3cret"));
+        assertTrue(json.contains("request"), "non-write-only fields must still serialize (exclusion is field-targeted)");
     }
 
     @Test

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDtoTest.java
@@ -1,0 +1,32 @@
+package com.otilm.api.model.core.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ClientCertificateRekeyRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void authorizationSecretIsAcceptedOnInputButNeverSerialized() throws Exception {
+        ClientCertificateRekeyRequestDto dto =
+                mapper.readValue("{\"authorizationSecret\":\"s3cret\"}", ClientCertificateRekeyRequestDto.class);
+        assertEquals("s3cret", dto.getAuthorizationSecret());
+
+        String json = mapper.writeValueAsString(dto);
+        assertFalse(json.contains("authorizationSecret"),
+                "write-only authorizationSecret must never be serialized back to a client");
+        assertFalse(json.contains("s3cret"));
+    }
+
+    @Test
+    void toStringOmitsAuthorizationSecret() {
+        ClientCertificateRekeyRequestDto dto = new ClientCertificateRekeyRequestDto();
+        dto.setAuthorizationSecret("s3cret");
+        assertFalse(dto.toString().contains("s3cret"),
+                "authorizationSecret is @ToString.Exclude and must not appear in the generated toString");
+    }
+}


### PR DESCRIPTION
## What

Prepares the client-operations request DTOs for external self-service issuance (ilm#130):

- **Rename** `ClientCertificateSignRequestDto` → `ClientCertificateIssueRequestDto`. Issuing a `REGISTERED` placeholder doesn't always sign a CSR (the platform may generate the key, or the CSR arrives later), so "Issue" is the accurate name. Only the v2 `ClientOperationController` (package-wildcard import) referenced it; the legacy v1 DTO/controller use a different class and are untouched.
- **Add write-only `authorizationSecret`** to the issue + rekey DTOs — a one-time secret proving the caller may complete a pre-registered certificate.

## Secret handling

Flat `String`, matching this repo's established write-only-secret idiom (SCEP `challengePassword`, TSP `password`): `@JsonProperty(WRITE_ONLY)` + `@Schema(accessMode = WRITE_ONLY)` + `@ToString.Exclude`. Accepted on input, never serialized back, never in `toString`.

A nested `authorization` object was considered for extensibility; an independent review confirmed **flat** is right here — future mechanisms (a vault secret-UUID via an `@AssertTrue` mutual-exclusion, an `authenticationType` enum) add additively / non-breaking, and single-field nested wrappers have no precedent in this repo.

## Tests

`ClientCertificateIssueRequestDtoTest` + `ClientCertificateRekeyRequestDtoTest` assert the write-only contract: `authorizationSecret` is accepted on deserialization but absent from serialization and `toString`. `mvn clean verify` green (397 tests).

## Scope

**Part of #699.** The request-attribute-shape alignment (`csrAttributes` → structured content) is deferred — not needed for R1's flat-identity path; the DTOs already carry request-attribute input as `List<RequestAttribute>`.

Downstream: once this releases, `core` bumps the interfaces version and adopts the rename in R1b (core#1570).
