### PR TITLE
Clarify register identity is csrAttributes or flat, not both

### DIFF
--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -69,9 +69,9 @@ public class ClientCertificateRegistrationDto {
     @Schema(
             description = "Structured request-attribute identity content (subject RDNs, SANs, extensions) — the "
                     + "typed alternative to the flat subjectDn/subjectAltName/extensions above, mirroring the issue "
-                    + "path. When provided, the platform projects it into the registration identity; the flat fields "
-                    + "remain the simple/compatibility shape. When both are supplied, the register handling defines "
-                    + "the precedence.",
+                    + "path. When provided, the platform projects it into the registration identity; the flat "
+                    + "subjectDn/subjectAltName/extensions are the simple alternative. Provide the identity via "
+                    + "csrAttributes OR the flat fields, not both.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private List<RequestAttribute> csrAttributes;

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -128,4 +128,21 @@ public class ClientCertificateRegistrationDto {
                 || (subjectAltName != null && !subjectAltName.isBlank())
                 || (csrAttributes != null && csrAttributes.stream().anyMatch(Objects::nonNull));
     }
+
+    /**
+     * The pre-registration identity comes either from structured csrAttributes or from the flat
+     * subjectDn/subjectAltName/extensions fields — never both. Mixing the two forms is ambiguous
+     * (which one defines the placeholder subject?), so it is rejected at the contract boundary
+     * rather than surfacing as a less specific error from register handling.
+     */
+    @JsonIgnore
+    @AssertTrue(message = "Provide the pre-registration identity via csrAttributes or the flat subjectDn/subjectAltName/extensions fields, not both")
+    @Schema(hidden = true)
+    public boolean isSingleIdentitySource() {
+        boolean structured = csrAttributes != null && csrAttributes.stream().anyMatch(Objects::nonNull);
+        boolean flat = (subjectDn != null && !subjectDn.isBlank())
+                || (subjectAltName != null && !subjectAltName.isBlank())
+                || (extensions != null && !extensions.isEmpty());
+        return !(structured && flat);
+    }
 }

--- a/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
+++ b/src/test/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDtoTest.java
@@ -3,6 +3,7 @@ package com.otilm.api.model.core.v2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.otilm.api.model.client.attribute.RequestAttributeV2;
+import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -75,6 +76,59 @@ class ClientCertificateRegistrationDtoTest {
         dto.setCsrAttributes(Collections.singletonList(null));
         assertFalse(dto.isSubjectIdentificationProvided(),
                 "a csrAttributes list of only null elements carries no identity");
+    }
+
+    @Test
+    void csrAttributesWithFlatFields_violatesMutualExclusion() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setSubjectDn("CN=device-7");
+        dto.setCsrAttributes(List.of(new RequestAttributeV2()));
+        assertFalse(dto.isSingleIdentitySource(),
+                "supplying both csrAttributes and a flat identity field is ambiguous and must be rejected");
+        assertFalse(mutualExclusionViolations(dto).isEmpty(),
+                "the @AssertTrue constraint must surface as a bean-validation violation");
+    }
+
+    @Test
+    void csrAttributesWithFlatExtensionsOnly_violatesMutualExclusion() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setExtensions(List.of(new CertificateExtension()));
+        dto.setCsrAttributes(List.of(new RequestAttributeV2()));
+        assertFalse(dto.isSingleIdentitySource(),
+                "flat extensions alongside csrAttributes is still the mixed form");
+    }
+
+    @Test
+    void csrAttributesAlone_satisfiesMutualExclusion() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setCsrAttributes(List.of(new RequestAttributeV2()));
+        assertTrue(dto.isSingleIdentitySource());
+        assertTrue(mutualExclusionViolations(dto).isEmpty());
+    }
+
+    @Test
+    void flatFieldsAlone_satisfyMutualExclusion() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setSubjectDn("CN=device-7");
+        dto.setSubjectAltName("DNS:device-7.example.com");
+        assertTrue(dto.isSingleIdentitySource());
+        assertTrue(mutualExclusionViolations(dto).isEmpty());
+    }
+
+    @Test
+    void nullElementCsrAttributesWithFlat_notMixed() {
+        ClientCertificateRegistrationDto dto = new ClientCertificateRegistrationDto();
+        dto.setSubjectDn("CN=device-7");
+        dto.setCsrAttributes(Collections.singletonList(null));
+        assertTrue(dto.isSingleIdentitySource(),
+                "a csrAttributes list carrying no real element is not the structured form, so no conflict with flat");
+    }
+
+    private static Set<ConstraintViolation<ClientCertificateRegistrationDto>> mutualExclusionViolations(
+            ClientCertificateRegistrationDto dto) {
+        return VALIDATOR.validate(dto).stream()
+                .filter(v -> v.getPropertyPath().toString().equals("singleIdentitySource"))
+                .collect(Collectors.toSet());
     }
 
     @Test


### PR DESCRIPTION
Part of #1788 (follow-up to #769).

core#1789 rejects a register request that supplies both structured `csrAttributes` and the flat `subjectDn`/`subjectAltName`/`extensions`. The `ClientCertificateRegistrationDto.csrAttributes` `@Schema` previously said "when both are supplied, the register handling defines the precedence" — misleading now. Reworded to state the two identity forms are **mutually exclusive**: provide identity via `csrAttributes` OR the flat fields, not both.

Doc-only (`@Schema` description); no wire/behavior change.