### PR TITLE
Document empty dependsOn semantics on the AttributeCallback schema

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/AuthorityInstanceController.java
@@ -113,7 +113,7 @@ public interface AuthorityInstanceController extends AuthProtectedController {
     @Operation(summary = "List RA Profile Attributes")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attribute information retrieved")})
     @GetMapping(path = "/{uuid}/attributes/raProfile", produces = {"application/json"})
-    List<BaseAttribute> listRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid) throws ConnectorException, NotFoundException;
+    List<BaseAttribute> listRAProfileAttributes(@Parameter(description = "Authority instance UUID") @PathVariable String uuid) throws ConnectorException, NotFoundException, AttributeException;
 
     @Operation(summary = "Validate RA Profile Attributes")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Attribute information validated"),

--- a/src/main/java/com/otilm/api/model/common/attribute/common/callback/AttributeCallback.java
+++ b/src/main/java/com/otilm/api/model/common/attribute/common/callback/AttributeCallback.java
@@ -40,9 +40,12 @@ public class AttributeCallback implements Serializable {
      * the legacy v1/v2 deserialization path. An empty (non-null) list means "fire on form open".
      */
     @Schema(
-            description = "Names of the attributes this Attributes v2 callback consumes and is triggered by. "
-                    + "Marks an NG (Attributes v2) callback; at most one of dependsOn / callbackContext may be set "
-                    + "(neither = no callback). Forbidden on RESOURCE attributes. Enforced by Core.",
+            description = "Names of the attributes, within this same form, whose values this Attributes v2 "
+                    + "callback consumes and is triggered by. Providing this field — even as an empty list — "
+                    + "marks the callback as an Attributes v2 callback; an empty list means the callback fires "
+                    + "once when the form opens (it depends on no other field). At most one of dependsOn or "
+                    + "callbackContext may be set; a callback with neither field set defines no callback. "
+                    + "Not allowed on RESOURCE attributes. These rules are enforced by the platform.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private List<String> dependsOn;


### PR DESCRIPTION
## What

Clarify the `AttributeCallback.dependsOn` `@Schema` description so the empty-list case is explicit. Doc-only annotation change — no behavior.

## Why

The description said "(neither = no callback)" but never stated what an **empty** (non-null) list means, so consumers generating clients from the published OpenAPI (the polyglot connector fleet) could not distinguish an empty list from an absent field. The class Javadoc already documents "empty (non-null) list = fire on form open"; this brings the published `@Schema` prose in line with it.

## Contract now stated

- Providing `dependsOn` — even as an empty list — marks the callback as an Attributes v2 callback.
- An empty list means the callback fires once when the form opens (depends on no other field).
- Only when neither `dependsOn` nor `callbackContext` is set is there no callback.
- Names are form-scoped (siblings only); parent-scope inputs arrive via `contextAttributes`, not `dependsOn`.

## Context

Part of the Attributes v2 empty-`dependsOn` reconciliation, epic OmniTrustILM/ilm#251. Sibling items:

- OmniTrustILM/core#1807 — dispatch an empty `dependsOn` as an NG fire-on-mount callback (drop the `!isEmpty()` gate), plus first-open definition resolution and a `currentAttributes` null→`[]` coalesce.
- OmniTrustILM/fe-administrator#1764 — FE fire-on-mount for empty `dependsOn` (blocked on core#1807).
- OmniTrustILM/ms-adcs-ng-connector#26 — connector declares an empty `dependsOn` for the certificate-template dropdown.

## Testing

Doc-only string literal — no runtime behavior to exercise. The OpenAPI doc-quality guard (`AttributesControllerDocTest`) scans controller `@Operation` prose only, not model `@Schema` fields, so it is unaffected.
