### PR TITLE
Tune connector WebClient: timeouts, connection pool, TLS-client cache

### DIFF
--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -419,11 +419,12 @@ public abstract class BaseApiClient {
                     || unwrapped instanceof io.netty.handler.timeout.TimeoutException
                     || unwrapped instanceof TimeoutException
                     || isPoolAcquireExhausted(unwrapped)) {
-                // Connect, response, and pool-acquire failures land here. Netty's timeout exceptions
-                // are not IOExceptions, and the pool "pending acquire limit" exception is a plain
-                // RuntimeException, so they are matched explicitly rather than rethrown raw. Log the
-                // type + message (the full cause rides on the ConnectorCommunicationException below);
-                // toString keeps message-less timeouts identifiable without spamming netty stacks.
+                // Connect, response, and pool-acquire failures land here. Netty timeout exceptions
+                // are not IOExceptions, and the pool pending-acquire-limit exception is a plain
+                // RuntimeException, so they are matched explicitly rather than rethrown raw. We log
+                // the failure type and message. The full cause is preserved on the
+                // ConnectorCommunicationException thrown just below, and toString keeps a
+                // message-less timeout identifiable without spamming netty stacks.
                 logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (unwrapped instanceof ConnectorException ce) {
@@ -442,6 +443,7 @@ public abstract class BaseApiClient {
      * is saturated — is a plain {@code RuntimeException}. Match it by simple name to avoid a
      * compile-time dependency on Reactor-Netty's shaded internal pool package.
      */
+    @SuppressWarnings("java:S1872") // name match is intentional — see Javadoc; instanceof would couple to the shaded type
     private static boolean isPoolAcquireExhausted(Throwable t) {
         return "PoolAcquirePendingLimitException".equals(t.getClass().getSimpleName());
     }

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -9,8 +9,10 @@ import com.otilm.api.model.common.error.ProblemDetailExtended;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.core.util.AttributeDefinitionUtils;
 import com.otilm.core.util.KeyStoreUtils;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -23,14 +25,23 @@ import org.springframework.web.reactive.function.client.*;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 public abstract class BaseApiClient {
@@ -51,6 +62,35 @@ public abstract class BaseApiClient {
     // API key attribute names
     public static final String ATTRIBUTE_API_KEY_HEADER = "apiKeyHeader";
     public static final String ATTRIBUTE_API_KEY = "apiKey";
+
+    private static final int CODEC_MAX_IN_MEMORY = 16 * 1024 * 1024;
+
+    // Pool hygiene, fixed here because it is not deployment-specific. Connector servers typically
+    // drop keep-alive connections around 60s; idle connections are evicted (30s) before they go
+    // stale to avoid PrematureCloseException on reuse. maxIdleTime < the read-idle guard below so
+    // idle pooled connections are reclaimed by eviction rather than by that guard firing on them.
+    private static final Duration POOL_MAX_IDLE = Duration.ofSeconds(30);
+    private static final Duration POOL_MAX_LIFE = Duration.ofMinutes(5);
+    private static final Duration POOL_EVICT_INTERVAL = Duration.ofSeconds(30);
+    private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
+    private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
+
+    // The tuned HttpClient is the single source the CERTIFICATE path derives from (via secure()),
+    // so per-connector TLS clients inherit the same pool and timeouts. Tuning is write-once: the
+    // first prepareWebClient(ClientTuning) wins, because rebuilding would orphan the live
+    // ConnectionProvider (Reactor-Netty pools are never disposed here).
+    private static volatile ClientTuning appliedTuning;
+    private static volatile HttpClient baseHttpClient = buildHttpClient(ClientTuning.defaults());
+
+    // Per-connector CERTIFICATE WebClients, keyed by connector UUID. The stored authMaterialHash
+    // invalidates the entry when credentials rotate. Caching the built WebClient (not just the
+    // SslContext) keeps the Reactor-Netty pool key stable across requests — the pool key hashes the
+    // SslProvider, so a fresh SslContext per request would give CERTIFICATE connectors no connection
+    // reuse and an ever-growing pool map.
+    private static final Map<String, CachedCertClient> certClientCache = new ConcurrentHashMap<>();
+
+    private record CachedCertClient(String authHash, WebClient webClient) {
+    }
 
     protected WebClient webClient;
 
@@ -98,9 +138,7 @@ public abstract class BaseApiClient {
                         .headers(h -> h.setBasicAuth(usernameValue, passwordValue));
                 break;
             case CERTIFICATE:
-                SslContext sslContext = createSslContext(authAttributes);
-                HttpClient httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
-                request = webClient.mutate().clientConnector(new ReactorClientHttpConnector(httpClient)).build().method(method);
+                request = certificateWebClient(connector).method(method);
                 break;
             case API_KEY:
                 List<StringAttributeContentV2> apiKeyHeaderContent = AttributeDefinitionUtils.getAttributeContent(ATTRIBUTE_API_KEY_HEADER, authAttributes, StringAttributeContentV2.class);
@@ -129,6 +167,28 @@ public abstract class BaseApiClient {
         if (connectorStatus == ConnectorStatus.WAITING_FOR_APPROVAL) {
             throw new ValidationException(ValidationError.create("Connector has invalid status: " + connectorStatus.getLabel()));
         }
+    }
+
+    /**
+     * Resolve the CERTIFICATE-auth WebClient for a connector, reusing the cached instance while the
+     * connector's auth material is unchanged. Derives from the shared tuned {@link #baseHttpClient}
+     * so the per-connector TLS client inherits the connection pool and timeouts.
+     */
+    WebClient certificateWebClient(ApiClientConnectorInfo connector) {
+        String authHash = authMaterialHash(connector.getAuthAttributes());
+        CachedCertClient cached = certClientCache.get(connector.getUuid());
+        if (cached != null && cached.authHash().equals(authHash)) {
+            return cached.webClient();
+        }
+
+        SslContext sslContext = createSslContext(connector.getAuthAttributes());
+        HttpClient certHttpClient = baseHttpClient.secure(spec -> spec.sslContext(sslContext));
+        WebClient certWebClient = webClient.mutate()
+                .clientConnector(new ReactorClientHttpConnector(certHttpClient))
+                .build();
+
+        certClientCache.put(connector.getUuid(), new CachedCertClient(authHash, certWebClient));
+        return certWebClient;
     }
 
     private SslContext createSslContext(List<ResponseAttribute> attributes) {
@@ -176,6 +236,32 @@ public abstract class BaseApiClient {
         }
     }
 
+    /**
+     * Content hash of the keystore/truststore material used to build the SslContext. Used as the
+     * cache-invalidation token for {@link #certClientCache} so rotated credentials rebuild the TLS
+     * client. Hashing (rather than keying on the raw material) keeps secrets out of the cache map.
+     */
+    private static String authMaterialHash(List<ResponseAttribute> attributes) {
+        String material = String.join("\n",
+                String.valueOf(getStoreType(attributes, ATTRIBUTE_KEYSTORE_TYPE)),
+                String.valueOf(storeContent(attributes, ATTRIBUTE_KEYSTORE)),
+                String.valueOf(getStorePassword(attributes, ATTRIBUTE_KEYSTORE_PASSWORD)),
+                String.valueOf(getStoreType(attributes, ATTRIBUTE_TRUSTSTORE_TYPE)),
+                String.valueOf(storeContent(attributes, ATTRIBUTE_TRUSTSTORE)),
+                String.valueOf(getStorePassword(attributes, ATTRIBUTE_TRUSTSTORE_PASSWORD)));
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(material.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static String storeContent(List<ResponseAttribute> attributes, String name) {
+        List<FileAttributeContentV2> list = AttributeDefinitionUtils.getAttributeContent(name, attributes, FileAttributeContentV2.class);
+        return list != null && !list.isEmpty() ? list.get(0).getData().getContent() : null;
+    }
+
     private static String getStoreType(List<ResponseAttribute> attributes, String name) {
         List<StringAttributeContentV2> keyStoreTypeList = AttributeDefinitionUtils.getAttributeContent(name, attributes, StringAttributeContentV2.class);
         return keyStoreTypeList != null && !keyStoreTypeList.isEmpty() ? keyStoreTypeList.get(0).getData() : null;
@@ -189,15 +275,70 @@ public abstract class BaseApiClient {
     private static final ParameterizedTypeReference<List<String>> ERROR_LIST_TYPE_REF = new ParameterizedTypeReference<>() {
     };
 
+    /**
+     * Build the shared connector WebClient with default tuning. Callers that do not configure tuning
+     * (tests, and any consumer without deployment config) get {@link ClientTuning#defaults()}.
+     */
     public static WebClient prepareWebClient() {
-        final int size = 16 * 1024 * 1024;
-        final ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
+        return buildWebClient(baseHttpClient);
+    }
+
+    /**
+     * Build the shared connector WebClient with the supplied tuning. The first call wins: a later
+     * call with different tuning is ignored (with a warning) so the live ConnectionProvider is not
+     * orphaned — important under Spring test-context caching, which can invoke the bean factory more
+     * than once per JVM.
+     */
+    public static synchronized WebClient prepareWebClient(ClientTuning tuning) {
+        if (appliedTuning == null) {
+            appliedTuning = tuning;
+            baseHttpClient = buildHttpClient(tuning);
+        } else if (!appliedTuning.equals(tuning)) {
+            logger.warn("Connector WebClient already tuned; ignoring differing tuning request");
+        }
+        return buildWebClient(baseHttpClient);
+    }
+
+    private static HttpClient buildHttpClient(ClientTuning tuning) {
+        ConnectionProvider provider = ConnectionProvider.builder("connector")
+                .maxConnections(tuning.maxConnections())
+                .pendingAcquireMaxCount(tuning.maxConnections() * 2)
+                .pendingAcquireTimeout(tuning.pendingAcquireTimeout())
+                .maxIdleTime(POOL_MAX_IDLE)
+                .maxLifeTime(POOL_MAX_LIFE)
+                .evictInBackground(POOL_EVICT_INTERVAL)
+                .disposeInactivePoolsInBackground(POOL_DISPOSE_INTERVAL, POOL_DISPOSE_AFTER)
+                .lifo()
+                .build();
+        return HttpClient.create(provider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) tuning.connectTimeout().toMillis())
+                .responseTimeout(tuning.responseTimeout())
+                // responseTimeout stops applying once response headers arrive; this read-idle guard
+                // bounds a connector that returns headers then stalls mid-body, which would otherwise
+                // block() forever. It surfaces as ReadTimeoutException (mapped in processRequest).
+                .doOnConnected(conn -> conn.addHandlerLast(
+                        new ReadTimeoutHandler(tuning.responseTimeout().toMillis(), TimeUnit.MILLISECONDS)));
+    }
+
+    private static WebClient buildWebClient(HttpClient httpClient) {
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(CODEC_MAX_IN_MEMORY))
                 .build();
         return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .filter(ExchangeFilterFunction.ofResponseProcessor(BaseApiClient::handleHttpExceptions))
                 .exchangeStrategies(strategies)
                 .build();
+    }
+
+    /**
+     * Reset the static tuning and CERTIFICATE-client cache to defaults. Test-only seam so cases that
+     * apply custom tuning do not leak into subsequent cases in the same JVM.
+     */
+    static void resetConnectorClientForTest() {
+        appliedTuning = null;
+        baseHttpClient = buildHttpClient(ClientTuning.defaults());
+        certClientCache.clear();
     }
 
     /**
@@ -236,8 +377,14 @@ public abstract class BaseApiClient {
             if (unwrapped instanceof ConnectorProblemException pde) {
                 pde.setConnector(connector);
                 throw pde;
-            } else if (unwrapped instanceof IOException || unwrapped instanceof WebClientRequestException) {
-                logger.error(unwrapped.getMessage());
+            } else if (unwrapped instanceof IOException
+                    || unwrapped instanceof WebClientRequestException
+                    || unwrapped instanceof io.netty.handler.timeout.TimeoutException
+                    || unwrapped instanceof TimeoutException) {
+                // Connect / response / read-idle / pool-acquire timeouts land here. Netty's timeout
+                // exceptions are not IOExceptions, and a read-idle timeout during the body phase is
+                // not wrapped in WebClientRequestException, so they are matched explicitly.
+                logger.error(String.valueOf(unwrapped.getMessage()));
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (unwrapped instanceof ConnectorException ce) {
                 ce.setConnector(connector);

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -87,6 +87,10 @@ public abstract class BaseApiClient {
     // SslContext) keeps the Reactor-Netty pool key stable across requests — the pool key hashes the
     // SslProvider, so a fresh SslContext per request would give CERTIFICATE connectors no connection
     // reuse and an ever-growing pool map.
+    // The cache is process-wide, so it assumes every BaseApiClient shares one base WebClient (its
+    // filters/codecs) and one defaultTrustManagers set — which holds in core, where both are single
+    // beans injected into all clients. If per-client base configuration ever diverged, that config
+    // would need to be part of the cache key.
     private static final Map<String, CachedCertClient> certClientCache = new ConcurrentHashMap<>();
 
     private record CachedCertClient(String authHash, WebClient webClient) {

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -249,19 +249,34 @@ public abstract class BaseApiClient {
      * client. Hashing (rather than keying on the raw material) keeps secrets out of the cache map.
      */
     private static String authMaterialHash(List<ResponseAttribute> attributes) {
-        String material = String.join("\n",
-                String.valueOf(getStoreType(attributes, ATTRIBUTE_KEYSTORE_TYPE)),
-                String.valueOf(storeContent(attributes, ATTRIBUTE_KEYSTORE)),
-                String.valueOf(getStorePassword(attributes, ATTRIBUTE_KEYSTORE_PASSWORD)),
-                String.valueOf(getStoreType(attributes, ATTRIBUTE_TRUSTSTORE_TYPE)),
-                String.valueOf(storeContent(attributes, ATTRIBUTE_TRUSTSTORE)),
-                String.valueOf(getStorePassword(attributes, ATTRIBUTE_TRUSTSTORE_PASSWORD)));
         try {
-            byte[] digest = MessageDigest.getInstance("SHA-256").digest(material.getBytes(StandardCharsets.UTF_8));
-            return Base64.getEncoder().encodeToString(digest);
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            // Feed each field to the digest directly (no concatenated copy of the keystore blobs) and
+            // length-prefix it, so absent/empty/adjacent values cannot alias one another.
+            updateField(digest, getStoreType(attributes, ATTRIBUTE_KEYSTORE_TYPE));
+            updateField(digest, storeContent(attributes, ATTRIBUTE_KEYSTORE));
+            updateField(digest, getStorePassword(attributes, ATTRIBUTE_KEYSTORE_PASSWORD));
+            updateField(digest, getStoreType(attributes, ATTRIBUTE_TRUSTSTORE_TYPE));
+            updateField(digest, storeContent(attributes, ATTRIBUTE_TRUSTSTORE));
+            updateField(digest, getStorePassword(attributes, ATTRIBUTE_TRUSTSTORE_PASSWORD));
+            return Base64.getEncoder().encodeToString(digest.digest());
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 not available", e);
         }
+    }
+
+    private static void updateField(MessageDigest digest, String value) {
+        if (value == null) {
+            digest.update((byte) 0);
+            return;
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update((byte) 1);
+        digest.update((byte) (bytes.length >>> 24));
+        digest.update((byte) (bytes.length >>> 16));
+        digest.update((byte) (bytes.length >>> 8));
+        digest.update((byte) bytes.length);
+        digest.update(bytes);
     }
 
     private static String storeContent(List<ResponseAttribute> attributes, String name) {
@@ -406,8 +421,10 @@ public abstract class BaseApiClient {
                     || isPoolAcquireExhausted(unwrapped)) {
                 // Connect, response, and pool-acquire failures land here. Netty's timeout exceptions
                 // are not IOExceptions, and the pool "pending acquire limit" exception is a plain
-                // RuntimeException, so they are matched explicitly rather than rethrown raw.
-                logger.error(String.valueOf(unwrapped.getMessage()));
+                // RuntimeException, so they are matched explicitly rather than rethrown raw. Log the
+                // type + message (the full cause rides on the ConnectorCommunicationException below);
+                // toString keeps message-less timeouts identifiable without spamming netty stacks.
+                logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (unwrapped instanceof ConnectorException ce) {
                 ce.setConnector(connector);

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -174,12 +175,13 @@ public abstract class BaseApiClient {
      * so the per-connector TLS client inherits the connection pool and timeouts.
      */
     WebClient certificateWebClient(ApiClientConnectorInfo connector) {
-        String authHash = authMaterialHash(connector.getAuthAttributes());
         String uuid = connector.getUuid();
         if (uuid == null) {
-            // Not cacheable without a stable key (a ConcurrentHashMap rejects null keys anyway); build per request.
+            // Not cacheable without a stable key (a ConcurrentHashMap rejects null keys anyway); build
+            // per request without hashing the auth material.
             return buildCertificateWebClient(connector);
         }
+        String authHash = authMaterialHash(connector.getAuthAttributes());
         // compute() builds at most once per (uuid, authHash): concurrent first-callers for the same
         // connector serialize on the map bin instead of each building a distinct SslContext, which
         // would briefly give one host two Reactor pool keys.
@@ -281,7 +283,11 @@ public abstract class BaseApiClient {
 
     private static String storeContent(List<ResponseAttribute> attributes, String name) {
         List<FileAttributeContentV2> list = AttributeDefinitionUtils.getAttributeContent(name, attributes, FileAttributeContentV2.class);
-        return list != null && !list.isEmpty() ? list.get(0).getData().getContent() : null;
+        if (list == null || list.isEmpty()) {
+            return null;
+        }
+        var data = list.get(0).getData();
+        return data != null ? data.getContent() : null;
     }
 
     private static String getStoreType(List<ResponseAttribute> attributes, String name) {
@@ -312,6 +318,7 @@ public abstract class BaseApiClient {
      * than once per JVM.
      */
     public static synchronized WebClient prepareWebClient(ClientTuning tuning) {
+        Objects.requireNonNull(tuning, "tuning must not be null");
         if (appliedTuning == null) {
             appliedTuning = tuning;
             connectionProvider = buildConnectionProvider(tuning);
@@ -333,7 +340,7 @@ public abstract class BaseApiClient {
     private static ConnectionProvider buildConnectionProvider(ClientTuning tuning) {
         return ConnectionProvider.builder("connector")
                 .maxConnections(tuning.maxConnections())
-                .pendingAcquireMaxCount(tuning.maxConnections() * 2)
+                .pendingAcquireMaxCount(Math.multiplyExact(tuning.maxConnections(), 2))
                 .pendingAcquireTimeout(tuning.pendingAcquireTimeout())
                 .maxIdleTime(POOL_MAX_IDLE)
                 .maxLifeTime(POOL_MAX_LIFE)
@@ -349,7 +356,7 @@ public abstract class BaseApiClient {
         // responds without ever firing on an idle pooled connection. A mid-body stall after headers
         // is bounded by the caller's transaction timeout rather than a persistent channel handler.
         return HttpClient.create(provider)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) tuning.connectTimeout().toMillis())
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(tuning.connectTimeout().toMillis()))
                 .responseTimeout(tuning.responseTimeout());
     }
 

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -12,7 +12,6 @@ import com.otilm.core.util.KeyStoreUtils;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -40,7 +39,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
@@ -66,21 +64,22 @@ public abstract class BaseApiClient {
     private static final int CODEC_MAX_IN_MEMORY = 16 * 1024 * 1024;
 
     // Pool hygiene, fixed here because it is not deployment-specific. Connector servers typically
-    // drop keep-alive connections around 60s; idle connections are evicted (30s) before they go
-    // stale to avoid PrematureCloseException on reuse. maxIdleTime < the read-idle guard below so
-    // idle pooled connections are reclaimed by eviction rather than by that guard firing on them.
+    // drop keep-alive connections around 60s, so idle connections are evicted and capped in age to
+    // avoid reusing a server-closed connection (PrematureCloseException).
     private static final Duration POOL_MAX_IDLE = Duration.ofSeconds(30);
     private static final Duration POOL_MAX_LIFE = Duration.ofMinutes(5);
     private static final Duration POOL_EVICT_INTERVAL = Duration.ofSeconds(30);
     private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
     private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
 
-    // The tuned HttpClient is the single source the CERTIFICATE path derives from (via secure()),
-    // so per-connector TLS clients inherit the same pool and timeouts. Tuning is write-once: the
-    // first prepareWebClient(ClientTuning) wins, because rebuilding would orphan the live
-    // ConnectionProvider (Reactor-Netty pools are never disposed here).
+    // Tuning is applied once (first prepareWebClient wins); the tuned HttpClient is the single source
+    // the CERTIFICATE path derives from (via secure()), so per-connector TLS clients inherit the same
+    // pool and timeouts. baseHttpClient is built lazily on first use so a deployment that always
+    // supplies tuning never builds a throwaway default ConnectionProvider — an orphaned provider is
+    // never GC'd (its background eviction task keeps a strong reference to it forever).
     private static volatile ClientTuning appliedTuning;
-    private static volatile HttpClient baseHttpClient = buildHttpClient(ClientTuning.defaults());
+    private static volatile ConnectionProvider connectionProvider;
+    private static volatile HttpClient baseHttpClient;
 
     // Per-connector CERTIFICATE WebClients, keyed by connector UUID. The stored authMaterialHash
     // invalidates the entry when credentials rotate. Caching the built WebClient (not just the
@@ -176,19 +175,27 @@ public abstract class BaseApiClient {
      */
     WebClient certificateWebClient(ApiClientConnectorInfo connector) {
         String authHash = authMaterialHash(connector.getAuthAttributes());
-        CachedCertClient cached = certClientCache.get(connector.getUuid());
-        if (cached != null && cached.authHash().equals(authHash)) {
-            return cached.webClient();
+        String uuid = connector.getUuid();
+        if (uuid == null) {
+            // Not cacheable without a stable key (a ConcurrentHashMap rejects null keys anyway); build per request.
+            return buildCertificateWebClient(connector);
         }
+        // compute() builds at most once per (uuid, authHash): concurrent first-callers for the same
+        // connector serialize on the map bin instead of each building a distinct SslContext, which
+        // would briefly give one host two Reactor pool keys.
+        return certClientCache.compute(uuid, (key, existing) ->
+                existing != null && existing.authHash().equals(authHash)
+                        ? existing
+                        : new CachedCertClient(authHash, buildCertificateWebClient(connector))
+        ).webClient();
+    }
 
+    private WebClient buildCertificateWebClient(ApiClientConnectorInfo connector) {
         SslContext sslContext = createSslContext(connector.getAuthAttributes());
-        HttpClient certHttpClient = baseHttpClient.secure(spec -> spec.sslContext(sslContext));
-        WebClient certWebClient = webClient.mutate()
+        HttpClient certHttpClient = baseHttpClient().secure(spec -> spec.sslContext(sslContext));
+        return webClient.mutate()
                 .clientConnector(new ReactorClientHttpConnector(certHttpClient))
                 .build();
-
-        certClientCache.put(connector.getUuid(), new CachedCertClient(authHash, certWebClient));
-        return certWebClient;
     }
 
     private SslContext createSslContext(List<ResponseAttribute> attributes) {
@@ -280,7 +287,7 @@ public abstract class BaseApiClient {
      * (tests, and any consumer without deployment config) get {@link ClientTuning#defaults()}.
      */
     public static WebClient prepareWebClient() {
-        return buildWebClient(baseHttpClient);
+        return prepareWebClient(ClientTuning.defaults());
     }
 
     /**
@@ -292,15 +299,24 @@ public abstract class BaseApiClient {
     public static synchronized WebClient prepareWebClient(ClientTuning tuning) {
         if (appliedTuning == null) {
             appliedTuning = tuning;
-            baseHttpClient = buildHttpClient(tuning);
+            connectionProvider = buildConnectionProvider(tuning);
+            baseHttpClient = buildHttpClient(connectionProvider, tuning);
         } else if (!appliedTuning.equals(tuning)) {
             logger.warn("Connector WebClient already tuned; ignoring differing tuning request");
         }
         return buildWebClient(baseHttpClient);
     }
 
-    private static HttpClient buildHttpClient(ClientTuning tuning) {
-        ConnectionProvider provider = ConnectionProvider.builder("connector")
+    /** Lazily initialize with defaults if a client is used before any prepareWebClient call. */
+    private static synchronized HttpClient baseHttpClient() {
+        if (baseHttpClient == null) {
+            prepareWebClient();
+        }
+        return baseHttpClient;
+    }
+
+    private static ConnectionProvider buildConnectionProvider(ClientTuning tuning) {
+        return ConnectionProvider.builder("connector")
                 .maxConnections(tuning.maxConnections())
                 .pendingAcquireMaxCount(tuning.maxConnections() * 2)
                 .pendingAcquireTimeout(tuning.pendingAcquireTimeout())
@@ -310,14 +326,16 @@ public abstract class BaseApiClient {
                 .disposeInactivePoolsInBackground(POOL_DISPOSE_INTERVAL, POOL_DISPOSE_AFTER)
                 .lifo()
                 .build();
+    }
+
+    private static HttpClient buildHttpClient(ConnectionProvider provider, ClientTuning tuning) {
+        // responseTimeout is reactor-netty's own per-request read guard (added when the request is
+        // sent, removed when the response is received), so it fails fast on a connector that never
+        // responds without ever firing on an idle pooled connection. A mid-body stall after headers
+        // is bounded by the caller's transaction timeout rather than a persistent channel handler.
         return HttpClient.create(provider)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) tuning.connectTimeout().toMillis())
-                .responseTimeout(tuning.responseTimeout())
-                // responseTimeout stops applying once response headers arrive; this read-idle guard
-                // bounds a connector that returns headers then stalls mid-body, which would otherwise
-                // block() forever. It surfaces as ReadTimeoutException (mapped in processRequest).
-                .doOnConnected(conn -> conn.addHandlerLast(
-                        new ReadTimeoutHandler(tuning.responseTimeout().toMillis(), TimeUnit.MILLISECONDS)));
+                .responseTimeout(tuning.responseTimeout());
     }
 
     private static WebClient buildWebClient(HttpClient httpClient) {
@@ -335,9 +353,13 @@ public abstract class BaseApiClient {
      * Reset the static tuning and CERTIFICATE-client cache to defaults. Test-only seam so cases that
      * apply custom tuning do not leak into subsequent cases in the same JVM.
      */
-    static void resetConnectorClientForTest() {
+    static synchronized void resetConnectorClientForTest() {
+        if (connectionProvider != null) {
+            connectionProvider.dispose();
+        }
+        connectionProvider = null;
+        baseHttpClient = null;
         appliedTuning = null;
-        baseHttpClient = buildHttpClient(ClientTuning.defaults());
         certClientCache.clear();
     }
 
@@ -380,10 +402,11 @@ public abstract class BaseApiClient {
             } else if (unwrapped instanceof IOException
                     || unwrapped instanceof WebClientRequestException
                     || unwrapped instanceof io.netty.handler.timeout.TimeoutException
-                    || unwrapped instanceof TimeoutException) {
-                // Connect / response / read-idle / pool-acquire timeouts land here. Netty's timeout
-                // exceptions are not IOExceptions, and a read-idle timeout during the body phase is
-                // not wrapped in WebClientRequestException, so they are matched explicitly.
+                    || unwrapped instanceof TimeoutException
+                    || isPoolAcquireExhausted(unwrapped)) {
+                // Connect, response, and pool-acquire failures land here. Netty's timeout exceptions
+                // are not IOExceptions, and the pool "pending acquire limit" exception is a plain
+                // RuntimeException, so they are matched explicitly rather than rethrown raw.
                 logger.error(String.valueOf(unwrapped.getMessage()));
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (unwrapped instanceof ConnectorException ce) {
@@ -394,6 +417,16 @@ public abstract class BaseApiClient {
                 throw e;
             }
         }
+    }
+
+    /**
+     * Reactor-Netty's {@code PoolAcquireTimeoutException} extends {@link TimeoutException} (already
+     * matched), but {@code PoolAcquirePendingLimitException} — thrown when the pending-acquire queue
+     * is saturated — is a plain {@code RuntimeException}. Match it by simple name to avoid a
+     * compile-time dependency on Reactor-Netty's shaded internal pool package.
+     */
+    private static boolean isPoolAcquireExhausted(Throwable t) {
+        return "PoolAcquirePendingLimitException".equals(t.getClass().getSimpleName());
     }
 
     private static Mono<ClientResponse> handleHttpExceptions(ClientResponse clientResponse) {

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -179,11 +179,16 @@ public abstract class BaseApiClient {
      * so the per-connector TLS client inherits the connection pool and timeouts.
      */
     WebClient certificateWebClient(ApiClientConnectorInfo connector) {
+        // Resolve the shared base client (which may take the class lock) before compute(), so the
+        // map-bin lock held inside the compute lambda never nests the class lock. The reverse order
+        // — resetConnectorClientForTest() takes the class lock then clears the map — would otherwise
+        // be a lock-ordering inversion that could deadlock under parallel execution.
+        HttpClient httpClient = baseHttpClient();
         String uuid = connector.getUuid();
         if (uuid == null) {
             // Not cacheable without a stable key (a ConcurrentHashMap rejects null keys anyway); build
             // per request without hashing the auth material.
-            return buildCertificateWebClient(connector);
+            return buildCertificateWebClient(connector, httpClient);
         }
         String authHash = authMaterialHash(connector.getAuthAttributes());
         // compute() builds at most once per (uuid, authHash): concurrent first-callers for the same
@@ -192,16 +197,27 @@ public abstract class BaseApiClient {
         return certClientCache.compute(uuid, (key, existing) ->
                 existing != null && existing.authHash().equals(authHash)
                         ? existing
-                        : new CachedCertClient(authHash, buildCertificateWebClient(connector))
+                        : new CachedCertClient(authHash, buildCertificateWebClient(connector, httpClient))
         ).webClient();
     }
 
-    private WebClient buildCertificateWebClient(ApiClientConnectorInfo connector) {
+    private WebClient buildCertificateWebClient(ApiClientConnectorInfo connector, HttpClient httpClient) {
         SslContext sslContext = createSslContext(connector.getAuthAttributes());
-        HttpClient certHttpClient = baseHttpClient().secure(spec -> spec.sslContext(sslContext));
+        HttpClient certHttpClient = httpClient.secure(spec -> spec.sslContext(sslContext));
         return webClient.mutate()
                 .clientConnector(new ReactorClientHttpConnector(certHttpClient))
                 .build();
+    }
+
+    /**
+     * Remove the cached CERTIFICATE {@link WebClient} for a connector. Core calls this when a
+     * connector is deleted or its authentication configuration changes, so the process-wide cache
+     * does not retain a client (and its parsed key material) for a connector that no longer exists.
+     */
+    public static void evictCertificateClient(String connectorUuid) {
+        if (connectorUuid != null) {
+            certClientCache.remove(connectorUuid);
+        }
     }
 
     private SslContext createSslContext(List<ResponseAttribute> attributes) {
@@ -328,7 +344,7 @@ public abstract class BaseApiClient {
             connectionProvider = buildConnectionProvider(tuning);
             baseHttpClient = buildHttpClient(connectionProvider, tuning);
         } else if (!appliedTuning.equals(tuning)) {
-            logger.warn("Connector WebClient already tuned; ignoring differing tuning request");
+            logger.warn("Connector WebClient already tuned with {}; ignoring differing request {}", appliedTuning, tuning);
         }
         return buildWebClient(baseHttpClient);
     }

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -64,33 +64,25 @@ public abstract class BaseApiClient {
 
     private static final int CODEC_MAX_IN_MEMORY = 16 * 1024 * 1024;
 
-    // Pool hygiene, fixed here because it is not deployment-specific. Connector servers typically
-    // drop keep-alive connections around 60s, so idle connections are evicted and capped in age to
-    // avoid reusing a server-closed connection (PrematureCloseException).
+    // Pool hygiene (not deployment-specific): evict idle and age-cap connections so a server-closed
+    // keep-alive is not reused (PrematureCloseException).
     private static final Duration POOL_MAX_IDLE = Duration.ofSeconds(30);
     private static final Duration POOL_MAX_LIFE = Duration.ofMinutes(5);
     private static final Duration POOL_EVICT_INTERVAL = Duration.ofSeconds(30);
     private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
     private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
 
-    // Tuning is applied once (first prepareWebClient wins); the tuned HttpClient is the single source
-    // the CERTIFICATE path derives from (via secure()), so per-connector TLS clients inherit the same
-    // pool and timeouts. baseHttpClient is built lazily on first use so a deployment that always
-    // supplies tuning never builds a throwaway default ConnectionProvider — an orphaned provider is
-    // never GC'd (its background eviction task keeps a strong reference to it forever).
+    // Applied once (first prepareWebClient wins). The tuned HttpClient is the single source the
+    // CERTIFICATE path derives from, built lazily so a tuned deployment never leaves an orphaned
+    // default ConnectionProvider (which its background task would pin forever).
     private static volatile ClientTuning appliedTuning;
     private static volatile ConnectionProvider connectionProvider;
     private static volatile HttpClient baseHttpClient;
 
-    // Per-connector CERTIFICATE WebClients, keyed by connector UUID. The stored authMaterialHash
-    // invalidates the entry when credentials rotate. Caching the built WebClient (not just the
-    // SslContext) keeps the Reactor-Netty pool key stable across requests — the pool key hashes the
-    // SslProvider, so a fresh SslContext per request would give CERTIFICATE connectors no connection
-    // reuse and an ever-growing pool map.
-    // The cache is process-wide, so it assumes every BaseApiClient shares one base WebClient (its
-    // filters/codecs) and one defaultTrustManagers set — which holds in core, where both are single
-    // beans injected into all clients. If per-client base configuration ever diverged, that config
-    // would need to be part of the cache key.
+    // Per-connector CERTIFICATE WebClients keyed by UUID; authMaterialHash invalidates on credential
+    // rotation. Caching the built WebClient (not just the SslContext) keeps the Reactor pool key
+    // stable — a fresh SslContext per request means a new SslProvider, hence no connection reuse.
+    // Process-wide: assumes all clients share one base WebClient + defaultTrustManagers (true in core).
     private static final Map<String, CachedCertClient> certClientCache = new ConcurrentHashMap<>();
 
     private record CachedCertClient(String authHash, WebClient webClient) {
@@ -174,26 +166,21 @@ public abstract class BaseApiClient {
     }
 
     /**
-     * Resolve the CERTIFICATE-auth WebClient for a connector, reusing the cached instance while the
-     * connector's auth material is unchanged. Derives from the shared tuned {@link #baseHttpClient}
-     * so the per-connector TLS client inherits the connection pool and timeouts.
+     * CERTIFICATE-auth WebClient for a connector, cached while its auth material is unchanged and
+     * derived from the shared tuned {@link #baseHttpClient} so it inherits the pool and timeouts.
      */
     WebClient certificateWebClient(ApiClientConnectorInfo connector) {
-        // Resolve the shared base client (which may take the class lock) before compute(), so the
-        // map-bin lock held inside the compute lambda never nests the class lock. The reverse order
-        // — resetConnectorClientForTest() takes the class lock then clears the map — would otherwise
-        // be a lock-ordering inversion that could deadlock under parallel execution.
+        // Resolve the base client (may take the class lock) before compute(), so the map-bin lock
+        // never nests the class lock — the reverse of resetConnectorClientForTest, a deadlock risk.
         HttpClient httpClient = baseHttpClient();
         String uuid = connector.getUuid();
         if (uuid == null) {
-            // Not cacheable without a stable key (a ConcurrentHashMap rejects null keys anyway); build
-            // per request without hashing the auth material.
+            // Not cacheable without a stable key; build per request.
             return buildCertificateWebClient(connector, httpClient);
         }
         String authHash = authMaterialHash(connector.getAuthAttributes());
-        // compute() builds at most once per (uuid, authHash): concurrent first-callers for the same
-        // connector serialize on the map bin instead of each building a distinct SslContext, which
-        // would briefly give one host two Reactor pool keys.
+        // compute() builds once per (uuid, authHash); concurrent first-callers serialize on the bin
+        // rather than each building a distinct SslContext (two pool keys for one host).
         return certClientCache.compute(uuid, (key, existing) ->
                 existing != null && existing.authHash().equals(authHash)
                         ? existing
@@ -210,9 +197,8 @@ public abstract class BaseApiClient {
     }
 
     /**
-     * Remove the cached CERTIFICATE {@link WebClient} for a connector. Core calls this when a
-     * connector is deleted or its authentication configuration changes, so the process-wide cache
-     * does not retain a client (and its parsed key material) for a connector that no longer exists.
+     * Drop the cached CERTIFICATE WebClient for a connector. Core calls this on connector delete or
+     * auth change so the process-wide cache does not retain a stale client and its key material.
      */
     public static void evictCertificateClient(String connectorUuid) {
         if (connectorUuid != null) {
@@ -266,15 +252,14 @@ public abstract class BaseApiClient {
     }
 
     /**
-     * Content hash of the keystore/truststore material used to build the SslContext. Used as the
-     * cache-invalidation token for {@link #certClientCache} so rotated credentials rebuild the TLS
-     * client. Hashing (rather than keying on the raw material) keeps secrets out of the cache map.
+     * Content hash of the keystore/truststore material — the cache-invalidation token for
+     * {@link #certClientCache}. Hashing keeps secrets out of the map keys.
      */
     private static String authMaterialHash(List<ResponseAttribute> attributes) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            // Feed each field to the digest directly (no concatenated copy of the keystore blobs) and
-            // length-prefix it, so absent/empty/adjacent values cannot alias one another.
+            // Length-prefix each field fed straight to the digest (no concatenated keystore copy),
+            // so absent/adjacent values cannot alias.
             updateField(digest, getStoreType(attributes, ATTRIBUTE_KEYSTORE_TYPE));
             updateField(digest, storeContent(attributes, ATTRIBUTE_KEYSTORE));
             updateField(digest, getStorePassword(attributes, ATTRIBUTE_KEYSTORE_PASSWORD));
@@ -332,10 +317,9 @@ public abstract class BaseApiClient {
     }
 
     /**
-     * Build the shared connector WebClient with the supplied tuning. The first call wins: a later
-     * call with different tuning is ignored (with a warning) so the live ConnectionProvider is not
-     * orphaned — important under Spring test-context caching, which can invoke the bean factory more
-     * than once per JVM.
+     * Build the shared WebClient with the given tuning. First call wins; a later call with different
+     * tuning is ignored (warned) so the live ConnectionProvider is not orphaned — matters under
+     * Spring test-context caching.
      */
     public static synchronized WebClient prepareWebClient(ClientTuning tuning) {
         Objects.requireNonNull(tuning, "tuning must not be null");
@@ -371,10 +355,8 @@ public abstract class BaseApiClient {
     }
 
     private static HttpClient buildHttpClient(ConnectionProvider provider, ClientTuning tuning) {
-        // responseTimeout is reactor-netty's own per-request read guard (added when the request is
-        // sent, removed when the response is received), so it fails fast on a connector that never
-        // responds without ever firing on an idle pooled connection. A mid-body stall after headers
-        // is bounded by the caller's transaction timeout rather than a persistent channel handler.
+        // responseTimeout is reactor-netty's per-request read guard (idle-safe), failing fast on a
+        // non-responding connector; a mid-body stall is bounded by the caller's transaction timeout.
         return HttpClient.create(provider)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(tuning.connectTimeout().toMillis()))
                 .responseTimeout(tuning.responseTimeout());
@@ -446,12 +428,9 @@ public abstract class BaseApiClient {
                     || unwrapped instanceof io.netty.handler.timeout.TimeoutException
                     || unwrapped instanceof TimeoutException
                     || isPoolAcquireExhausted(unwrapped)) {
-                // Connect, response, and pool-acquire failures land here. Netty timeout exceptions
-                // are not IOExceptions, and the pool pending-acquire-limit exception is a plain
-                // RuntimeException, so they are matched explicitly rather than rethrown raw. We log
-                // the failure type and message. The full cause is preserved on the
-                // ConnectorCommunicationException thrown just below, and toString keeps a
-                // message-less timeout identifiable without spamming netty stacks.
+                // Connect, response, and pool-acquire failures. Netty timeouts aren't IOExceptions and
+                // the pool pending-limit is a plain RuntimeException, so match them explicitly. Log
+                // type+message; the full cause rides on the exception thrown below.
                 logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (unwrapped instanceof ConnectorException ce) {
@@ -465,12 +444,11 @@ public abstract class BaseApiClient {
     }
 
     /**
-     * Reactor-Netty's {@code PoolAcquireTimeoutException} extends {@link TimeoutException} (already
-     * matched), but {@code PoolAcquirePendingLimitException} — thrown when the pending-acquire queue
-     * is saturated — is a plain {@code RuntimeException}. Match it by simple name to avoid a
-     * compile-time dependency on Reactor-Netty's shaded internal pool package.
+     * The pool pending-limit exception is a plain RuntimeException (unlike PoolAcquireTimeoutException,
+     * a {@link TimeoutException} matched above). Match by name to avoid depending on Reactor-Netty's
+     * shaded internal pool type.
      */
-    @SuppressWarnings("java:S1872") // name match is intentional — see Javadoc; instanceof would couple to the shaded type
+    @SuppressWarnings("java:S1872") // intentional name match — instanceof would couple to the shaded type
     private static boolean isPoolAcquireExhausted(Throwable t) {
         return "PoolAcquirePendingLimitException".equals(t.getClass().getSimpleName());
     }

--- a/src/main/java/com/otilm/api/clients/ClientTuning.java
+++ b/src/main/java/com/otilm/api/clients/ClientTuning.java
@@ -20,6 +20,21 @@ public record ClientTuning(
         int maxConnections,
         Duration pendingAcquireTimeout) {
 
+    public ClientTuning {
+        requirePositive(connectTimeout, "connectTimeout");
+        requirePositive(responseTimeout, "responseTimeout");
+        requirePositive(pendingAcquireTimeout, "pendingAcquireTimeout");
+        if (maxConnections <= 0) {
+            throw new IllegalArgumentException("maxConnections must be positive, was " + maxConnections);
+        }
+    }
+
+    private static void requirePositive(Duration value, String name) {
+        if (value == null || value.isNegative() || value.isZero()) {
+            throw new IllegalArgumentException(name + " must be a positive duration, was " + value);
+        }
+    }
+
     public static ClientTuning defaults() {
         // 35s response ~ authority connector per-call budget (30s) + margin; 3s connect fails fast on unreachable hosts.
         return new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10));

--- a/src/main/java/com/otilm/api/clients/ClientTuning.java
+++ b/src/main/java/com/otilm/api/clients/ClientTuning.java
@@ -1,0 +1,27 @@
+package com.otilm.api.clients;
+
+import java.time.Duration;
+
+/**
+ * Tuning for the shared connector {@link org.springframework.web.reactive.function.client.WebClient}.
+ *
+ * <p>Only the load-bearing knobs are exposed here; connection-pool hygiene (idle eviction,
+ * lifetime, background disposal, LIFO leasing) is fixed inside {@link BaseApiClient} because it is
+ * not deployment-specific. Deployment code supplies these values from configuration;
+ * {@link #defaults()} backs tests and any caller that does not tune.
+ *
+ * <p>{@code maxConnections} is <em>per remote host</em> (Reactor-Netty pools per destination), not a
+ * global cap, so it is sized against the per-connector concurrent load rather than a single queue's
+ * listener concurrency.
+ */
+public record ClientTuning(
+        Duration connectTimeout,
+        Duration responseTimeout,
+        int maxConnections,
+        Duration pendingAcquireTimeout) {
+
+    public static ClientTuning defaults() {
+        // 35s response ~ authority connector per-call budget (30s) + margin; 3s connect fails fast on unreachable hosts.
+        return new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10));
+    }
+}

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -299,7 +299,7 @@ class BaseApiClientTest {
         TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
 
         long startMs = System.currentTimeMillis();
-        Assertions.assertThrows(Exception.class, () ->
+        Throwable thrown = Assertions.assertThrows(Exception.class, () ->
                 tunedClient.prepareRequest(HttpMethod.GET, connector, false)
                         .uri("http://localhost:" + mockServer.port() + "/slow")
                         .retrieve()
@@ -308,6 +308,22 @@ class BaseApiClientTest {
         long elapsedMs = System.currentTimeMillis() - startMs;
 
         Assertions.assertTrue(elapsedMs < 3000, "expected fail-fast under the 500ms response timeout, took " + elapsedMs + "ms");
+        // Ensure it failed for the intended reason (a timeout), not a URI/connect error that merely happened fast.
+        Assertions.assertTrue(hasTimeoutCause(thrown), "expected a response/read timeout, got: " + thrown);
+    }
+
+    private static boolean hasTimeoutCause(Throwable thrown) {
+        for (Throwable t = thrown; t != null; t = t.getCause()) {
+            if (t instanceof java.util.concurrent.TimeoutException
+                    || t instanceof io.netty.handler.timeout.TimeoutException
+                    || t.getClass().getSimpleName().toLowerCase().contains("timeout")) {
+                return true;
+            }
+            if (t == t.getCause()) {
+                break;
+            }
+        }
+        return false;
     }
 
     @Test

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -67,9 +67,13 @@ class BaseApiClientTest {
 
     @AfterEach
     void tearDown() {
-        mockServer.stop();
-        // Custom tuning and the CERTIFICATE-client cache are static; reset so cases don't leak into each other.
-        BaseApiClient.resetConnectorClientForTest();
+        // Reset the static tuning/cache regardless of mockServer.stop() outcome, so state never leaks
+        // into the next test (which would make the tuned-timeout cases order-dependent).
+        try {
+            mockServer.stop();
+        } finally {
+            BaseApiClient.resetConnectorClientForTest();
+        }
     }
 
     @Test
@@ -287,6 +291,7 @@ class BaseApiClientTest {
 
     @Test
     void prepareRequest_slowResponse_failsFastWithinResponseTimeout() {
+        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
         WebClient tuned = BaseApiClient.prepareWebClient(
                 new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
         TestApiClient tunedClient = new TestApiClient(tuned);
@@ -307,6 +312,7 @@ class BaseApiClientTest {
 
     @Test
     void processRequest_responseTimeout_mappedToConnectorCommunicationException() {
+        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
         WebClient tuned = BaseApiClient.prepareWebClient(
                 new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
         TestApiClient tunedClient = new TestApiClient(tuned);
@@ -322,6 +328,23 @@ class BaseApiClientTest {
                                 .block(),
                         null,
                         connector));
+    }
+
+    @Test
+    void processRequest_poolAcquirePendingLimit_mappedToConnectorCommunicationException() {
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+        // Reactor-Netty throws this (a plain RuntimeException) when the pending-acquire queue is
+        // saturated; a local stand-in with the same simple name exercises the name-based mapping.
+        Assertions.assertThrows(ConnectorCommunicationException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw new PoolAcquirePendingLimitException("pending acquire limit reached");
+                }, null, connector));
+    }
+
+    private static class PoolAcquirePendingLimitException extends RuntimeException {
+        PoolAcquirePendingLimitException(String message) {
+            super(message);
+        }
     }
 
     private List<ResponseAttribute> certAuthAttributes(String keyStorePassword, String trustStorePassword) throws Exception {

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.common.attribute.common.content.data.SecretAttributeC
 import com.otilm.api.model.common.attribute.v2.content.FileAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.SecretAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.otilm.api.exception.ConnectorCommunicationException;
 import com.otilm.api.model.core.connector.AuthType;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.proxy.ProxyDto;
@@ -25,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -66,6 +68,8 @@ class BaseApiClientTest {
     @AfterEach
     void tearDown() {
         mockServer.stop();
+        // Custom tuning and the CERTIFICATE-client cache are static; reset so cases don't leak into each other.
+        BaseApiClient.resetConnectorClientForTest();
     }
 
     @Test
@@ -253,6 +257,95 @@ class BaseApiClientTest {
 
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 client.prepareRequest(HttpMethod.GET, connector, false));
+    }
+
+    @Test
+    void certificateWebClient_sameConnector_reusesCachedClientWithoutRebuildingSslContext() throws Exception {
+        List<ResponseAttribute> authAttributes = certAuthAttributes("clientPass", "clientTrustPass");
+        TestConnectorInfo connector = new TestConnectorInfo("https://localhost:9999", AuthType.CERTIFICATE, authAttributes);
+
+        WebClient first = client.certificateWebClient(connector);
+        WebClient second = client.certificateWebClient(connector);
+
+        // Same instance proves the SslContext (and its WebClient) was cached, not rebuilt per request.
+        Assertions.assertSame(first, second);
+    }
+
+    @Test
+    void certificateWebClient_rotatedCredentials_rebuildsClient() throws Exception {
+        List<ResponseAttribute> original = certAuthAttributes("clientPass", "clientTrustPass");
+        TestConnectorInfo connector = new TestConnectorInfo("https://localhost:9999", AuthType.CERTIFICATE, original);
+        WebClient first = client.certificateWebClient(connector);
+
+        // Same connector UUID, different keystore/truststore material -> cache entry must be invalidated.
+        List<ResponseAttribute> rotated = certAuthAttributes("clientPass", "clientTrustPass");
+        TestConnectorInfo rotatedConnector = new TestConnectorInfo("https://localhost:9999", AuthType.CERTIFICATE, rotated);
+        WebClient second = client.certificateWebClient(rotatedConnector);
+
+        Assertions.assertNotSame(first, second);
+    }
+
+    @Test
+    void prepareRequest_slowResponse_failsFastWithinResponseTimeout() {
+        WebClient tuned = BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
+        TestApiClient tunedClient = new TestApiClient(tuned);
+        mockServer.stubFor(get(urlEqualTo("/slow")).willReturn(aResponse().withStatus(200).withFixedDelay(5000)));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        long startMs = System.currentTimeMillis();
+        Assertions.assertThrows(Exception.class, () ->
+                tunedClient.prepareRequest(HttpMethod.GET, connector, false)
+                        .uri("http://localhost:" + mockServer.port() + "/slow")
+                        .retrieve()
+                        .toBodilessEntity()
+                        .block());
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        Assertions.assertTrue(elapsedMs < 3000, "expected fail-fast under the 500ms response timeout, took " + elapsedMs + "ms");
+    }
+
+    @Test
+    void processRequest_responseTimeout_mappedToConnectorCommunicationException() {
+        WebClient tuned = BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
+        TestApiClient tunedClient = new TestApiClient(tuned);
+        mockServer.stubFor(get(urlEqualTo("/slow")).willReturn(aResponse().withStatus(200).withFixedDelay(5000)));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        Assertions.assertThrows(ConnectorCommunicationException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> tunedClient.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/slow")
+                                .retrieve()
+                                .toBodilessEntity()
+                                .block(),
+                        null,
+                        connector));
+    }
+
+    private List<ResponseAttribute> certAuthAttributes(String keyStorePassword, String trustStorePassword) throws Exception {
+        KeyPair clientKeyPair = generateKeyPair();
+        X509Certificate clientCert = generateCert(clientKeyPair, "client");
+        KeyPair serverKeyPair = generateKeyPair();
+        X509Certificate serverCert = generateCert(serverKeyPair, "localhost");
+
+        FileAttributeContentData ksData = new FileAttributeContentData();
+        ksData.setContent(Base64.getEncoder().encodeToString(buildPkcs12(clientKeyPair, clientCert, "client", keyStorePassword)));
+        ksData.setFileName("client.p12");
+
+        FileAttributeContentData tsData = new FileAttributeContentData();
+        tsData.setContent(Base64.getEncoder().encodeToString(buildTrustStore(serverCert, "server", trustStorePassword)));
+        tsData.setFileName("trust.p12");
+
+        return List.of(
+                responseAttribute("keyStoreType", AttributeContentType.STRING, new StringAttributeContentV2("PKCS12")),
+                responseAttribute("keyStore", AttributeContentType.FILE, new FileAttributeContentV2(null, ksData)),
+                responseAttribute("keyStorePassword", AttributeContentType.SECRET, new SecretAttributeContentV2(null, new SecretAttributeContentData(keyStorePassword))),
+                responseAttribute("trustStoreType", AttributeContentType.STRING, new StringAttributeContentV2("PKCS12")),
+                responseAttribute("trustStore", AttributeContentType.FILE, new FileAttributeContentV2(null, tsData)),
+                responseAttribute("trustStorePassword", AttributeContentType.SECRET, new SecretAttributeContentV2(null, new SecretAttributeContentData(trustStorePassword)))
+        );
     }
 
     private static KeyPair generateKeyPair() throws NoSuchAlgorithmException {

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -33,6 +33,7 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -316,7 +317,7 @@ class BaseApiClientTest {
         for (Throwable t = thrown; t != null; t = t.getCause()) {
             if (t instanceof java.util.concurrent.TimeoutException
                     || t instanceof io.netty.handler.timeout.TimeoutException
-                    || t.getClass().getSimpleName().toLowerCase().contains("timeout")) {
+                    || t.getClass().getSimpleName().toLowerCase(Locale.ROOT).contains("timeout")) {
                 return true;
             }
             if (t == t.getCause()) {

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -308,7 +308,10 @@ class BaseApiClientTest {
                         .block());
         long elapsedMs = System.currentTimeMillis() - startMs;
 
-        Assertions.assertTrue(elapsedMs < 3000, "expected fail-fast under the 500ms response timeout, took " + elapsedMs + "ms");
+        // Proves fail-fast: the 500ms response timeout must trip before the server's 5000ms delay
+        // would return. Bound kept comfortably under 5000ms (not tight to 500ms) so a GC pause or a
+        // saturated CI runner doesn't flake it; hasTimeoutCause below confirms the reason.
+        Assertions.assertTrue(elapsedMs < 4500, "expected fail-fast under the 500ms response timeout, took " + elapsedMs + "ms");
         // Ensure it failed for the intended reason (a timeout), not a URI/connect error that merely happened fast.
         Assertions.assertTrue(hasTimeoutCause(thrown), "expected a response/read timeout, got: " + thrown);
     }


### PR DESCRIPTION
## What

Tune the shared connector `WebClient` used for all HTTP calls to connectors and authorities. Previously it set only the codec limit — no timeouts, no explicit connection pool — and the CERTIFICATE path rebuilt the `SslContext` plus a fresh `HttpClient` on every request.

- **Timeouts** — connect (3s) and response (35s), so a hung connector fails fast instead of blocking indefinitely. `responseTimeout` is reactor-netty's own per-request read guard, so it is idle-safe; a mid-body stall after headers is bounded by the caller's transaction timeout.
- **Connection pool** — explicit Reactor-Netty `ConnectionProvider` (per-host `maxConnections`, pending-acquire limit + timeout, idle eviction, max lifetime, LIFO, background disposal), replacing the default ~16-connection pool.
- **Per-connector CERTIFICATE cache** — the built `WebClient` is cached, keyed by connector UUID + a hash of the auth material, so the `SslContext` is not rebuilt per request and the Reactor pool key stays stable (a fresh `SslContext` per request otherwise gives CERTIFICATE connectors no connection reuse and a growing pool map).
- **Error mapping** — response, connect, and pool-acquire-exhaustion errors map to `ConnectorCommunicationException`.

Tuning is applied write-once (first caller wins) and the base `HttpClient` is built lazily, so a tuned deployment never orphans a `ConnectionProvider`. Values are supplied by `core` via `ClientTuning`; the no-arg `prepareWebClient()` falls back to `ClientTuning.defaults()` (used by tests).

## Testing

`BaseApiClientTest` adds coverage for CERTIFICATE-client cache reuse, credential-rotation invalidation, fail-fast response timeout, and timeout / pool-acquire mapping to `ConnectorCommunicationException`. Full interfaces suite green (431 tests).

Relates to OmniTrustILM/core#1878
