### PR TITLE
Add structured csrAttributes to the register request DTO

### DIFF
--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -16,6 +16,7 @@ import lombok.ToString;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Request body for the {@code POST /certificates/register} operator endpoint.
@@ -39,8 +40,8 @@ public class ClientCertificateRegistrationDto {
             description = "Subject DN. Optional per RFC 5280 §4.1.2.6: an empty subject is permitted "
                     + "when subject naming information is carried entirely in the Subject Alternative "
                     + "Name extension (in which case the subjectAltName extension MUST be marked "
-                    + "critical at issuance). At least one of subjectDn or subjectAltName must be "
-                    + "non-empty — enforced by the cross-field {@code subjectIdentificationProvided} "
+                    + "critical at issuance). At least one of subjectDn, subjectAltName, or csrAttributes "
+                    + "must provide subject identity — enforced by the cross-field {@code subjectIdentificationProvided} "
                     + "constraint.",
             example = "CN=device-7,O=Acme",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
@@ -51,7 +52,8 @@ public class ClientCertificateRegistrationDto {
             description = "Subject Alternative Name in RFC 5280 textual form (e.g. DNS:foo,IP:1.2.3.4,email:x@y). "
                     + "SAN MUST be carried here ONLY — do not also include it as OID 2.5.29.17 in extensions[]. "
                     + "Connectors reject duplicate-source requests with VALIDATION_FAILED. "
-                    + "Required when subjectDn is empty (see RFC 5280 §4.1.2.6).",
+                    + "Provides subject identity when subjectDn is empty (see RFC 5280 §4.1.2.6); "
+                    + "csrAttributes is a further alternative.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String subjectAltName;
@@ -68,7 +70,8 @@ public class ClientCertificateRegistrationDto {
             description = "Structured request-attribute identity content (subject RDNs, SANs, extensions) — the "
                     + "typed alternative to the flat subjectDn/subjectAltName/extensions above, mirroring the issue "
                     + "path. When provided, the platform projects it into the registration identity; the flat fields "
-                    + "remain the simple/compatibility shape.",
+                    + "remain the simple/compatibility shape. When both are supplied, the register handling defines "
+                    + "the precedence.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private List<RequestAttribute> csrAttributes;
@@ -123,6 +126,6 @@ public class ClientCertificateRegistrationDto {
     public boolean isSubjectIdentificationProvided() {
         return (subjectDn != null && !subjectDn.isBlank())
                 || (subjectAltName != null && !subjectAltName.isBlank())
-                || (csrAttributes != null && !csrAttributes.isEmpty());
+                || (csrAttributes != null && csrAttributes.stream().anyMatch(Objects::nonNull));
     }
 }

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -65,6 +65,15 @@ public class ClientCertificateRegistrationDto {
     private List<CertificateExtension> extensions;
 
     @Schema(
+            description = "Structured request-attribute identity content (subject RDNs, SANs, extensions) — the "
+                    + "typed alternative to the flat subjectDn/subjectAltName/extensions above, mirroring the issue "
+                    + "path. When provided, the platform projects it into the registration identity; the flat fields "
+                    + "remain the simple/compatibility shape.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<RequestAttribute> csrAttributes;
+
+    @Schema(
             description = "Authority-defined registration attributes (e.g., subject DN template, validity hints)."
     )
     private List<RequestAttribute> attributes;
@@ -103,15 +112,17 @@ public class ClientCertificateRegistrationDto {
 
     /**
      * RFC 5280 §4.1.2.6: a certificate's subject identity may be carried in subjectDn, in the
-     * subjectAltName extension, or both — but it cannot be empty in both. Connector-side issuance
-     * will require subjectAltName to be marked critical when subjectDn is empty; the operator
-     * input is checked here only for the basic "at least one is set" invariant.
+     * subjectAltName extension, or both — but it cannot be empty in both. Structured identity may
+     * instead arrive via csrAttributes (projected connector-side into a subject/SAN). Connector-side
+     * issuance will require subjectAltName to be marked critical when subjectDn is empty; the operator
+     * input is checked here only for the basic "at least one identity source is set" invariant.
      */
     @JsonIgnore
-    @AssertTrue(message = "At least one of subjectDn or subjectAltName must be non-empty (RFC 5280 §4.1.2.6)")
+    @AssertTrue(message = "At least one of subjectDn, subjectAltName, or csrAttributes must provide subject identity (RFC 5280 §4.1.2.6)")
     @Schema(hidden = true)
     public boolean isSubjectIdentificationProvided() {
         return (subjectDn != null && !subjectDn.isBlank())
-                || (subjectAltName != null && !subjectAltName.isBlank());
+                || (subjectAltName != null && !subjectAltName.isBlank())
+                || (csrAttributes != null && !csrAttributes.isEmpty());
     }
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
@@ -2,12 +2,14 @@ package com.otilm.api.model.core.v2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.otilm.api.model.client.attribute.RequestAttributeV2;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,6 +50,14 @@ class ClientCertificateRegistrationDtoTest {
         dto.setSubjectDn("CN=device-7");
         dto.setSubjectAltName("DNS:device-7.example.com");
         assertTrue(dto.isSubjectIdentificationProvided());
+    }
+
+    @Test
+    void csrAttributesOnly_providesIdentity() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setCsrAttributes(List.of(new RequestAttributeV2()));
+        assertTrue(dto.isSubjectIdentificationProvided(),
+                "structured csrAttributes is an accepted identity source alongside flat subjectDn/subjectAltName");
     }
 
     @Test

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
@@ -9,6 +9,7 @@ import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,6 +59,22 @@ class ClientCertificateRegistrationDtoTest {
         dto.setCsrAttributes(List.of(new RequestAttributeV2()));
         assertTrue(dto.isSubjectIdentificationProvided(),
                 "structured csrAttributes is an accepted identity source alongside flat subjectDn/subjectAltName");
+    }
+
+    @Test
+    void csrAttributesEmptyList_doesNotProvideIdentity() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setCsrAttributes(List.of());
+        assertFalse(dto.isSubjectIdentificationProvided(),
+                "an empty csrAttributes list is not an identity source");
+    }
+
+    @Test
+    void csrAttributesOnlyNullElements_doesNotProvideIdentity() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setCsrAttributes(Collections.singletonList(null));
+        assertFalse(dto.isSubjectIdentificationProvided(),
+                "a csrAttributes list of only null elements carries no identity");
     }
 
     @Test


### PR DESCRIPTION
Part of #1788.

Adds an optional `csrAttributes` (`List<RequestAttribute>`) to `ClientCertificateRegistrationDto` — the structured request-attribute identity input, mirroring the issue DTO. It is the typed alternative to the flat `subjectDn`/`subjectAltName`/`extensions`, which remain the simple/compatibility shape.

- **Additive and backward-compatible** — a request that omits `csrAttributes` behaves exactly as before.
- `isSubjectIdentificationProvided()` now also accepts a non-empty `csrAttributes` as an identity source, so a structured-only registration is valid.

Unblocks the register form's shared request-attribute editor (fe#1779) in fe-administrator#1693 once this is cut into the SNAPSHOT; core wires the projection (existing ilm#131 projector) under #1788.

Build: `mvn -o -B clean verify` green (413 tests).