### PR TITLE
Add interfaceUuid to attribute callback request DTO

### DIFF
--- a/src/main/java/com/otilm/api/model/common/attribute/common/callback/RequestAttributeCallback.java
+++ b/src/main/java/com/otilm/api/model/common/attribute/common/callback/RequestAttributeCallback.java
@@ -69,6 +69,7 @@ public class RequestAttributeCallback {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("name", name)
                 .append("uuid", uuid)
+                .append("interfaceUuid", interfaceUuid)
                 .append("pathVariable", pathVariable)
                 .append("requestParameter", requestParameter)
                 .append("body", body)

--- a/src/main/java/com/otilm/api/model/common/attribute/common/callback/RequestAttributeCallback.java
+++ b/src/main/java/com/otilm/api/model/common/attribute/common/callback/RequestAttributeCallback.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
@@ -20,6 +21,13 @@ public class RequestAttributeCallback {
 
     @Schema(description = "UUID of the Attribute")
     private String uuid;
+
+    @Schema(
+            description = "Connector-interface row UUID the form was listed under. Identifies the interface version "
+                    + "the callback belongs to for parent-less (Attributes v2) forms.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private UUID interfaceUuid;
 
     @Schema(description = "Name of the Attribute",
             requiredMode = Schema.RequiredMode.REQUIRED)


### PR DESCRIPTION
Adds an optional `interfaceUuid` (UUID) to `RequestAttributeCallback`.

NG (`dependsOn`) callbacks on parent-less connector forms — the connector/authority instance create-edit form — dispatch via the connector callback route (`POST /v2/connectors/{uuid}/callback`), which has no parent scope object for Core to derive the form's interface from. The field carries the connector-interface row UUID the form was listed under, so Core stamps the dispatched envelope's `connectorInterface`/`interfaceVersion` and disambiguates parallel NG interface versions on one connector.

Optional; unused on resource-scoped routes, which derive the interface from the scoped object.

Consumed by the core connector-route NG dispatch (OmniTrustILM/core#1842). Part of the Connector Attributes v2 API epic ilm#251.