### PR TITLE
Add register-attributes endpoint and certificate-detail register fields

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -251,6 +251,16 @@ public interface ClientOperationController extends AuthProtectedController {
 			@RequestBody List<RequestAttribute>attributes) throws ConnectorException, ValidationException, NotFoundException;
 
 	@Operation(
+			summary = "Get registration attributes",
+			description = "Return the list of attributes the client must populate when pre-registering a certificate through this RA profile. The list reflects the certificate authority's register-operation attribute schema."
+	)
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes obtained") })
+	@GetMapping(path = "/attributes/register", produces = {"application/json"})
+	List<BaseAttribute> listRegisterCertificateAttributes(
+			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
+			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid) throws ConnectorException, NotFoundException;
+
+	@Operation(
 			summary = "Revoke certificate",
 			description = "Revoke a certificate currently in state `ISSUED`. If the revocation is asynchronous, the certificate moves to state `PENDING_REVOKE` and must be confirmed once the revocation has been performed."
 	)

--- a/src/main/java/com/otilm/api/model/core/certificate/CertificateDetailDto.java
+++ b/src/main/java/com/otilm/api/model/core/certificate/CertificateDetailDto.java
@@ -118,6 +118,12 @@ public class CertificateDetailDto extends CertificateDto {
     @Schema(description = "List of revoke attributes")
     private List<ResponseAttribute> revokeAttributes = new ArrayList<>();
 
+    @Schema(description = "List of register attributes: the connector's register-operation attributes submitted when the certificate was pre-registered")
+    private List<ResponseAttribute> registerAttributes = new ArrayList<>();
+
+    @Schema(description = "List of request attributes submitted at registration: the operator-supplied request-attribute values that shaped the pre-registered identity")
+    private List<ResponseAttribute> registrationRequestAttributes = new ArrayList<>();
+
     @Schema(description = "List of related certificates")
     @Deprecated(since = "2.16.0", forRemoval = true)
     /**


### PR DESCRIPTION
Adds `GET /v2/operations/authorities/{a}/raProfiles/{r}/attributes/register` to the v2 Client Operations contract, surfacing the connector's register-operation attribute schema (parallel to the existing `/attributes/issue` and `/attributes/revoke`).

Adds two additive fields to `CertificateDetailDto`:
- `registerAttributes` — the connector's register-operation attributes.
- `registrationRequestAttributes` — the operator-supplied request-attribute values submitted at registration.

Contract-only; the Core implementation and FE follow separately.

Part of OmniTrustILM/core#1867.