### PR TITLE
Reflect platform-level pre-registration in register endpoint docs

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -345,20 +345,21 @@ public interface ClientOperationController extends AuthProtectedController {
 			throws NotFoundException;
 
 	@Operation(
-			summary = "Pre-register a certificate with the upstream CA",
+			summary = "Pre-register a certificate",
 			description = """
-					Reserves a slot at the CA for a certificate that will be issued later. Returns
-					a tracking handle (in metadata) that can be used to complete the issuance via
-					the standard issue flow.
+					Pre-registers a certificate that will be issued later, returning its UUID; completion runs
+					through the standard issue flow.
 
-					Only supported on v3 authorities advertising the `CERTIFICATE_REGISTRATION`
-					feature flag. The operation may complete synchronously (200) or asynchronously
-					(202 with status polling).
+					When the authority's connector supports registration (a v3 connector advertising the
+					`CERTIFICATE_REGISTRATION` feature flag), the registration is made with the upstream CA and may
+					complete synchronously (200) or asynchronously (202 with status polling), returning a tracking
+					handle in metadata. Otherwise the certificate is pre-registered at the platform level with no
+					connector call — a platform-level pre-registration does not imply a CA-side end-entity exists.
 					"""
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Registration accepted; tracking handle returned"),
-			@ApiResponse(responseCode = "422", description = "Authority does not support registration",
+			@ApiResponse(responseCode = "200", description = "Certificate pre-registered"),
+			@ApiResponse(responseCode = "422", description = "Invalid registration request",
 					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
 	})
 	@PostMapping(path = "/certificates/register", consumes = {"application/json"}, produces = {"application/json"})

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -347,14 +347,14 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Pre-register a certificate",
 			description = """
-					Pre-registers a certificate that will be issued later, returning its UUID; completion runs
-					through the standard issue flow.
+					Pre-registers a certificate that will be issued later; the response carries the pre-registered
+					certificate's UUID, and completion runs through the standard issue flow.
 
 					When the authority's connector supports registration (a v3 connector advertising the
-					`CERTIFICATE_REGISTRATION` feature flag), the registration is made with the upstream CA and may
-					complete synchronously (200) or asynchronously (202 with status polling), returning a tracking
-					handle in metadata. Otherwise the certificate is pre-registered at the platform level with no
-					connector call — a platform-level pre-registration does not imply a CA-side end-entity exists.
+					`CERTIFICATE_REGISTRATION` feature flag), the registration is made with the upstream CA; otherwise
+					the certificate is pre-registered at the platform level with no connector call — a platform-level
+					pre-registration does not imply a CA-side end-entity exists. Connector-side completion may be
+					asynchronous; it is tracked server-side and finished through the issue flow.
 					"""
 	)
 	@ApiResponses(value = {


### PR DESCRIPTION
Companion doc update to core#1816 / core#1820 (platform-level pre-registration).

Core now pre-registers a certificate at the platform level when the RA Profile's connector does not support registration, instead of rejecting. The register endpoint contract doc drifted:

- `@Operation` said registration is "Only supported on v3 authorities advertising the `CERTIFICATE_REGISTRATION` feature flag" and "Reserves a slot at the CA" — no longer true for the platform-level path.
- The `422` `@ApiResponse` was described as "Authority does not support registration", a response that path no longer emits.

This rewords the `@Operation` description to cover both the connector-backed and platform-level paths (noting a platform-level pre-registration does not imply a CA-side end-entity), and changes the `422` description to "Invalid registration request" (bad window / ambiguous identity / invalid csrAttributes still 422). Doc/OpenAPI only — no contract or signature change.
