### PR TITLE
Add optional owner and groups to certificate registration DTO

### DIFF
--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateRegistrationDto.java
@@ -17,6 +17,8 @@ import lombok.ToString;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Request body for the {@code POST /certificates/register} operator endpoint.
@@ -90,6 +92,22 @@ public class ClientCertificateRegistrationDto {
             description = "List of Custom Attributes"
     )
     private List<RequestAttribute> customAttributes;
+
+    @Schema(
+            description = "Optional UUID of the user to set as the certificate owner at registration. When "
+                    + "omitted, the registering user becomes the owner. The value set here is preserved when the "
+                    + "pre-registered certificate is later issued.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String ownerUuid;
+
+    @Schema(
+            description = "Optional set of group UUIDs to associate with the certificate at registration. When "
+                    + "provided, it replaces any existing group set. The groups set here are preserved when the "
+                    + "pre-registered certificate is later issued.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private Set<UUID> groupUuids;
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude


### PR DESCRIPTION
## What

Adds two optional properties to `ClientCertificateRegistrationDto`:

- `String ownerUuid` — UUID of the user to set as the certificate owner at registration. When omitted, the registering user becomes the owner.
- `Set<UUID> groupUuids` — group UUIDs to associate with the certificate at registration (replaces any existing group set).

Both are optional and documented as `NOT_REQUIRED`. The values are preserved when the pre-registered certificate is later issued.

## Why

Supports OmniTrustILM/core#1835 — certificate registration currently has no way to preset the owner or groups. The core-side consumption (persisting these on the placeholder at registration) is in the companion core PR.

## Note

Consumed by core PR `owner-groups-cert-registration-1835`. Merge and publish this SNAPSHOT before the core PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)