### PR TITLE
Add CERTIFICATE_REGISTERED event type and payload

### DIFF
--- a/src/main/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventData.java
+++ b/src/main/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventData.java
@@ -1,0 +1,32 @@
+package com.otilm.api.model.common.events.data;
+
+import com.otilm.api.model.common.attribute.v1.content.ZonedDateTimeDeserializer;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.ZonedDateTime;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class CertificateRegisteredEventData extends CertificateEventAuthorityData {
+
+    @Schema(description = "Deadline by which the pre-registered certificate must be issued, in \"yyyy-MM-dd'T'HH:mm:ssXXX\" format")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+    @JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+    @JsonSerialize(using = ZonedDateTimeSerializer.class)
+    private ZonedDateTime issuanceDeadline;
+
+    // The one-time credential (pre-registration challenge) the recipient presents to complete issuance. It is
+    // serialized to external notification providers, but excluded from toString and equals/hashCode so it cannot
+    // leak into logs or tracing spans (both event envelopes carry this object in their toString).
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @Schema(description = "One-time credential the recipient presents to complete issuance on the public portal")
+    private String credential;
+}

--- a/src/main/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventData.java
+++ b/src/main/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventData.java
@@ -16,15 +16,19 @@ import java.time.ZonedDateTime;
 @Data
 public class CertificateRegisteredEventData extends CertificateEventAuthorityData {
 
-    @Schema(description = "Deadline by which the pre-registered certificate must be issued, in \"yyyy-MM-dd'T'HH:mm:ssXXX\" format")
+    @Schema(description = "Deadline by which the completion request must be presented — a valid challenge must be "
+            + "supplied before this instant. It gates the completion request, not final issuance: an approved or "
+            + "otherwise asynchronous completion may finalize shortly after. Format \"yyyy-MM-dd'T'HH:mm:ssXXX\".")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
     @JsonDeserialize(using = ZonedDateTimeDeserializer.class)
     @JsonSerialize(using = ZonedDateTimeSerializer.class)
-    private ZonedDateTime issuanceDeadline;
+    private ZonedDateTime completionDeadline;
 
-    // The one-time credential (pre-registration challenge) the recipient presents to complete issuance. It is
-    // serialized to external notification providers, but excluded from toString and equals/hashCode so it cannot
-    // leak into logs or tracing spans (both event envelopes carry this object in their toString).
+    // The one-time credential (the pre-registration challenge the operator supplied as authorizationSecret) that the
+    // recipient presents to complete issuance. Serialized to external notification providers, but excluded from
+    // toString and equals/hashCode so it cannot leak into logs or tracing spans (both event envelopes carry this
+    // object in their toString). That exclusion covers the toString path only — downstream must not JSON-log or
+    // persist the event payload; core keeps the credential out of internal notifications and event-history.
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     @Schema(description = "One-time credential the recipient presents to complete issuance on the public portal")

--- a/src/main/java/com/otilm/api/model/core/other/ResourceEvent.java
+++ b/src/main/java/com/otilm/api/model/core/other/ResourceEvent.java
@@ -24,6 +24,7 @@ public enum ResourceEvent implements IPlatformEnum {
     CERTIFICATE_EXPIRING(Codes.CERTIFICATE_EXPIRING, "Certificate expiring", "Event to trigger actions associated with expiring certificates without renewal", Resource.CERTIFICATE, List.of(Resource.RA_PROFILE, Resource.GROUP), CertificateExpiringEventData.class, true),
     CERTIFICATE_NOT_COMPLIANT(Codes.CERTIFICATE_NOT_COMPLIANT, "Certificate not compliant", "Event when the certificate is evaluated as not compliant", Resource.CERTIFICATE, List.of(Resource.RA_PROFILE), CertificateNotCompliantEventData.class, false),
     CERTIFICATE_UPLOADED(Codes.CERTIFICATE_UPLOADED, "Certificate uploaded", "Event when the certificate has been uploaded", Resource.CERTIFICATE, CertificateEventData.class, false),
+    CERTIFICATE_REGISTERED(Codes.CERTIFICATE_REGISTERED, "Certificate registered", "Event when a certificate has been successfully pre-registered, carrying the credential and issuance deadline to complete issuance", Resource.CERTIFICATE, CertificateRegisteredEventData.class, false),
 
     // Discoveries
     DISCOVERY_FINISHED(Codes.DISCOVERY_FINISHED, "Discovery Finished", "Event when discovery has been finished.", Resource.DISCOVERY, DiscoveryFinishedEventData.class, false),
@@ -103,6 +104,7 @@ public enum ResourceEvent implements IPlatformEnum {
         public static final String CERTIFICATE_DISCOVERED = "certificate_discovered";
         public static final String CERTIFICATE_EXPIRING = "certificate_expiring";
         public static final String CERTIFICATE_UPLOADED = "certificate_uploaded";
+        public static final String CERTIFICATE_REGISTERED = "certificate_registered";
 
         public static final String DISCOVERY_FINISHED = "discovery_finished";
 

--- a/src/main/java/com/otilm/api/model/core/other/ResourceEvent.java
+++ b/src/main/java/com/otilm/api/model/core/other/ResourceEvent.java
@@ -24,7 +24,7 @@ public enum ResourceEvent implements IPlatformEnum {
     CERTIFICATE_EXPIRING(Codes.CERTIFICATE_EXPIRING, "Certificate expiring", "Event to trigger actions associated with expiring certificates without renewal", Resource.CERTIFICATE, List.of(Resource.RA_PROFILE, Resource.GROUP), CertificateExpiringEventData.class, true),
     CERTIFICATE_NOT_COMPLIANT(Codes.CERTIFICATE_NOT_COMPLIANT, "Certificate not compliant", "Event when the certificate is evaluated as not compliant", Resource.CERTIFICATE, List.of(Resource.RA_PROFILE), CertificateNotCompliantEventData.class, false),
     CERTIFICATE_UPLOADED(Codes.CERTIFICATE_UPLOADED, "Certificate uploaded", "Event when the certificate has been uploaded", Resource.CERTIFICATE, CertificateEventData.class, false),
-    CERTIFICATE_REGISTERED(Codes.CERTIFICATE_REGISTERED, "Certificate registered", "Event when a certificate has been successfully pre-registered, carrying the credential and issuance deadline to complete issuance", Resource.CERTIFICATE, CertificateRegisteredEventData.class, false),
+    CERTIFICATE_REGISTERED(Codes.CERTIFICATE_REGISTERED, "Certificate registered", "Event when a certificate has been successfully pre-registered, carrying the credential and completion deadline to complete issuance", Resource.CERTIFICATE, List.of(Resource.RA_PROFILE, Resource.GROUP), CertificateRegisteredEventData.class, false),
 
     // Discoveries
     DISCOVERY_FINISHED(Codes.DISCOVERY_FINISHED, "Discovery Finished", "Event when discovery has been finished.", Resource.DISCOVERY, DiscoveryFinishedEventData.class, false),

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -110,8 +110,11 @@ public class ClientCertificateRegistrationDto {
 
     @Future
     @Schema(
-            description = "Optional absolute deadline by which the pre-registered certificate must be issued. "
-                    + "When omitted, the platform applies the default registration issuance window.",
+            description = "Optional absolute deadline by which the completion request must be presented — a valid "
+                    + "challenge must be supplied before this instant. It gates the completion request, not the "
+                    + "final issuance: when the request is approved or otherwise processed asynchronously, issuance "
+                    + "may finalize shortly after the deadline. When omitted, the platform applies the default "
+                    + "registration issuance window.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private OffsetDateTime expiresAt;

--- a/src/test/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventDataTest.java
+++ b/src/test/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventDataTest.java
@@ -1,0 +1,32 @@
+package com.otilm.api.model.common.events.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class CertificateRegisteredEventDataTest {
+
+    @Test
+    void toStringExcludesCredential() {
+        CertificateRegisteredEventData data = new CertificateRegisteredEventData();
+        data.setSubjectDn("CN=device-7");
+        data.setIssuanceDeadline(ZonedDateTime.parse("2026-08-01T00:00:00Z"));
+        data.setCredential("s3cret-challenge-value");
+
+        String rendered = data.toString();
+        assertFalse(rendered.contains("s3cret-challenge-value"),
+                "the credential must never appear in toString (both event envelopes carry this object in their toString → logs/tracing spans)");
+        assertFalse(rendered.contains("credential"), "the credential field must be excluded from toString");
+    }
+
+    @Test
+    void credentialIsReadableForExternalDelivery() {
+        CertificateRegisteredEventData data = new CertificateRegisteredEventData();
+        data.setCredential("s3cret");
+        // Still accessible (and JSON-serializable) so the external notification provider receives it.
+        assertEquals("s3cret", data.getCredential());
+    }
+}

--- a/src/test/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventDataTest.java
+++ b/src/test/java/com/otilm/api/model/common/events/data/CertificateRegisteredEventDataTest.java
@@ -1,32 +1,54 @@
 package com.otilm.api.model.common.events.data;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CertificateRegisteredEventDataTest {
 
+    private final ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
+
     @Test
-    void toStringExcludesCredential() {
+    void toStringExcludesCredentialButKeepsOtherFields() {
         CertificateRegisteredEventData data = new CertificateRegisteredEventData();
-        data.setSubjectDn("CN=device-7");
-        data.setIssuanceDeadline(ZonedDateTime.parse("2026-08-01T00:00:00Z"));
+        data.setCompletionDeadline(ZonedDateTime.parse("2026-08-01T00:00:00Z"));
         data.setCredential("s3cret-challenge-value");
 
         String rendered = data.toString();
         assertFalse(rendered.contains("s3cret-challenge-value"),
                 "the credential must never appear in toString (both event envelopes carry this object in their toString → logs/tracing spans)");
         assertFalse(rendered.contains("credential"), "the credential field must be excluded from toString");
+        assertTrue(rendered.contains("completionDeadline"),
+                "a non-excluded field must still render — proves the exclusion is selective, not an empty toString");
     }
 
     @Test
-    void credentialIsReadableForExternalDelivery() {
+    void credentialSerializesToJsonForExternalDelivery() throws Exception {
         CertificateRegisteredEventData data = new CertificateRegisteredEventData();
-        data.setCredential("s3cret");
-        // Still accessible (and JSON-serializable) so the external notification provider receives it.
-        assertEquals("s3cret", data.getCredential());
+        data.setCredential("s3cret-challenge-value");
+
+        String json = mapper.writeValueAsString(data);
+        // The whole design depends on the credential reaching external notification providers via JSON — a stray
+        // @JsonIgnore (plausible next to the toString/equals exclusions) would silently break delivery.
+        assertTrue(json.contains("s3cret-challenge-value"), "the credential must serialize to JSON for external delivery");
+
+        CertificateRegisteredEventData back = mapper.readValue(json, CertificateRegisteredEventData.class);
+        assertEquals("s3cret-challenge-value", back.getCredential(), "the credential must round-trip through JSON");
+    }
+
+    @Test
+    void credentialExcludedFromEqualsAndHashCode() {
+        CertificateRegisteredEventData a = new CertificateRegisteredEventData();
+        a.setCredential("secret-a");
+        CertificateRegisteredEventData b = new CertificateRegisteredEventData();
+        b.setCredential("secret-b");
+        assertEquals(a, b, "the credential must not affect equals()");
+        assertEquals(a.hashCode(), b.hashCode(), "the credential must not affect hashCode()");
     }
 }


### PR DESCRIPTION
Part of #1571. Adds the `CERTIFICATE_REGISTERED` event type + payload that core fires when a certificate is pre-registered.

- `ResourceEvent.CERTIFICATE_REGISTERED` (+ `Codes` constant) — resource CERTIFICATE, `monitoring=false` (one-shot), payload `CertificateRegisteredEventData`.
- `CertificateRegisteredEventData` extends `CertificateEventAuthorityData` and adds `issuanceDeadline` and `credential` (the one-time challenge the recipient presents to complete issuance). `credential` is JSON-serialized so external notification providers deliver it, but **excluded from `toString` and `equals`/`hashCode`** so it cannot leak into logs or tracing spans (both event envelopes carry this object in their `toString`).
- Clarifies the register `expiresAt` description: it gates the **completion request** (a valid challenge before the deadline), not final issuance — an approved/async completion may finalize shortly after.

Consumed by the core handler + firing (core#1571). No behavior on its own.
