### PR TITLE
Remove non-functional QC_STATEMENT from OidCategory and recategorize system OID

### DIFF
--- a/src/main/java/com/otilm/api/model/core/oid/OidCategory.java
+++ b/src/main/java/com/otilm/api/model/core/oid/OidCategory.java
@@ -10,7 +10,6 @@ public enum OidCategory implements IPlatformEnum {
 
     RDN_ATTRIBUTE_TYPE(Codes.RDN_ATTRIBUTE_TYPE, "RDN Attribute Type", "OID for a type of attribute that can appear in DN"),
     EXTENDED_KEY_USAGE(Codes.EXTENDED_KEY_USAGE, "Extended Key Usage", "OID specifying key purpose in Extended Key Usage extension"),
-    QC_STATEMENT(Codes.QC_STATEMENT, "QC Statement", "OID identifying a qualified certificate statement (ETSI EN 319 412)"),
     CERTIFICATE_EXTENSION(Codes.CERTIFICATE_EXTENSION, "Certificate Extension", "OID for a custom X.509 certificate extension with typed value encoding"),
     GENERIC(Codes.GENERIC, "Generic", "Generic OID for general use")
     ;
@@ -58,7 +57,6 @@ public enum OidCategory implements IPlatformEnum {
     public static class Codes {
         public static final String RDN_ATTRIBUTE_TYPE = "rdnAttributeType";
         public static final String EXTENDED_KEY_USAGE = "extendedKeyUsage";
-        public static final String QC_STATEMENT = "qcStatement";
         public static final String CERTIFICATE_EXTENSION = "certificateExtension";
         public static final String GENERIC = "generic";
 

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -38,7 +38,7 @@ public enum SystemOid {
     IPSEC_TUNNEL("1.3.6.1.5.5.7.3.6", "IPSec Tunnel", OidCategory.EXTENDED_KEY_USAGE),
     AUTHENTIC_DOCUMENTS_TRUST("1.2.840.113583.1.1.5", "Authentic Documents Trust", OidCategory.EXTENDED_KEY_USAGE),
 
-    // QC Statements for time-stamp tokens (ETSI EN 319 422 Annex B)
+    // Generic
     QTST_STATEMENT_1("0.4.0.19422.1.1", "Qualified Electronic Time-Stamp", OidCategory.GENERIC)
     ;
 

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -38,7 +38,6 @@ public enum SystemOid {
     IPSEC_TUNNEL("1.3.6.1.5.5.7.3.6", "IPSec Tunnel", OidCategory.EXTENDED_KEY_USAGE),
     AUTHENTIC_DOCUMENTS_TRUST("1.2.840.113583.1.1.5", "Authentic Documents Trust", OidCategory.EXTENDED_KEY_USAGE),
 
-    // Generic
     QTST_STATEMENT_1("0.4.0.19422.1.1", "Qualified Electronic Time-Stamp", OidCategory.GENERIC)
     ;
 

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -39,7 +39,7 @@ public enum SystemOid {
     AUTHENTIC_DOCUMENTS_TRUST("1.2.840.113583.1.1.5", "Authentic Documents Trust", OidCategory.EXTENDED_KEY_USAGE),
 
     // QC Statements for time-stamp tokens (ETSI EN 319 422 Annex B)
-    QTST_STATEMENT_1("0.4.0.19422.1.1", "Qualified Electronic Time-Stamp", OidCategory.QC_STATEMENT)
+    QTST_STATEMENT_1("0.4.0.19422.1.1", "Qualified Electronic Time-Stamp", OidCategory.GENERIC)
     ;
 
     private static final SystemOid[] VALUES;


### PR DESCRIPTION
## Summary
Removes the non-functional `QC_STATEMENT` value from `OidCategory` (package `com.otilm.api.model.core.oid`) and recategorizes its only referencing system OID.

- **`OidCategory.java`** — removed the `QC_STATEMENT` enum constant and the `Codes.QC_STATEMENT` (`"qcStatement"`) code string.
- **`SystemOid.java`** — changed `QTST_STATEMENT_1("0.4.0.19422.1.1", "Qualified Electronic Time-Stamp", …)` from `OidCategory.QC_STATEMENT` to `OidCategory.GENERIC`. Behavior-preserving — the OID stays reserved via `SystemOid.fromOID`, only its category changes.

`core` requires no change — `CustomOidEntryServiceImpl.createCustomOidEntry` already has no `QC_STATEMENT` case.

## Definition of Done
- [x] `QC_STATEMENT` removed from `OidCategory` and `Codes`
- [x] `QTST_STATEMENT_1` recategorized to `GENERIC`
- [x] Build passes; no references to `QC_STATEMENT` remain
- [x] Generated OpenAPI / platform-enum output no longer advertises `qcStatement`

Closes #763
Parent: OmniTrustILM/ilm#263

🤖 Generated with [Claude Code](https://claude.com/claude-code)