### PR TITLE
Reject empty certificateUuids on compliance-check request

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/web/CertificateController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/CertificateController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -156,7 +157,7 @@ public interface CertificateController extends AuthProtectedController {
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Compliance check initiated")})
     @PostMapping(path = "/compliance", produces = {MediaType.APPLICATION_JSON_VALUE})
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    void checkCompliance(@RequestBody CertificateComplianceCheckDto request) throws NotFoundException;
+    void checkCompliance(@Valid @RequestBody CertificateComplianceCheckDto request) throws NotFoundException;
 
     @Operation(summary = "Get Certificate Validation Result")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate validation detail retrieved")})

--- a/src/main/java/com/otilm/api/model/client/certificate/CertificateComplianceCheckDto.java
+++ b/src/main/java/com/otilm/api/model/client/certificate/CertificateComplianceCheckDto.java
@@ -1,11 +1,13 @@
 package com.otilm.api.model.client.certificate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public class CertificateComplianceCheckDto {
-    @Schema(description = "List of UUIDs of the Certificates")
+    @NotEmpty
+    @Schema(description = "List of UUIDs of the Certificates", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> certificateUuids;
 
     public List<String> getCertificateUuids() {


### PR DESCRIPTION
## What

- `CertificateComplianceCheckDto.certificateUuids` is now annotated `@NotEmpty` (with `Schema.RequiredMode.REQUIRED`).
- `CertificateController.checkCompliance(...)` now marks the `@RequestBody` with `@Valid`, so the constraint is actually enforced.

## Why

Follow-up to a review comment on [core#1746](https://github.com/OmniTrustILM/core/pull/1746). That PR moved the `certificateUuids → SecuredUUID` conversion into the controller. With no validation, a `null`/empty `certificateUuids` NPEs during conversion — surfacing as a synchronous, client-visible **500** on malformed input.

With `@NotEmpty` + `@Valid`, the request is rejected with a clean **400** at the controller boundary, before any conversion runs. `@NotEmpty` already implies non-null, so no separate `@NotNull` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)