### PR TITLE
Add registration-flow DTOs: register secret, settings, and detail block

### DIFF
--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateDetailDto.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateDetailDto.java
@@ -61,6 +61,12 @@ public class CertificateDetailDto extends CertificateDto {
     )
     private Set<LocationDto> locations;
 
+    @Schema(
+            description = "Pre-registration authorization status; present only for certificates that were pre-registered",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private CertificateRegistrationDetailDto registration;
+
     /**
      * @deprecated As of release 2.16.0. Replaced by {@link com.otilm.api.interfaces.core.web.v2.ComplianceController#getComplianceCheckResult(Resource, UUID)} endpoint instead that is part of compliance v2 implementation.
      */

--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.core.certificate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -7,6 +8,7 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CertificateRegistrationDetailDto implements Serializable {
 
     @Schema(description = "Registration authorization state", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
@@ -1,0 +1,21 @@
+package com.otilm.api.model.core.certificate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+@Data
+public class CertificateRegistrationDetailDto implements Serializable {
+
+    @Schema(description = "Registration authorization state", allowableValues = {"ACTIVE", "EXPIRED", "LOCKED", "CLOSED"}, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String state;
+
+    @Schema(description = "Issuance deadline for completing the pre-registered certificate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private OffsetDateTime expiresAt;
+
+    @Schema(description = "Number of failed challenge-verification attempts recorded", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer failedAttempts;
+
+}

--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDto.java
@@ -9,8 +9,8 @@ import java.time.OffsetDateTime;
 @Data
 public class CertificateRegistrationDetailDto implements Serializable {
 
-    @Schema(description = "Registration authorization state", allowableValues = {"ACTIVE", "EXPIRED", "LOCKED", "CLOSED"}, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private String state;
+    @Schema(description = "Registration authorization state", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private CertificateRegistrationState state;
 
     @Schema(description = "Issuance deadline for completing the pre-registered certificate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private OffsetDateTime expiresAt;

--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationState.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateRegistrationState.java
@@ -1,0 +1,59 @@
+package com.otilm.api.model.core.certificate;
+
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.common.enums.IPlatformEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+
+@Schema(enumAsRef = true)
+public enum CertificateRegistrationState implements IPlatformEnum {
+    ACTIVE("active", "Active", "Registration is active; the challenge gates issue/rekey"),
+    EXPIRED("expired", "Expired", "The issuance window has passed"),
+    LOCKED("locked", "Locked", "Locked after too many failed challenge attempts"),
+    CLOSED("closed", "Closed", "Behaves as unregistered (operator-closed or terminal)");
+
+    private static final CertificateRegistrationState[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    private final String code;
+    private final String label;
+    private final String description;
+
+    CertificateRegistrationState(String code, String label, String description) {
+        this.code = code;
+        this.label = label;
+        this.description = description;
+    }
+
+    @Override
+    @JsonValue
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getLabel() {
+        return this.label;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @JsonCreator
+    public static CertificateRegistrationState findByCode(String code) {
+        return Arrays.stream(VALUES)
+                .filter(k -> k.code.equals(code))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ValidationException(ValidationError.create("Unknown certificate registration state {}", code)));
+    }
+}

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsDto.java
@@ -1,11 +1,13 @@
 package com.otilm.api.model.core.settings;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.io.Serializable;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CertificateRegistrationSettingsDto implements Serializable {
 
     @Schema(description = "Default issuance window in days, applied when a pre-registration omits an explicit expiry", requiredMode = Schema.RequiredMode.NOT_REQUIRED, minimum = "1")

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsDto.java
@@ -1,0 +1,17 @@
+package com.otilm.api.model.core.settings;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class CertificateRegistrationSettingsDto implements Serializable {
+
+    @Schema(description = "Default issuance window in days, applied when a pre-registration omits an explicit expiry", requiredMode = Schema.RequiredMode.NOT_REQUIRED, minimum = "1")
+    private Integer defaultIssuanceWindowDays;
+
+    @Schema(description = "Maximum failed challenge-verification attempts before the registration authorization locks", requiredMode = Schema.RequiredMode.NOT_REQUIRED, minimum = "1")
+    private Integer maxFailedAttempts;
+
+}

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDto.java
@@ -1,0 +1,20 @@
+package com.otilm.api.model.core.settings;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class CertificateRegistrationSettingsUpdateDto implements Serializable {
+
+    @Schema(description = "Default issuance window in days, applied when a pre-registration omits an explicit expiry", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "7", minimum = "1")
+    @Positive
+    private Integer defaultIssuanceWindowDays = 7;
+
+    @Schema(description = "Maximum failed challenge-verification attempts before the registration authorization locks", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "5", minimum = "1")
+    @Positive
+    private Integer maxFailedAttempts = 5;
+
+}

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.core.settings;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
@@ -7,6 +8,7 @@ import lombok.Data;
 import java.io.Serializable;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CertificateRegistrationSettingsUpdateDto implements Serializable {
 
     @Schema(description = "Default issuance window in days, applied when a pre-registration omits an explicit expiry", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "7", minimum = "1")

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateSettingsDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateSettingsDto.java
@@ -12,4 +12,6 @@ public class CertificateSettingsDto implements Serializable {
 
     private CertificateRequestAttributesSettingsDto requestAttributes;
 
+    private CertificateRegistrationSettingsDto registration;
+
 }

--- a/src/main/java/com/otilm/api/model/core/settings/CertificateSettingsUpdateDto.java
+++ b/src/main/java/com/otilm/api/model/core/settings/CertificateSettingsUpdateDto.java
@@ -16,4 +16,8 @@ public class CertificateSettingsUpdateDto implements Serializable {
     @Valid
     @Schema(description = "Platform default request-attribute set")
     private CertificateRequestAttributesSettingsUpdateDto requestAttributes;
+
+    @Valid
+    @Schema(description = "Certificate pre-registration settings")
+    private CertificateRegistrationSettingsUpdateDto registration;
 }

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
@@ -88,6 +88,7 @@ public class ClientCertificateIssueRequestDto {
     )
     private List<RequestAttribute> customAttributes;
 
+    @EqualsAndHashCode.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(
             description = "One-time authorization secret proving the caller may complete a pre-registered "

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDto.java
@@ -88,6 +88,8 @@ public class ClientCertificateIssueRequestDto {
     )
     private List<RequestAttribute> customAttributes;
 
+    // Format (@Size/@Pattern) is enforced at registration, not here: on the verify path a malformed secret
+    // must fail the challenge identically to a wrong one, so no format constraint is applied (no format oracle).
     @EqualsAndHashCode.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -7,9 +7,11 @@ import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.time.OffsetDateTime;
@@ -78,16 +80,20 @@ public class ClientCertificateRegistrationDto {
     private List<RequestAttribute> customAttributes;
 
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Size(min = 12, max = 255)
-    @Pattern(regexp = "\\p{Print}+", message = "authorizationSecret must be printable ASCII")
+    @Pattern(regexp = "[\\x20-\\x7E]+", message = "authorizationSecret must be printable ASCII")
     @Schema(
             description = "Authorization secret (challenge) that gates later issue/rekey of this "
-                    + "pre-registered certificate. Write-only; the operator supplies it (the platform never generates one).",
-            accessMode = Schema.AccessMode.WRITE_ONLY
+                    + "pre-registered certificate. Write-only and optional — the operator supplies it to opt the "
+                    + "registration into challenge-gated completion; the platform never generates one.",
+            accessMode = Schema.AccessMode.WRITE_ONLY,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String authorizationSecret;
 
+    @Future
     @Schema(
             description = "Optional absolute deadline by which the pre-registered certificate must be issued. "
                     + "When omitted, the platform applies the default registration issuance window.",

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -1,12 +1,18 @@
 package com.otilm.api.model.core.v2;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -71,12 +77,31 @@ public class ClientCertificateRegistrationDto {
     )
     private List<RequestAttribute> customAttributes;
 
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Size(min = 12, max = 255)
+    @Pattern(regexp = "\\p{Print}+", message = "authorizationSecret must be printable ASCII")
+    @Schema(
+            description = "Authorization secret (challenge) that gates later issue/rekey of this "
+                    + "pre-registered certificate. Write-only; the operator supplies it (the platform never generates one).",
+            accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    private String authorizationSecret;
+
+    @Schema(
+            description = "Optional absolute deadline by which the pre-registered certificate must be issued. "
+                    + "When omitted, the platform applies the default registration issuance window.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private OffsetDateTime expiresAt;
+
     /**
      * RFC 5280 §4.1.2.6: a certificate's subject identity may be carried in subjectDn, in the
      * subjectAltName extension, or both — but it cannot be empty in both. Connector-side issuance
      * will require subjectAltName to be marked critical when subjectDn is empty; the operator
      * input is checked here only for the basic "at least one is set" invariant.
      */
+    @JsonIgnore
     @AssertTrue(message = "At least one of subjectDn or subjectAltName must be non-empty (RFC 5280 §4.1.2.6)")
     @Schema(hidden = true)
     public boolean isSubjectIdentificationProvided() {

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
@@ -83,6 +83,8 @@ public class ClientCertificateRekeyRequestDto {
     )
     private List<RequestAttribute> altSignatureAttributes;
 
+    // Format (@Size/@Pattern) is enforced at registration, not here: on the verify path a malformed secret
+    // must fail the challenge identically to a wrong one, so no format constraint is applied (no format oracle).
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDto.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
@@ -83,6 +84,7 @@ public class ClientCertificateRekeyRequestDto {
     private List<RequestAttribute> altSignatureAttributes;
 
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(
             description = "One-time authorization secret for rekeying a certificate that has an active "

--- a/src/test/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDtoTest.java
@@ -1,0 +1,37 @@
+package com.otilm.api.model.core.certificate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class CertificateRegistrationDetailDtoTest {
+
+    private final ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
+
+    @Test
+    void registrationBlockRoundTrips() throws Exception {
+        CertificateRegistrationDetailDto reg = new CertificateRegistrationDetailDto();
+        reg.setState("ACTIVE");
+        reg.setExpiresAt(OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+        reg.setFailedAttempts(2);
+
+        CertificateRegistrationDetailDto back =
+                mapper.readValue(mapper.writeValueAsString(reg), CertificateRegistrationDetailDto.class);
+        assertEquals("ACTIVE", back.getState());
+        assertEquals(reg.getExpiresAt(), back.getExpiresAt());
+        assertEquals(2, back.getFailedAttempts());
+    }
+
+    @Test
+    void certificateDetailExposesRegistrationBlock() {
+        CertificateRegistrationDetailDto reg = new CertificateRegistrationDetailDto();
+        CertificateDetailDto detail = new CertificateDetailDto();
+        detail.setRegistration(reg);
+        assertSame(reg, detail.getRegistration());
+    }
+}

--- a/src/test/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/certificate/CertificateRegistrationDetailDtoTest.java
@@ -16,13 +16,13 @@ class CertificateRegistrationDetailDtoTest {
     @Test
     void registrationBlockRoundTrips() throws Exception {
         CertificateRegistrationDetailDto reg = new CertificateRegistrationDetailDto();
-        reg.setState("ACTIVE");
+        reg.setState(CertificateRegistrationState.ACTIVE);
         reg.setExpiresAt(OffsetDateTime.parse("2026-08-01T00:00:00Z"));
         reg.setFailedAttempts(2);
 
         CertificateRegistrationDetailDto back =
                 mapper.readValue(mapper.writeValueAsString(reg), CertificateRegistrationDetailDto.class);
-        assertEquals("ACTIVE", back.getState());
+        assertEquals(CertificateRegistrationState.ACTIVE, back.getState());
         assertEquals(reg.getExpiresAt(), back.getExpiresAt());
         assertEquals(2, back.getFailedAttempts());
     }

--- a/src/test/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDtoTest.java
@@ -1,0 +1,35 @@
+package com.otilm.api.model.core.settings;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CertificateRegistrationSettingsUpdateDtoTest {
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void defaultsAreValid() {
+        assertTrue(VALIDATOR.validate(new CertificateRegistrationSettingsUpdateDto()).isEmpty());
+    }
+
+    @Test
+    void rejectsNonPositiveWindowAndAttempts() {
+        CertificateRegistrationSettingsUpdateDto dto = new CertificateRegistrationSettingsUpdateDto();
+        dto.setDefaultIssuanceWindowDays(-1);
+        dto.setMaxFailedAttempts(0);
+        assertFalse(VALIDATOR.validate(dto).isEmpty(), "@Positive must reject <= 0");
+    }
+
+    @Test
+    void cascadesFromCertificateSettingsUpdate() {
+        CertificateSettingsUpdateDto parent = new CertificateSettingsUpdateDto();
+        CertificateRegistrationSettingsUpdateDto reg = new CertificateRegistrationSettingsUpdateDto();
+        reg.setMaxFailedAttempts(0);
+        parent.setRegistration(reg);
+        assertFalse(VALIDATOR.validate(parent).isEmpty(), "@Valid must cascade into the registration sub-DTO");
+    }
+}

--- a/src/test/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/settings/CertificateRegistrationSettingsUpdateDtoTest.java
@@ -4,6 +4,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,7 +22,7 @@ class CertificateRegistrationSettingsUpdateDtoTest {
         CertificateRegistrationSettingsUpdateDto dto = new CertificateRegistrationSettingsUpdateDto();
         dto.setDefaultIssuanceWindowDays(-1);
         dto.setMaxFailedAttempts(0);
-        assertFalse(VALIDATOR.validate(dto).isEmpty(), "@Positive must reject <= 0");
+        assertEquals(2, VALIDATOR.validate(dto).size(), "each @Positive field must be rejected independently");
     }
 
     @Test

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateIssueRequestDtoTest.java
@@ -31,4 +31,14 @@ class ClientCertificateIssueRequestDtoTest {
         dto.setAuthorizationSecret("s3cret");
         assertFalse(dto.toString().contains("s3cret"), "authorizationSecret must not appear in toString");
     }
+
+    @Test
+    void authorizationSecretIsExcludedFromEqualsAndHashCode() {
+        ClientCertificateIssueRequestDto a = new ClientCertificateIssueRequestDto();
+        a.setAuthorizationSecret("secret-a");
+        ClientCertificateIssueRequestDto b = new ClientCertificateIssueRequestDto();
+        b.setAuthorizationSecret("secret-b");
+        assertEquals(a, b, "authorizationSecret must not affect equals()");
+        assertEquals(a.hashCode(), b.hashCode(), "authorizationSecret must not affect hashCode()");
+    }
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
@@ -2,9 +2,14 @@ package com.otilm.api.model.core.v2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -13,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ClientCertificateRegistrationDtoTest {
 
     private final ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
     @Test
     void bothEmpty_failsRfc5280Constraint() {
@@ -64,6 +70,8 @@ class ClientCertificateRegistrationDtoTest {
         assertFalse(json.contains("authorizationSecret"), "write-only secret must never serialize back");
         assertFalse(json.contains("s3cret-value-1234"));
         assertTrue(json.contains("subjectDn"), "non-write-only fields must still serialize");
+        assertFalse(json.contains("subjectIdentificationProvided"),
+                "the @JsonIgnore'd @AssertTrue getter must not serialize");
     }
 
     @Test
@@ -81,5 +89,22 @@ class ClientCertificateRegistrationDtoTest {
         ClientCertificateRegistrationDto back =
                 mapper.readValue(mapper.writeValueAsString(dto), ClientCertificateRegistrationDto.class);
         assertEquals(dto.getExpiresAt(), back.getExpiresAt());
+    }
+
+    @Test
+    void authorizationSecretFormatIsEnforced() {
+        assertTrue(secretViolations("abcdefghijkl").isEmpty(), "a 12-char printable secret is valid");
+        assertFalse(secretViolations("abcdefghijk").isEmpty(), "an 11-char secret is too short");
+        assertFalse(secretViolations("a".repeat(256)).isEmpty(), "a 256-char secret is too long");
+        assertFalse(secretViolations("abcdefghijklé").isEmpty(), "a character outside printable ASCII is rejected");
+    }
+
+    private static Set<ConstraintViolation<ClientCertificateRegistrationDto>> secretViolations(String secret) {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setSubjectDn("CN=x");
+        dto.setAuthorizationSecret(secret);
+        return VALIDATOR.validate(dto).stream()
+                .filter(v -> v.getPropertyPath().toString().equals("authorizationSecret"))
+                .collect(Collectors.toSet());
     }
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
@@ -1,11 +1,18 @@
 package com.otilm.api.model.core.v2;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClientCertificateRegistrationDtoTest {
+
+    private final ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
 
     @Test
     void bothEmpty_failsRfc5280Constraint() {
@@ -44,5 +51,35 @@ class ClientCertificateRegistrationDtoTest {
         dto.setSubjectAltName("\t\n  ");
         assertFalse(dto.isSubjectIdentificationProvided(),
                 "Whitespace-only strings must not satisfy the subject-identification constraint");
+    }
+
+    @Test
+    void authorizationSecretIsAcceptedOnInputButNeverSerialized() throws Exception {
+        ClientCertificateRegistrationDto dto = mapper.readValue(
+                "{\"subjectDn\":\"CN=x\",\"authorizationSecret\":\"s3cret-value-1234\"}",
+                ClientCertificateRegistrationDto.class);
+        assertEquals("s3cret-value-1234", dto.getAuthorizationSecret());
+
+        String json = mapper.writeValueAsString(dto);
+        assertFalse(json.contains("authorizationSecret"), "write-only secret must never serialize back");
+        assertFalse(json.contains("s3cret-value-1234"));
+        assertTrue(json.contains("subjectDn"), "non-write-only fields must still serialize");
+    }
+
+    @Test
+    void toStringOmitsAuthorizationSecret() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setAuthorizationSecret("s3cret-value-1234");
+        assertFalse(dto.toString().contains("s3cret-value-1234"), "authorizationSecret must not appear in toString");
+    }
+
+    @Test
+    void expiresAtRoundTrips() throws Exception {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setSubjectDn("CN=x");
+        dto.setExpiresAt(OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+        ClientCertificateRegistrationDto back =
+                mapper.readValue(mapper.writeValueAsString(dto), ClientCertificateRegistrationDto.class);
+        assertEquals(dto.getExpiresAt(), back.getExpiresAt());
     }
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRekeyRequestDtoTest.java
@@ -29,4 +29,14 @@ class ClientCertificateRekeyRequestDtoTest {
         assertFalse(dto.toString().contains("s3cret"),
                 "authorizationSecret is @ToString.Exclude and must not appear in the generated toString");
     }
+
+    @Test
+    void authorizationSecretIsExcludedFromEqualsAndHashCode() {
+        ClientCertificateRekeyRequestDto a = new ClientCertificateRekeyRequestDto();
+        a.setAuthorizationSecret("secret-a");
+        ClientCertificateRekeyRequestDto b = new ClientCertificateRekeyRequestDto();
+        b.setAuthorizationSecret("secret-b");
+        assertEquals(a, b, "authorizationSecret must not affect equals()");
+        assertEquals(a.hashCode(), b.hashCode(), "authorizationSecret must not affect hashCode()");
+    }
 }


### PR DESCRIPTION
Closes #762.

Consolidated, additive registration-flow API contract so fe-administrator can regenerate its client once and build the whole registration UI, decoupled from core's implementation cadence.

- **`ClientCertificateRegistrationDto`** — write-only `authorizationSecret` (challenge; `@Size(12,255)` + printable-ASCII `@Pattern`) plus an optional `expiresAt`; added `@JsonIgnore` on `isSubjectIdentificationProvided()` so the derived boolean no longer serializes.
- **Settings** — new `CertificateRegistrationSettingsDto` (+ `…UpdateDto`) hung off `CertificateSettingsDto` / `…UpdateDto`, mirroring the `validation` pattern: `defaultIssuanceWindowDays`, `maxFailedAttempts`.
- **`CertificateDetailDto`** — read-only `registration` block (`CertificateRegistrationDetailDto`: state / expiresAt / failedAttempts).

All additive and backward-compatible; the operator always supplies the challenge (the platform never generates one). Write-only-contract, validation-cascade, and round-trip tests added; `mvn -o clean verify` = 409 tests green.

Unblocks fe-administrator#1693; consumed by core#1570.