### PR TITLE
Seed SystemOid with common certificate extensions and RDN types

### DIFF
--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.core.oid;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -32,16 +33,9 @@ public enum SystemOid {
     USER_ID("0.9.2342.19200300.100.1.1", "User ID", OidCategory.RDN_ATTRIBUTE_TYPE, "UID", List.of()),
 
     /**
-     * Certificate extensions a requester plausibly places in a CSR, so that STRICT request-attribute
-     * validation can admit them without an operator first hand-registering the OID.
-     *
-     * <p>Subject Alternative Name (2.5.29.17) is deliberately absent: the request parser diverts it out
-     * of the extension list into {@code subjectAltNames} and a dedicated SAN mapping target exists, so
-     * an extension mapping on it could never match.
-     *
-     * <p>Entries flagged CA-controlled are selectable for display but must be rejected as
-     * request-attribute mapping targets — a requester-supplied value must never drive a cA/pathLen
-     * assertion, a name-constraints tree, or a key identifier that no longer matches the public key.
+     * Certificate extensions a requester plausibly places in a CSR. SAN (2.5.29.17) is absent because
+     * the parser diverts it into {@code subjectAltNames}, so an extension mapping on it never matches.
+     * The trailing flag marks CA-owned extensions, which must be rejected as mapping targets.
      */
     EXTENDED_KEY_USAGE_EXTENSION("2.5.29.37", "Extended Key Usage", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
     KEY_USAGE("2.5.29.15", "Key Usage", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, false),
@@ -74,48 +68,59 @@ public enum SystemOid {
         VALUES = values();
     }
 
+    /** Properties only a certificate extension carries; {@code null} for every other category. */
+    private record ExtensionProperties(boolean defaultCritical, ExtensionValueEncoding valueEncoding, boolean caControlled) {}
+
     private final String oid;
     private final String displayName;
     private final OidCategory category;
     private final String code;
     private final List<String> altCodes;
-    private final Boolean defaultCritical;
-    private final ExtensionValueEncoding valueEncoding;
-    private final boolean caControlled;
+    @Getter(AccessLevel.NONE)
+    private final ExtensionProperties extensionProperties;
 
     /** RDN attribute type: carries the short code, plus any alternative spellings that must also parse. */
     SystemOid(String oid, String displayName, OidCategory category, String code, List<String> altCodes) {
-        this(oid, displayName, category, code, altCodes, null, null, false);
+        this(oid, displayName, category, code, altCodes, null);
     }
 
     /** Entry with no additional properties — an extended-key-usage purpose or a generic identifier. */
     SystemOid(String oid, String displayName, OidCategory category) {
-        this(oid, displayName, category, null, List.of(), null, null, false);
+        this(oid, displayName, category, null, List.of(), null);
     }
 
-    /**
-     * Certificate extension: carries the criticality and value-encoding defaults applied when a mapped
-     * request attribute is projected into a certificate request, and whether the issuing CA owns the
-     * extension and so must reject it as a mapping target.
-     */
+    /** Certificate extension: projection defaults, plus whether the issuing CA owns the extension. */
     SystemOid(String oid, String displayName, OidCategory category, boolean defaultCritical,
               ExtensionValueEncoding valueEncoding, boolean caControlled) {
-        this(oid, displayName, category, null, List.of(), defaultCritical, valueEncoding, caControlled);
+        this(oid, displayName, category, null, List.of(),
+                new ExtensionProperties(defaultCritical, valueEncoding, caControlled));
     }
 
     SystemOid(String oid, String displayName, OidCategory category, String code, List<String> altCodes,
-              Boolean defaultCritical, ExtensionValueEncoding valueEncoding, boolean caControlled) {
+              ExtensionProperties extensionProperties) {
         this.oid = oid;
         this.displayName = displayName;
         this.category = category;
         this.code = code;
-        // Never null so any consumer iterating all values can flatten altCodes without a guard; today
-        // the only unguarded reader is RDN-scoped. Naming the constant matters because a null here
-        // fails class initialisation, which would otherwise surface as a bare NPE.
+        // Never null, so a consumer iterating all values can flatten altCodes without a guard. Named
+        // because a null fails class initialisation, which would otherwise surface as a bare NPE.
         this.altCodes = List.copyOf(Objects.requireNonNull(altCodes, () -> "altCodes must not be null for " + name()));
-        this.defaultCritical = defaultCritical;
-        this.valueEncoding = valueEncoding;
-        this.caControlled = caControlled;
+        this.extensionProperties = extensionProperties;
+    }
+
+    /** {@code null} unless this is a certificate extension. */
+    public Boolean getDefaultCritical() {
+        return extensionProperties == null ? null : extensionProperties.defaultCritical();
+    }
+
+    /** {@code null} unless this is a certificate extension. */
+    public ExtensionValueEncoding getValueEncoding() {
+        return extensionProperties == null ? null : extensionProperties.valueEncoding();
+    }
+
+    /** Whether the issuing CA owns this extension, making it invalid as a request-attribute mapping target. */
+    public boolean isCaControlled() {
+        return extensionProperties != null && extensionProperties.caControlled();
     }
 
     public static SystemOid fromOID(String oid) {

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 public enum SystemOid {
@@ -17,15 +18,41 @@ public enum SystemOid {
     STATE("2.5.4.8", "State", OidCategory.RDN_ATTRIBUTE_TYPE, "ST", List.of("S")),
     DOMAIN_COMPONENT("0.9.2342.19200300.100.1.25", "Domain Component", OidCategory.RDN_ATTRIBUTE_TYPE, "DC", List.of()),
     COUNTRY("2.5.4.6", "Country", OidCategory.RDN_ATTRIBUTE_TYPE, "C", List.of()),
-    DISTINGUISHED_NAME_QUALIFIER("2.5.4.46", "Distinguished Name Qualifier", OidCategory.RDN_ATTRIBUTE_TYPE, "DNQ", List.of()),
+    DISTINGUISHED_NAME_QUALIFIER("2.5.4.46", "Distinguished Name Qualifier", OidCategory.RDN_ATTRIBUTE_TYPE, "DNQ", List.of("DN", "dnQualifier")),
     TITLE("2.5.4.12", "Title", OidCategory.RDN_ATTRIBUTE_TYPE, "T", List.of("TITLE")),
     SURNAME("2.5.4.4", "Surname", OidCategory.RDN_ATTRIBUTE_TYPE, "SN", List.of("SURNAME")),
     GIVEN_NAME("2.5.4.42", "Given Name", OidCategory.RDN_ATTRIBUTE_TYPE, "GIVENNAME", List.of()),
     INITIALS("2.5.4.43", "Initials", OidCategory.RDN_ATTRIBUTE_TYPE, "INITIALS", List.of()),
     PSEUDONYM("2.5.4.65", "Pseudonym", OidCategory.RDN_ATTRIBUTE_TYPE, "PSEUDONYM", List.of()),
     GENERATION_QUALIFIER("2.5.4.44", "Generation Qualifier", OidCategory.RDN_ATTRIBUTE_TYPE, "GENERATION", List.of()),
+    SERIAL_NUMBER("2.5.4.5", "Serial Number", OidCategory.RDN_ATTRIBUTE_TYPE, "SERIALNUMBER", List.of()),
+    STREET_ADDRESS("2.5.4.9", "Street Address", OidCategory.RDN_ATTRIBUTE_TYPE, "STREET", List.of()),
+    POSTAL_CODE("2.5.4.17", "Postal Code", OidCategory.RDN_ATTRIBUTE_TYPE, "PostalCode", List.of()),
+    BUSINESS_CATEGORY("2.5.4.15", "Business Category", OidCategory.RDN_ATTRIBUTE_TYPE, "BusinessCategory", List.of()),
+    USER_ID("0.9.2342.19200300.100.1.1", "User ID", OidCategory.RDN_ATTRIBUTE_TYPE, "UID", List.of()),
 
-    // Extended Key Usage
+    /**
+     * Certificate extensions a requester plausibly places in a CSR, so that STRICT request-attribute
+     * validation can admit them without an operator first hand-registering the OID.
+     *
+     * <p>Subject Alternative Name (2.5.29.17) is deliberately absent: the request parser diverts it out
+     * of the extension list into {@code subjectAltNames} and a dedicated SAN mapping target exists, so
+     * an extension mapping on it could never match.
+     *
+     * <p>Entries flagged CA-controlled are selectable for display but must be rejected as
+     * request-attribute mapping targets — a requester-supplied value must never drive a cA/pathLen
+     * assertion, a name-constraints tree, or a key identifier that no longer matches the public key.
+     */
+    EXTENDED_KEY_USAGE_EXTENSION("2.5.29.37", "Extended Key Usage", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
+    KEY_USAGE("2.5.29.15", "Key Usage", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, false),
+    BASIC_CONSTRAINTS("2.5.29.19", "Basic Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, true),
+    SUBJECT_KEY_IDENTIFIER("2.5.29.14", "Subject Key Identifier", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, true),
+    SUBJECT_DIRECTORY_ATTRIBUTES("2.5.29.9", "Subject Directory Attributes", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
+    NAME_CONSTRAINTS("2.5.29.30", "Name Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, true),
+    PRIVATE_KEY_USAGE_PERIOD("2.5.29.16", "Private Key Usage Period", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
+    TLS_FEATURE("1.3.6.1.5.5.7.1.24", "TLS Feature", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
+
+    // Extended Key Usage purposes
     SERVER_AUTH("1.3.6.1.5.5.7.3.1", "TLS Web Server Authentication", OidCategory.EXTENDED_KEY_USAGE),
     CLIENT_AUTH("1.3.6.1.5.5.7.3.2", "TLS Web Client Authentication", OidCategory.EXTENDED_KEY_USAGE),
     CODE_SIGNING("1.3.6.1.5.5.7.3.3", "Code Signing", OidCategory.EXTENDED_KEY_USAGE),
@@ -52,17 +79,43 @@ public enum SystemOid {
     private final OidCategory category;
     private final String code;
     private final List<String> altCodes;
+    private final Boolean defaultCritical;
+    private final ExtensionValueEncoding valueEncoding;
+    private final boolean caControlled;
 
+    /** RDN attribute type: carries the short code, plus any alternative spellings that must also parse. */
     SystemOid(String oid, String displayName, OidCategory category, String code, List<String> altCodes) {
+        this(oid, displayName, category, code, altCodes, null, null, false);
+    }
+
+    /** Entry with no additional properties — an extended-key-usage purpose or a generic identifier. */
+    SystemOid(String oid, String displayName, OidCategory category) {
+        this(oid, displayName, category, null, List.of(), null, null, false);
+    }
+
+    /**
+     * Certificate extension: carries the criticality and value-encoding defaults applied when a mapped
+     * request attribute is projected into a certificate request, and whether the issuing CA owns the
+     * extension and so must reject it as a mapping target.
+     */
+    SystemOid(String oid, String displayName, OidCategory category, boolean defaultCritical,
+              ExtensionValueEncoding valueEncoding, boolean caControlled) {
+        this(oid, displayName, category, null, List.of(), defaultCritical, valueEncoding, caControlled);
+    }
+
+    SystemOid(String oid, String displayName, OidCategory category, String code, List<String> altCodes,
+              Boolean defaultCritical, ExtensionValueEncoding valueEncoding, boolean caControlled) {
         this.oid = oid;
         this.displayName = displayName;
         this.category = category;
         this.code = code;
-        this.altCodes = altCodes;
-    }
-
-    SystemOid(String oid, String displayName, OidCategory category) {
-        this(oid, displayName, category, null, null);
+        // Never null so any consumer iterating all values can flatten altCodes without a guard; today
+        // the only unguarded reader is RDN-scoped. Naming the constant matters because a null here
+        // fails class initialisation, which would otherwise surface as a bare NPE.
+        this.altCodes = List.copyOf(Objects.requireNonNull(altCodes, () -> "altCodes must not be null for " + name()));
+        this.defaultCritical = defaultCritical;
+        this.valueEncoding = valueEncoding;
+        this.caControlled = caControlled;
     }
 
     public static SystemOid fromOID(String oid) {

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -35,16 +35,15 @@ public enum SystemOid {
     /**
      * Certificate extensions a requester plausibly places in a CSR. SAN (2.5.29.17) is absent because
      * the parser diverts it into {@code subjectAltNames}, so an extension mapping on it never matches.
-     * The trailing flag marks CA-owned extensions, which must be rejected as mapping targets.
      */
-    EXTENDED_KEY_USAGE_EXTENSION("2.5.29.37", "Extended Key Usage", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
-    KEY_USAGE("2.5.29.15", "Key Usage", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, false),
-    BASIC_CONSTRAINTS("2.5.29.19", "Basic Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, true),
-    SUBJECT_KEY_IDENTIFIER("2.5.29.14", "Subject Key Identifier", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, true),
-    SUBJECT_DIRECTORY_ATTRIBUTES("2.5.29.9", "Subject Directory Attributes", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
-    NAME_CONSTRAINTS("2.5.29.30", "Name Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER, true),
-    PRIVATE_KEY_USAGE_PERIOD("2.5.29.16", "Private Key Usage Period", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
-    TLS_FEATURE("1.3.6.1.5.5.7.1.24", "TLS Feature", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER, false),
+    EXTENDED_KEY_USAGE_EXTENSION("2.5.29.37", "Extended Key Usage", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER),
+    KEY_USAGE("2.5.29.15", "Key Usage", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER),
+    BASIC_CONSTRAINTS("2.5.29.19", "Basic Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER),
+    SUBJECT_KEY_IDENTIFIER("2.5.29.14", "Subject Key Identifier", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER),
+    SUBJECT_DIRECTORY_ATTRIBUTES("2.5.29.9", "Subject Directory Attributes", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER),
+    NAME_CONSTRAINTS("2.5.29.30", "Name Constraints", OidCategory.CERTIFICATE_EXTENSION, true, ExtensionValueEncoding.DER),
+    PRIVATE_KEY_USAGE_PERIOD("2.5.29.16", "Private Key Usage Period", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER),
+    TLS_FEATURE("1.3.6.1.5.5.7.1.24", "TLS Feature", OidCategory.CERTIFICATE_EXTENSION, false, ExtensionValueEncoding.DER),
 
     // Extended Key Usage purposes
     SERVER_AUTH("1.3.6.1.5.5.7.3.1", "TLS Web Server Authentication", OidCategory.EXTENDED_KEY_USAGE),
@@ -69,7 +68,7 @@ public enum SystemOid {
     }
 
     /** Properties only a certificate extension carries; {@code null} for every other category. */
-    private record ExtensionProperties(boolean defaultCritical, ExtensionValueEncoding valueEncoding, boolean caControlled) {}
+    private record ExtensionProperties(boolean defaultCritical, ExtensionValueEncoding valueEncoding) {}
 
     private final String oid;
     private final String displayName;
@@ -89,11 +88,11 @@ public enum SystemOid {
         this(oid, displayName, category, null, List.of(), null);
     }
 
-    /** Certificate extension: projection defaults, plus whether the issuing CA owns the extension. */
+    /** Certificate extension: the criticality and value-encoding defaults applied when projecting. */
     SystemOid(String oid, String displayName, OidCategory category, boolean defaultCritical,
-              ExtensionValueEncoding valueEncoding, boolean caControlled) {
+              ExtensionValueEncoding valueEncoding) {
         this(oid, displayName, category, null, List.of(),
-                new ExtensionProperties(defaultCritical, valueEncoding, caControlled));
+                new ExtensionProperties(defaultCritical, valueEncoding));
     }
 
     SystemOid(String oid, String displayName, OidCategory category, String code, List<String> altCodes,
@@ -116,11 +115,6 @@ public enum SystemOid {
     /** {@code null} unless this is a certificate extension. */
     public ExtensionValueEncoding getValueEncoding() {
         return extensionProperties == null ? null : extensionProperties.valueEncoding();
-    }
-
-    /** Whether the issuing CA owns this extension, making it invalid as a request-attribute mapping target. */
-    public boolean isCaControlled() {
-        return extensionProperties != null && extensionProperties.caControlled();
     }
 
     public static SystemOid fromOID(String oid) {

--- a/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
+++ b/src/main/java/com/otilm/api/model/core/oid/SystemOid.java
@@ -27,7 +27,7 @@ public enum SystemOid {
     PSEUDONYM("2.5.4.65", "Pseudonym", OidCategory.RDN_ATTRIBUTE_TYPE, "PSEUDONYM", List.of()),
     GENERATION_QUALIFIER("2.5.4.44", "Generation Qualifier", OidCategory.RDN_ATTRIBUTE_TYPE, "GENERATION", List.of()),
     SERIAL_NUMBER("2.5.4.5", "Serial Number", OidCategory.RDN_ATTRIBUTE_TYPE, "SERIALNUMBER", List.of()),
-    STREET_ADDRESS("2.5.4.9", "Street Address", OidCategory.RDN_ATTRIBUTE_TYPE, "STREET", List.of()),
+    STREET_ADDRESS("2.5.4.9", "Street Address", OidCategory.RDN_ATTRIBUTE_TYPE, "STREET", List.of("streetAddress")),
     POSTAL_CODE("2.5.4.17", "Postal Code", OidCategory.RDN_ATTRIBUTE_TYPE, "PostalCode", List.of()),
     BUSINESS_CATEGORY("2.5.4.15", "Business Category", OidCategory.RDN_ATTRIBUTE_TYPE, "BusinessCategory", List.of()),
     USER_ID("0.9.2342.19200300.100.1.1", "User ID", OidCategory.RDN_ATTRIBUTE_TYPE, "UID", List.of()),

--- a/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
+++ b/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
@@ -23,10 +23,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 class SystemOidTest {
 
     /**
-     * RDN constants whose code deliberately differs from BouncyCastle's rendered symbol. Each is a
-     * shipped, better-than-BC choice that must stay frozen: renaming one would change how every
-     * already-stored subject DN renders. {@code PSEUDONYM} is absent because it differs from BC only
-     * in case, which the parity comparison ignores.
+     * Codes that deliberately differ from BouncyCastle's symbol. Frozen: renaming one would change how
+     * every stored subject DN renders. {@code PSEUDONYM} differs only in case, which parity ignores.
      */
     private static final Set<SystemOid> FROZEN_BC_SYMBOL_DIVERGENCES = Set.of(
             SystemOid.EMAIL,                          // ours EMAIL, BC E
@@ -35,9 +33,8 @@ class SystemOidTest {
     );
 
     /**
-     * RDN constants knowingly registered for an OID BouncyCastle has no symbol for. Such an OID
-     * currently renders as its dotted form, so giving it a code changes stored DN text and requires a
-     * {@code updateCertificateDNs} migration. Empty by design — an entry here is a decision record.
+     * OIDs BouncyCastle has no symbol for, knowingly given a code. Such an OID renders as its dotted
+     * form today, so a code changes stored DN text and needs an {@code updateCertificateDNs} migration.
      */
     private static final Set<SystemOid> RDN_CODES_WITHOUT_BC_SYMBOL = Set.of();
 
@@ -76,8 +73,8 @@ class SystemOidTest {
 
     @Test
     void marksCaOwnedExtensionsAsIneligibleMappingTargets() {
-        // given — the CA owns these: a requester-supplied value must never drive a cA/pathLen
-        // assertion, a name-constraints tree, or a key identifier that no longer matches the key
+        // given — a requester-supplied value must never drive cA/pathLen, a name-constraints tree,
+        // or a key identifier that no longer matches the key
         // when / then
         assertTrue(SystemOid.fromOID("2.5.29.19").isCaControlled(), "basicConstraints must be CA-controlled");
         assertTrue(SystemOid.fromOID("2.5.29.30").isCaControlled(), "nameConstraints must be CA-controlled");
@@ -96,9 +93,8 @@ class SystemOidTest {
 
     @Test
     void doesNotSeedSmimeCapabilitiesUntilItsCsrPlacementIsConfirmed() {
-        // given — 1.2.840.113549.1.9.15 is dual-natured: in its PKCS#9 CSR-attribute form the request
-        // parser never sees it, so a mapping would be a silent no-op. Shipped constants are costly to
-        // withdraw, so it stays out until a captured CSR proves the extensionRequest placement.
+        // given — dual-natured: in its PKCS#9 CSR-attribute form the parser never sees it, so a
+        // mapping would be a silent no-op. Out until a captured CSR proves the extensionRequest form.
         // when / then
         assertNull(SystemOid.fromOID("1.2.840.113549.1.9.15"),
                 "smimeCapabilities must stay deferred until its extensionRequest placement is verified");
@@ -139,9 +135,8 @@ class SystemOidTest {
 
     @Test
     void givesSerialNumberNoAltCodesSoItCanNeverBeReachedAsSn() {
-        // given — SN is surname (2.5.4.4) in OpenSSL, RFC 4519 and BouncyCastle. The RFC 4519 spelling
-        // of 2.5.4.5 is serialNumber, which differs from the code only in case, and the platform's
-        // code lookup is already case-insensitive.
+        // given — SN is surname (2.5.4.4) everywhere. The RFC 4519 spelling of 2.5.4.5 differs from
+        // the code only in case, and the code lookup is already case-insensitive.
         SystemOid serialNumber = SystemOid.fromOID("2.5.4.5");
 
         // when / then
@@ -199,9 +194,9 @@ class SystemOidTest {
                 if (RDN_CODES_WITHOUT_BC_SYMBOL.contains(entry)) {
                     continue;
                 }
-                fail("BouncyCastle has no symbol for " + entry.name() + " (" + entry.getOid() + "), so giving it "
-                        + "code '" + entry.getCode() + "' changes rendering from the dotted OID and needs an "
-                        + "updateCertificateDNs migration; add it to RDN_CODES_WITHOUT_BC_SYMBOL once that is done");
+                fail("no BouncyCastle symbol for " + entry.name() + " (" + entry.getOid() + "), so code '"
+                        + entry.getCode() + "' changes rendering from the dotted OID and needs an "
+                        + "updateCertificateDNs migration; then add it to RDN_CODES_WITHOUT_BC_SYMBOL");
             }
             assertEquals(bcSymbol.toLowerCase(Locale.ROOT), entry.getCode().toLowerCase(Locale.ROOT),
                     "code for " + entry.name() + " (" + entry.getOid() + ") diverges from BouncyCastle's symbol; "
@@ -223,10 +218,9 @@ class SystemOidTest {
 
     @Test
     void keepsEveryRdnCodeAndAltCodeUniqueAcrossConstants() {
-        // given — OidHandler flattens every code and altCode of every RDN entry into one
-        // case-insensitive map with no collision check, so a duplicate token resolves to an arbitrary
-        // OID. Deduplicate within a constant first: several BC symbols differ from their RFC 4519
-        // spelling only in case.
+        // given — OidHandler flattens codes and altCodes into one case-insensitive map with no
+        // collision check, so a duplicate resolves arbitrarily. Dedupe within a constant first:
+        // several BC symbols differ from their RFC 4519 spelling only in case.
         Map<String, String> owner = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         // when / then

--- a/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
+++ b/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
@@ -1,0 +1,274 @@
+package com.otilm.api.model.core.oid;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class SystemOidTest {
+
+    /**
+     * RDN constants whose code deliberately differs from BouncyCastle's rendered symbol. Each is a
+     * shipped, better-than-BC choice that must stay frozen: renaming one would change how every
+     * already-stored subject DN renders. {@code PSEUDONYM} is absent because it differs from BC only
+     * in case, which the parity comparison ignores.
+     */
+    private static final Set<SystemOid> FROZEN_BC_SYMBOL_DIVERGENCES = Set.of(
+            SystemOid.EMAIL,                          // ours EMAIL, BC E
+            SystemOid.SURNAME,                        // ours SN (OpenSSL / RFC 4519 short name), BC SURNAME
+            SystemOid.DISTINGUISHED_NAME_QUALIFIER    // ours DNQ, BC DN — which universally means distinguished name
+    );
+
+    /**
+     * RDN constants knowingly registered for an OID BouncyCastle has no symbol for. Such an OID
+     * currently renders as its dotted form, so giving it a code changes stored DN text and requires a
+     * {@code updateCertificateDNs} migration. Empty by design — an entry here is a decision record.
+     */
+    private static final Set<SystemOid> RDN_CODES_WITHOUT_BC_SYMBOL = Set.of();
+
+    /** Expected properties of one seeded certificate extension. */
+    private record ExtensionExpectation(String displayName, boolean defaultCritical, boolean caControlled) {}
+
+    private static final Map<String, ExtensionExpectation> EXPECTED_EXTENSIONS = Map.of(
+            "2.5.29.37", new ExtensionExpectation("Extended Key Usage", false, false),
+            "2.5.29.15", new ExtensionExpectation("Key Usage", true, false),
+            "2.5.29.19", new ExtensionExpectation("Basic Constraints", true, true),
+            "2.5.29.14", new ExtensionExpectation("Subject Key Identifier", false, true),
+            "2.5.29.9", new ExtensionExpectation("Subject Directory Attributes", false, false),
+            "2.5.29.30", new ExtensionExpectation("Name Constraints", true, true),
+            "2.5.29.16", new ExtensionExpectation("Private Key Usage Period", false, false),
+            "1.3.6.1.5.5.7.1.24", new ExtensionExpectation("TLS Feature", false, false)
+    );
+
+    @Test
+    void seedsTheCertificateExtensionsThatRequestersPutInACsr() {
+        // when
+        List<SystemOid> extensions = byCategory(OidCategory.CERTIFICATE_EXTENSION);
+
+        // then
+        assertEquals(EXPECTED_EXTENSIONS.size(), extensions.size(), "unexpected number of certificate-extension entries");
+        for (SystemOid entry : extensions) {
+            ExtensionExpectation expected = EXPECTED_EXTENSIONS.get(entry.getOid());
+            assertNotNull(expected, "unexpected certificate-extension OID " + entry.getOid());
+            // The display name is what an operator picks from in the mapping dropdown, so a name/OID
+            // mismatch would silently mint the wrong extension.
+            assertEquals(expected.displayName(), entry.getDisplayName(), "wrong displayName for " + entry.getOid());
+            assertEquals(expected.defaultCritical(), entry.getDefaultCritical(), "wrong defaultCritical for " + entry.getOid());
+            assertEquals(expected.caControlled(), entry.isCaControlled(), "wrong caControlled for " + entry.getOid());
+            assertEquals(ExtensionValueEncoding.DER, entry.getValueEncoding(), "wrong valueEncoding for " + entry.getOid());
+        }
+    }
+
+    @Test
+    void marksCaOwnedExtensionsAsIneligibleMappingTargets() {
+        // given — the CA owns these: a requester-supplied value must never drive a cA/pathLen
+        // assertion, a name-constraints tree, or a key identifier that no longer matches the key
+        // when / then
+        assertTrue(SystemOid.fromOID("2.5.29.19").isCaControlled(), "basicConstraints must be CA-controlled");
+        assertTrue(SystemOid.fromOID("2.5.29.30").isCaControlled(), "nameConstraints must be CA-controlled");
+        assertTrue(SystemOid.fromOID("2.5.29.14").isCaControlled(), "subjectKeyIdentifier must be CA-controlled");
+        assertFalse(SystemOid.fromOID("2.5.29.37").isCaControlled(), "extKeyUsage is requester-mappable");
+    }
+
+    @Test
+    void doesNotRegisterSubjectAlternativeNameAsACertificateExtension() {
+        // given — rationale recorded on the CERTIFICATE_EXTENSION group in SystemOid
+        var san = SystemOid.fromOID("2.5.29.17");
+
+        // when / then
+        assertNull(san, "2.5.29.17 must not be a system OID; use the SAN mapping target");
+    }
+
+    @Test
+    void doesNotSeedSmimeCapabilitiesUntilItsCsrPlacementIsConfirmed() {
+        // given — 1.2.840.113549.1.9.15 is dual-natured: in its PKCS#9 CSR-attribute form the request
+        // parser never sees it, so a mapping would be a silent no-op. Shipped constants are costly to
+        // withdraw, so it stays out until a captured CSR proves the extensionRequest placement.
+        // when / then
+        assertNull(SystemOid.fromOID("1.2.840.113549.1.9.15"),
+                "smimeCapabilities must stay deferred until its extensionRequest placement is verified");
+    }
+
+    @Test
+    void leavesExtensionPropertiesUnsetForNonExtensionEntries() {
+        // given / when / then
+        for (SystemOid entry : SystemOid.values()) {
+            if (entry.getCategory() == OidCategory.CERTIFICATE_EXTENSION) {
+                continue;
+            }
+            assertNull(entry.getDefaultCritical(), "defaultCritical must be null for " + entry.name());
+            assertNull(entry.getValueEncoding(), "valueEncoding must be null for " + entry.name());
+            assertFalse(entry.isCaControlled(), "caControlled must be false for " + entry.name());
+        }
+    }
+
+    @Test
+    void seedsTheRdnTypesNeededWhenAuthoringAMapping() {
+        // given — OID, expected code (BouncyCastle's symbol verbatim, including its casing)
+        Map<String, String> expected = Map.of(
+                "2.5.4.5", "SERIALNUMBER",
+                "2.5.4.9", "STREET",
+                "2.5.4.17", "PostalCode",
+                "2.5.4.15", "BusinessCategory",
+                "0.9.2342.19200300.100.1.1", "UID"
+        );
+
+        // when / then
+        expected.forEach((oid, code) -> {
+            SystemOid entry = SystemOid.fromOID(oid);
+            assertNotNull(entry, "missing RDN entry for " + oid);
+            assertEquals(OidCategory.RDN_ATTRIBUTE_TYPE, entry.getCategory(), "wrong category for " + oid);
+            assertEquals(code, entry.getCode(), "wrong code for " + oid);
+        });
+    }
+
+    @Test
+    void givesSerialNumberNoAltCodesSoItCanNeverBeReachedAsSn() {
+        // given — SN is surname (2.5.4.4) in OpenSSL, RFC 4519 and BouncyCastle. The RFC 4519 spelling
+        // of 2.5.4.5 is serialNumber, which differs from the code only in case, and the platform's
+        // code lookup is already case-insensitive.
+        SystemOid serialNumber = SystemOid.fromOID("2.5.4.5");
+
+        // when / then
+        assertNotNull(serialNumber);
+        assertTrue(serialNumber.getAltCodes().isEmpty(), "2.5.4.5 must declare no alt codes");
+        assertEquals("SN", SystemOid.fromOID("2.5.4.4").getCode(), "SN must remain surname");
+    }
+
+    @Test
+    void letsDnQualifierParseUnderItsStandardSpellings() {
+        // given — a DN written dnQualifier=x resolves in neither the platform registry nor
+        // BouncyCastle today, because BC binds only "dn"
+        SystemOid dnQualifier = SystemOid.fromOID("2.5.4.46");
+
+        // when
+        Set<String> altCodes = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        altCodes.addAll(dnQualifier.getAltCodes());
+
+        // then
+        assertTrue(altCodes.contains("DN"), "2.5.4.46 must accept BouncyCastle's DN spelling");
+        assertTrue(altCodes.contains("dnQualifier"), "2.5.4.46 must accept the RFC 4519 / OpenSSL spelling");
+    }
+
+    @Test
+    void declaresAltCodesAsAnEmptyListRatherThanNull() {
+        // given — consumers iterate altCodes across every category without a null guard
+        // when / then
+        for (SystemOid entry : SystemOid.values()) {
+            assertNotNull(entry.getAltCodes(), "altCodes must not be null for " + entry.name());
+        }
+    }
+
+    @Test
+    void keepsEveryOidUniqueAcrossConstants() {
+        // given — fromOID resolves with findFirst, so a duplicated OID silently returns whichever
+        // constant is declared first
+        // when
+        long distinctOids = Arrays.stream(SystemOid.values()).map(SystemOid::getOid).distinct().count();
+
+        // then
+        assertEquals(SystemOid.values().length, distinctOids, "two constants share an OID");
+    }
+
+    @Test
+    void rendersEveryRdnUnderBouncyCastlesSymbolExceptTheFrozenDivergences() {
+        // given — matching BC's symbol keeps the rendered subject-DN token unchanged, so no stored DN
+        // needs rewriting
+        // when / then
+        for (SystemOid entry : byCategory(OidCategory.RDN_ATTRIBUTE_TYPE)) {
+            if (FROZEN_BC_SYMBOL_DIVERGENCES.contains(entry)) {
+                continue;
+            }
+            String bcSymbol = BCStyle.INSTANCE.oidToDisplayName(new ASN1ObjectIdentifier(entry.getOid()));
+            if (bcSymbol == null) {
+                if (RDN_CODES_WITHOUT_BC_SYMBOL.contains(entry)) {
+                    continue;
+                }
+                fail("BouncyCastle has no symbol for " + entry.name() + " (" + entry.getOid() + "), so giving it "
+                        + "code '" + entry.getCode() + "' changes rendering from the dotted OID and needs an "
+                        + "updateCertificateDNs migration; add it to RDN_CODES_WITHOUT_BC_SYMBOL once that is done");
+            }
+            assertEquals(bcSymbol.toLowerCase(Locale.ROOT), entry.getCode().toLowerCase(Locale.ROOT),
+                    "code for " + entry.name() + " (" + entry.getOid() + ") diverges from BouncyCastle's symbol; "
+                            + "either match it or migrate stored DNs with updateCertificateDNs");
+        }
+    }
+
+    @Test
+    void keepsEveryFrozenDivergenceActuallyDivergent() {
+        // given — a frozen entry that no longer diverges must be removed from the list
+        // when / then
+        for (SystemOid entry : FROZEN_BC_SYMBOL_DIVERGENCES) {
+            String bcSymbol = BCStyle.INSTANCE.oidToDisplayName(new ASN1ObjectIdentifier(entry.getOid()));
+            assertNotNull(bcSymbol, "no BouncyCastle symbol for " + entry.name() + "; it cannot diverge");
+            assertFalse(bcSymbol.equalsIgnoreCase(entry.getCode()),
+                    entry.name() + " no longer diverges from BouncyCastle; drop it from the frozen list");
+        }
+    }
+
+    @Test
+    void keepsEveryRdnCodeAndAltCodeUniqueAcrossConstants() {
+        // given — OidHandler flattens every code and altCode of every RDN entry into one
+        // case-insensitive map with no collision check, so a duplicate token resolves to an arbitrary
+        // OID. Deduplicate within a constant first: several BC symbols differ from their RFC 4519
+        // spelling only in case.
+        Map<String, String> owner = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        // when / then
+        for (SystemOid entry : byCategory(OidCategory.RDN_ATTRIBUTE_TYPE)) {
+            for (String token : distinctTokens(entry)) {
+                String previous = owner.put(token, entry.name());
+                assertNull(previous, "token '" + token + "' is claimed by both " + previous + " and " + entry.name());
+            }
+        }
+    }
+
+    @Test
+    void neverShadowsABouncyCastleKeywordBoundToADifferentOid() {
+        // given — PlatformX500NameStyle resolves RDN codes registry-first, so a token we bind
+        // silently overrides BouncyCastle's binding when parsing DN strings from other systems
+        // when / then
+        for (SystemOid entry : byCategory(OidCategory.RDN_ATTRIBUTE_TYPE)) {
+            for (String token : distinctTokens(entry)) {
+                ASN1ObjectIdentifier bcOid;
+                try {
+                    bcOid = BCStyle.INSTANCE.attrNameToOID(token);
+                } catch (IllegalArgumentException e) {
+                    continue; // BouncyCastle does not know this token, so nothing can be shadowed
+                }
+                assertEquals(entry.getOid(), bcOid.getId(),
+                        "token '" + token + "' on " + entry.name() + " shadows BouncyCastle's binding to " + bcOid.getId());
+            }
+        }
+    }
+
+    private static List<SystemOid> byCategory(OidCategory category) {
+        return Arrays.stream(SystemOid.values()).filter(e -> e.getCategory() == category).toList();
+    }
+
+    /** Codes and alt codes of one entry, deduplicated case-insensitively. */
+    private static Set<String> distinctTokens(SystemOid entry) {
+        Set<String> tokens = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        List<String> all = new ArrayList<>(entry.getAltCodes());
+        if (entry.getCode() != null) {
+            all.add(entry.getCode());
+        }
+        tokens.addAll(all);
+        return tokens;
+    }
+}

--- a/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
+++ b/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
@@ -39,17 +39,17 @@ class SystemOidTest {
     private static final Set<SystemOid> RDN_CODES_WITHOUT_BC_SYMBOL = Set.of();
 
     /** Expected properties of one seeded certificate extension. */
-    private record ExtensionExpectation(String displayName, boolean defaultCritical, boolean caControlled) {}
+    private record ExtensionExpectation(String displayName, boolean defaultCritical) {}
 
     private static final Map<String, ExtensionExpectation> EXPECTED_EXTENSIONS = Map.of(
-            "2.5.29.37", new ExtensionExpectation("Extended Key Usage", false, false),
-            "2.5.29.15", new ExtensionExpectation("Key Usage", true, false),
-            "2.5.29.19", new ExtensionExpectation("Basic Constraints", true, true),
-            "2.5.29.14", new ExtensionExpectation("Subject Key Identifier", false, true),
-            "2.5.29.9", new ExtensionExpectation("Subject Directory Attributes", false, false),
-            "2.5.29.30", new ExtensionExpectation("Name Constraints", true, true),
-            "2.5.29.16", new ExtensionExpectation("Private Key Usage Period", false, false),
-            "1.3.6.1.5.5.7.1.24", new ExtensionExpectation("TLS Feature", false, false)
+            "2.5.29.37", new ExtensionExpectation("Extended Key Usage", false),
+            "2.5.29.15", new ExtensionExpectation("Key Usage", true),
+            "2.5.29.19", new ExtensionExpectation("Basic Constraints", true),
+            "2.5.29.14", new ExtensionExpectation("Subject Key Identifier", false),
+            "2.5.29.9", new ExtensionExpectation("Subject Directory Attributes", false),
+            "2.5.29.30", new ExtensionExpectation("Name Constraints", true),
+            "2.5.29.16", new ExtensionExpectation("Private Key Usage Period", false),
+            "1.3.6.1.5.5.7.1.24", new ExtensionExpectation("TLS Feature", false)
     );
 
     @Test
@@ -66,20 +66,8 @@ class SystemOidTest {
             // mismatch would silently mint the wrong extension.
             assertEquals(expected.displayName(), entry.getDisplayName(), "wrong displayName for " + entry.getOid());
             assertEquals(expected.defaultCritical(), entry.getDefaultCritical(), "wrong defaultCritical for " + entry.getOid());
-            assertEquals(expected.caControlled(), entry.isCaControlled(), "wrong caControlled for " + entry.getOid());
             assertEquals(ExtensionValueEncoding.DER, entry.getValueEncoding(), "wrong valueEncoding for " + entry.getOid());
         }
-    }
-
-    @Test
-    void marksCaOwnedExtensionsAsIneligibleMappingTargets() {
-        // given — a requester-supplied value must never drive cA/pathLen, a name-constraints tree,
-        // or a key identifier that no longer matches the key
-        // when / then
-        assertTrue(SystemOid.fromOID("2.5.29.19").isCaControlled(), "basicConstraints must be CA-controlled");
-        assertTrue(SystemOid.fromOID("2.5.29.30").isCaControlled(), "nameConstraints must be CA-controlled");
-        assertTrue(SystemOid.fromOID("2.5.29.14").isCaControlled(), "subjectKeyIdentifier must be CA-controlled");
-        assertFalse(SystemOid.fromOID("2.5.29.37").isCaControlled(), "extKeyUsage is requester-mappable");
     }
 
     @Test
@@ -109,7 +97,6 @@ class SystemOidTest {
             }
             assertNull(entry.getDefaultCritical(), "defaultCritical must be null for " + entry.name());
             assertNull(entry.getValueEncoding(), "valueEncoding must be null for " + entry.name());
-            assertFalse(entry.isCaControlled(), "caControlled must be false for " + entry.name());
         }
     }
 

--- a/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
+++ b/src/test/java/com/otilm/api/model/core/oid/SystemOidTest.java
@@ -101,6 +101,36 @@ class SystemOidTest {
     }
 
     @Test
+    void givesEveryCertificateExtensionItsProjectionDefaults() {
+        // given — the mirror of leavesExtensionPropertiesUnsetForNonExtensionEntries. An extension
+        // declared through the no-properties constructor compiles fine and yields a null
+        // defaultCritical, which is the shape behind emitting a critical extension as non-critical.
+        List<SystemOid> extensions = byCategory(OidCategory.CERTIFICATE_EXTENSION);
+
+        // when / then
+        assertFalse(extensions.isEmpty(), "no certificate extensions are seeded");
+        for (SystemOid entry : extensions) {
+            assertNotNull(entry.getDefaultCritical(), "defaultCritical missing for " + entry.name());
+            assertNotNull(entry.getValueEncoding(), "valueEncoding missing for " + entry.name());
+        }
+    }
+
+    @Test
+    void letsStreetAddressParseUnderItsOpenSslSpelling() {
+        // given — the registry binds STREET and BouncyCastle binds only "street", so the OpenSSL long
+        // name resolves in neither without an alt code
+        SystemOid street = SystemOid.fromOID("2.5.4.9");
+
+        // when
+        Set<String> altCodes = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        altCodes.addAll(street.getAltCodes());
+
+        // then — parse-only, so the rendered token stays STREET and no stored DN changes
+        assertTrue(altCodes.contains("streetAddress"), "2.5.4.9 must accept the OpenSSL long name");
+        assertEquals("STREET", street.getCode());
+    }
+
+    @Test
     void seedsTheRdnTypesNeededWhenAuthoringAMapping() {
         // given — OID, expected code (BouncyCastle's symbol verbatim, including its casing)
         Map<String, String> expected = Map.of(


### PR DESCRIPTION
Closes #791

## Release sequencing — must not ship alone

This is 1 of 3 cross-repo changes. Merging the interfaces bump without the paired core change leaves two defects live:

- `NAME_CONSTRAINTS` declares `defaultCritical = true`, but core's `getOidToRecordMap` builds system `OidRecord`s without the field, so `2.5.29.30` would project **non-critical**, contrary to RFC 5280 §4.2.1.10. `KEY_USAGE` and `BASIC_CONSTRAINTS` are masked from this by `X509RequestContentRenderer.CRITICALITY_FORCED_OIDS`; name constraints is not.
- `GET /v1/oids/system?category=certificateExtension` would return the eight new entries with `additionalProperties` absent, although `CertificateExtensionOidPropertiesDto` marks both fields `@NotNull` / REQUIRED — the response would violate its own published schema.

Paired work: **core#1894** (registry propagation, `caControlled` enforcement, upgrade guards, migration) and **fe-administrator#1936** (merge system entries into the extension dropdown). Until core#1894 lands, the seeded extensions are also unreachable from the admin UI, so this is not a user-facing feature on its own.

Two existing core integration tests break on the interfaces bump and are handled in core#1894: `CustomOidEntryServiceITest` asserts the system `CERTIFICATE_EXTENSION` list is empty, and `PlatformX500NameStyleITest` registers a custom RDN coded `UID` that this branch's `USER_ID` constant now contests.

## What changed

`SystemOid` gains `defaultCritical` and `valueEncoding`, so the enum can express a certificate extension at all — the branch in `AttributeEngine.validateMappedField` that accepts a system extension OID has been unreachable dead code until now.

**Eight certificate extensions**, all `valueEncoding = DER`: `2.5.29.37` EKU, `2.5.29.15` keyUsage (critical), `2.5.29.19` basicConstraints (critical), `2.5.29.14` SKI, `2.5.29.9` subjectDirectoryAttributes, `2.5.29.30` nameConstraints (critical), `2.5.29.16` privateKeyUsagePeriod, `1.3.6.1.5.5.7.1.24` TLS Feature.

**Five RDN types**: `2.5.4.5` `SERIALNUMBER`, `2.5.4.9` `STREET`, `2.5.4.17` `PostalCode`, `2.5.4.15` `BusinessCategory`, `0.9.2342.19200300.100.1.1` `UID`.

## Decisions worth reviewing

**A `caControlled` marker was proposed, implemented, and then reverted.** It marked basicConstraints, nameConstraints and subjectKeyIdentifier as CA-owned and had core refuse them as request-attribute mapping targets, on the grounds that a requester-supplied value must not drive a cA/pathLen assertion, a name-constraints tree, or a stale key identifier.

A multi-reviewer pass on core#1895 showed that breaks more than it protects. The STRICT whitelist admits an extension only when some request attribute maps its OID — `mappedExtensionOids` is populated solely from `ExtensionMappedField`, and the check is plain set membership with no exemption path. So refusing those OIDs as mapping targets also refused them **in incoming CSRs**, which is the exact failure core#1883 exists to fix, for an extension seeded here precisely because `openssl req -addext` emits it. An earlier version of this description claimed they stayed "admissible under the STRICT whitelist" — that was false.

Reverted in `28a2c4eb`. The mapping risk it addressed already existed, since any extension OID could be registered as a Custom OID and mapped. Blocking it properly needs a whitelist exemption plus a projection-time guard designed together, which is separate work.

**RDN codes are BouncyCastle `BCStyle` symbols verbatim**, including its inconsistent casing (`PostalCode`, `BusinessCategory`). This is a migration-cost decision, not a claim that BC is authoritative: `PlatformX500NameStyle` falls back to BC's table, so a matching code leaves the rendered subject-DN token byte-identical and no stored DN needs rewriting. Standard RFC 4519 / OpenSSL spellings are added as **alt codes** instead, which are parse-only and never render.

**Three pre-existing BC divergences stay frozen** (`EMAIL`/`E`, `SN`/`SURNAME`, `DNQ`/`DN`), enforced by an explicit exception set in the parity test. Two are better than BC's choice — `SN` is the OpenSSL and RFC 4519 short name, and BC's `DN` for dnQualifier collides with the universal meaning of "DN" — and renaming any of them would require rewriting stored DNs.

**`2.5.29.17` subjectAlternativeName is deliberately not registered.** The parser diverts it into `subjectAltNames` and a dedicated SAN mapping target exists, so an extension mapping on it could never match.

**`1.2.840.113549.1.9.15` smimeCapabilities is deliberately not seeded.** It is dual-natured, and in its PKCS#9 CSR-attribute form the parser never sees it, so a mapping would be a silent no-op. Its candidacy rested on an unverified claim about Windows tooling emitting it inside `extensionRequest`; it stays out until a captured CSR confirms that, since removing a shipped constant breaks stored mappings. A test pins the deferral.

**`2.5.4.5` takes no alt codes.** Its RFC 4519 spelling `serialNumber` differs from the code only in case and the lookup is already case-insensitive. It must never be aliased to `SN`, which is surname.

**`dnQualifier` gains `DN` and `dnQualifier` alt codes**, closing a parse gap where a DN written `dnQualifier=x` resolved in neither the registry nor BouncyCastle.

## Tests

14 new tests, 445/445 suite green. `SystemOid` line and branch coverage 100%. Beyond asserting the seeded data, four are standing guards:

- BouncyCastle symbol parity, failing on a new code that diverges *or* on an OID BC has no symbol for — both cases need an `updateCertificateDNs` migration, each with its own explicit opt-out set.
- Code and alt-code uniqueness across constants, case-insensitively, because `OidHandler` flattens them into one case-insensitive map with no collision check.
- No token may shadow a BouncyCastle keyword bound to a different OID, since RDN resolution is registry-first and would silently override BC when parsing DNs from other systems.
- OID uniqueness across constants — `fromOID` is `findFirst`, so a duplicate would resolve silently.

These live here rather than in core because `bcprov` is a compile-scope dependency of this repo.

