### PR TITLE
Add system OID listing endpoint to Custom OID API

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/web/CustomOidEntryController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/web/CustomOidEntryController.java
@@ -55,6 +55,12 @@ public interface CustomOidEntryController extends AuthProtectedController {
     @PostMapping(path = "/list", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     CustomOidEntryListResponseDto listCustomOidEntries(@RequestBody SearchRequestDto searchRequestDto);
 
+    @Operation(summary = "List built-in system OID entries, optionally filtered by category")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "System OID entries retrieved")})
+    @GetMapping(path = "/system", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<CustomOidEntryDetailResponseDto> listSystemOidEntries(
+            @Parameter(description = "Optional OID category filter") @RequestParam(required = false) OidCategory category);
+
     @Operation(operationId = "getCustomOidEntrySearchableFields", summary = "Get searchable filter fields for custom OID entries")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Searchable fields retrieved")})
     @GetMapping(path = "/search", produces = MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## What

Adds `GET /v1/oids/system` to `CustomOidEntryController`, returning the built-in `SystemOid` entries (standard RDN attribute types, EKUs, generic OIDs) with an optional `category` query-param filter.

## Why

The DB-backed `POST /v1/oids/list` returns only custom OID entries. Clients that must offer selectable OID values — e.g. the RDN mapping-target dropdown in fe-administrator#1874 — cannot list standard RDNs (CN, O, OU, …) without this. Response reuses `CustomOidEntryDetailResponseDto`, so clients merge system and custom OIDs on a single shape.

## Notes

Contract-only change; implementation is in the `core` PR. Part of epic OmniTrustILM/ilm#131. Backend issue: OmniTrustILM/core#1825.