### PR TITLE
Bump parent dependencies to 1.4.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.otilm</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>interfaces</artifactId>


### PR DESCRIPTION
Updates the Maven parent POM version from 1.4.1 to 1.4.2-SNAPSHOT to align this module with the latest shared dependency baseline.