### PR TITLE
Classify resource actions by access type and add REGISTER action

### DIFF
--- a/src/main/java/com/otilm/core/model/auth/ResourceAction.java
+++ b/src/main/java/com/otilm/core/model/auth/ResourceAction.java
@@ -11,54 +11,68 @@ import java.util.Arrays;
 
 @Schema(enumAsRef = true)
 public enum ResourceAction implements IPlatformEnum {
-    NONE("NONE", "None"),
-    ANY("ANY", "Any"), // Action that is evaluated as any action
-    MEMBERS("members", "Members"), // action that is evaluated to allow action for resource lower in hierarchy, e.g. access to certificates through RA profile members action
+    NONE("NONE", "None", AccessType.NOT_GRANTABLE),
+    ANY("ANY", "Any", AccessType.NOT_GRANTABLE), // Action that is evaluated as any action
+    MEMBERS("members", "Members", AccessType.READ), // action that is evaluated to allow action for resource lower in hierarchy, e.g. access to certificates through RA profile members action
 
     // Default (CRUD) Actions
-    LIST("list", "List"),
-    DETAIL("detail", "Detail"),
-    CREATE("create", "Create"),
-    UPDATE("update", "Update"),
-    DELETE("delete", "Delete"),
+    LIST("list", "List", AccessType.READ),
+    DETAIL("detail", "Detail", AccessType.READ),
+    CREATE("create", "Create", AccessType.WRITE),
+    UPDATE("update", "Update", AccessType.WRITE),
+    DELETE("delete", "Delete", AccessType.WRITE),
 
     // Default change state actions that allows also reverse action (disable/deactivate)
-    ENABLE("enable", "Enable"),
-    ACTIVATE("activate", "Activate"),
+    ENABLE("enable", "Enable", AccessType.WRITE),
+    ACTIVATE("activate", "Activate", AccessType.WRITE),
 
     // Connector actions
-    APPROVE("approve", "Approve"),
-    CONNECT("connect", "Connect"), // allows also reconnect action
+    APPROVE("approve", "Approve", AccessType.WRITE),
+    CONNECT("connect", "Connect", AccessType.WRITE), // allows also reconnect action
 
     // Certificate actions
-    ISSUE("issue", "Issue"),
-    RENEW("renew", "Renew"),
-    REKEY("rekey", "Rekey"),
-    REVOKE("revoke", "Revoke"),
-    ARCHIVE("archive", "Archive"),
+    REGISTER("register", "Register", AccessType.WRITE),
+    ISSUE("issue", "Issue", AccessType.WRITE),
+    RENEW("renew", "Renew", AccessType.WRITE),
+    REKEY("rekey", "Rekey", AccessType.WRITE),
+    REVOKE("revoke", "Revoke", AccessType.WRITE),
+    ARCHIVE("archive", "Archive", AccessType.WRITE),
 
     // Audit Log export
-    EXPORT("export", "Export"),
+    EXPORT("export", "Export", AccessType.READ),
 
     // Certificate, RA Profile and Compliance Profile
-    CHECK_COMPLIANCE("checkCompliance", "Check compliance"),
+    CHECK_COMPLIANCE("checkCompliance", "Check compliance", AccessType.WRITE),
 
     // Cryptography operation
-    ENCRYPT("encrypt", "Encrypt"),
-    DECRYPT("decrypt", "Decrypt"),
-    VERIFY("verify", "Verify"),
-    SIGN("sign", "Sign"),
+    ENCRYPT("encrypt", "Encrypt", AccessType.WRITE),
+    DECRYPT("decrypt", "Decrypt", AccessType.WRITE),
+    VERIFY("verify", "Verify", AccessType.WRITE),
+    SIGN("sign", "Sign", AccessType.WRITE),
 
     // PROXY
-    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation"),
+    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation", AccessType.READ),
 
     // Secret
-    GET_SECRET_CONTENT("getSecretContent", "Get secret content"),
-    UPDATE_SOURCE_VAULT_PROFILE("updateSourceVaultProfile", "Update source vault profile"),
+    GET_SECRET_CONTENT("getSecretContent", "Get secret content", AccessType.SENSITIVE_READ),
+    UPDATE_SOURCE_VAULT_PROFILE("updateSourceVaultProfile", "Update source vault profile", AccessType.WRITE),
 
     // Digital Signing
-    TIMESTAMP("timestamp", "Timestamp"), // RFC 3161 Timestamping
+    TIMESTAMP("timestamp", "Timestamp", AccessType.WRITE), // RFC 3161 Timestamping
     ;
+
+    /**
+     * Declares whether invoking an action reads or changes platform state, so that a permission set can be
+     * derived from the action catalogue instead of being maintained by hand. {@code SENSITIVE_READ} is a read
+     * that exposes stored secret material, and is therefore withheld from roles granted plain read access.
+     * {@code NOT_GRANTABLE} marks the sentinels that never appear in a stored permission row.
+     */
+    public enum AccessType {
+        READ,
+        WRITE,
+        SENSITIVE_READ,
+        NOT_GRANTABLE
+    }
 
     @Schema(description = "Resource Action Name",
             example = "create",
@@ -72,9 +86,12 @@ public enum ResourceAction implements IPlatformEnum {
 
     private final String label;
 
-    ResourceAction(String code, String label) {
+    private final AccessType accessType;
+
+    ResourceAction(String code, String label, AccessType accessType) {
         this.code = code;
         this.label = label;
+        this.accessType = accessType;
     }
 
     @JsonValue
@@ -90,6 +107,10 @@ public enum ResourceAction implements IPlatformEnum {
     @Override
     public String getDescription() {
         return null;
+    }
+
+    public AccessType getAccessType() {
+        return this.accessType;
     }
 
     @JsonCreator

--- a/src/main/java/com/otilm/core/model/auth/ResourceAction.java
+++ b/src/main/java/com/otilm/core/model/auth/ResourceAction.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 @Schema(enumAsRef = true)
 public enum ResourceAction implements IPlatformEnum {
     NONE("NONE", "None", AccessType.NOT_GRANTABLE),
-    ANY("ANY", "Any", AccessType.NOT_GRANTABLE), // Action that is evaluated as any action
+    ANY("ANY", "Any", AccessType.NOT_GRANTABLE),
     MEMBERS("members", "Members", AccessType.READ), // action that is evaluated to allow action for resource lower in hierarchy, e.g. access to certificates through RA profile members action
 
     // Default (CRUD) Actions
@@ -31,6 +31,8 @@ public enum ResourceAction implements IPlatformEnum {
     CONNECT("connect", "Connect", AccessType.WRITE), // allows also reconnect action
 
     // Certificate actions
+    // auth-opa-policies pairs this code with Resource.CONNECTOR in resourcesWithAnonymousAccess, so annotating
+    // it on that resource would leave the endpoint reachable unauthenticated.
     REGISTER("register", "Register", AccessType.WRITE),
     ISSUE("issue", "Issue", AccessType.WRITE),
     RENEW("renew", "Renew", AccessType.WRITE),
@@ -51,7 +53,8 @@ public enum ResourceAction implements IPlatformEnum {
     SIGN("sign", "Sign", AccessType.WRITE),
 
     // PROXY
-    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation", AccessType.READ),
+    // Instructions embed a client secret, a broker SAS key and a non-expiring configuration token.
+    GET_PROXY_INSTALLATION("getProxyInstallation", "Get proxy installation", AccessType.SENSITIVE_READ),
 
     // Secret
     GET_SECRET_CONTENT("getSecretContent", "Get secret content", AccessType.SENSITIVE_READ),
@@ -62,16 +65,27 @@ public enum ResourceAction implements IPlatformEnum {
     ;
 
     /**
-     * Declares whether invoking an action reads or changes platform state, so that a permission set can be
-     * derived from the action catalogue instead of being maintained by hand. {@code SENSITIVE_READ} is a read
-     * that exposes stored secret material, and is therefore withheld from roles granted plain read access.
-     * {@code NOT_GRANTABLE} marks the sentinels that never appear in a stored permission row.
+     * Whether an action may be granted to a role that must not be able to change anything, so such a
+     * permission set can be derived from the action catalogue rather than maintained by hand.
+     * <p>
+     * {@code WRITE} covers mutation, side effects in a called system, and use of platform key material even
+     * when nothing is persisted ({@code ENCRYPT}, {@code VERIFY}, {@code SIGN}, {@code TIMESTAMP}); when
+     * uncertain, classify {@code WRITE}, since a wrong {@code READ} grants a write silently.
+     * {@code SENSITIVE_READ} discloses stored secret material. {@code NOT_GRANTABLE} marks {@code NONE} and
+     * {@code ANY}, which the auth service rejects as unknown actions — omitting {@code ANY} denies nothing,
+     * as that gate is satisfied by holding any action on the resource.
      */
     public enum AccessType {
         READ,
         WRITE,
         SENSITIVE_READ,
         NOT_GRANTABLE
+    }
+
+    private static final ResourceAction[] VALUES;
+
+    static {
+        VALUES = values();
     }
 
     @Schema(description = "Resource Action Name",
@@ -113,9 +127,17 @@ public enum ResourceAction implements IPlatformEnum {
         return this.accessType;
     }
 
+    /**
+     * Prefer this over comparing {@link AccessType} directly: {@code != WRITE} admits both sensitive reads and
+     * the sentinels that cannot be persisted at all.
+     */
+    public boolean isGrantableToReadOnlyRole() {
+        return this.accessType == AccessType.READ;
+    }
+
     @JsonCreator
     public static ResourceAction findByCode(String code) {
-        return Arrays.stream(ResourceAction.values())
+        return Arrays.stream(VALUES)
                 .filter(k -> k.code.equals(code))
                 .findFirst()
                 .orElseThrow(() ->

--- a/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
+++ b/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.model.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -85,6 +86,29 @@ class ResourceActionAccessTypeTest {
     void findByCodeRoundTripsAllValues() {
         for (ResourceAction action : ResourceAction.values()) {
             assertEquals(action, ResourceAction.findByCode(action.getCode()), action.name());
+        }
+    }
+
+    /**
+     * The auth service stores action names and the OPA rules match on them, so the wire form is a cross-service
+     * contract: asserting the payload is the bare code also proves the classification cannot leak into it.
+     */
+    @Test
+    void serializesAsItsCodeAlone() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (ResourceAction action : ResourceAction.values()) {
+            assertEquals("\"%s\"".formatted(action.getCode()), mapper.writeValueAsString(action), action.name());
+        }
+    }
+
+    @Test
+    void deserializesFromItsCodeAlone() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (ResourceAction action : ResourceAction.values()) {
+            assertEquals(action, mapper.readValue("\"%s\"".formatted(action.getCode()), ResourceAction.class),
+                    action.name());
         }
     }
 

--- a/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
+++ b/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
@@ -2,6 +2,7 @@ package com.otilm.core.model.auth;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -18,11 +19,11 @@ class ResourceActionAccessTypeTest {
             ResourceAction.MEMBERS,
             ResourceAction.LIST,
             ResourceAction.DETAIL,
-            ResourceAction.EXPORT,
-            ResourceAction.GET_PROXY_INSTALLATION);
+            ResourceAction.EXPORT);
 
     private static final Set<ResourceAction> SENSITIVE_READ = EnumSet.of(
-            ResourceAction.GET_SECRET_CONTENT);
+            ResourceAction.GET_SECRET_CONTENT,
+            ResourceAction.GET_PROXY_INSTALLATION);
 
     @Test
     void everyActionDeclaresAnAccessType() {
@@ -46,14 +47,13 @@ class ResourceActionAccessTypeTest {
     }
 
     @Test
-    void secretContentIsClassifiedAsSensitiveRead() {
-        assertEquals(ResourceAction.AccessType.SENSITIVE_READ, ResourceAction.GET_SECRET_CONTENT.getAccessType());
+    void sensitiveReadActionsAreClassifiedAsSensitiveRead() {
+        for (ResourceAction action : SENSITIVE_READ) {
+            assertEquals(ResourceAction.AccessType.SENSITIVE_READ, action.getAccessType(), action.name());
+        }
     }
 
-    /**
-     * Complement of the read and sentinel sets. A newly added action that is mistakenly grouped with the
-     * readable actions fails here rather than silently widening what a read-only role is granted.
-     */
+    /** Complement of the read and sentinel sets, so a new action grouped with the readable ones fails here. */
     @Test
     void everyRemainingActionIsClassifiedAsWrite() {
         Set<ResourceAction> nonWrite = EnumSet.noneOf(ResourceAction.class);
@@ -75,7 +75,27 @@ class ResourceActionAccessTypeTest {
     }
 
     @Test
-    void registerResolvesFromItsCode() {
-        assertEquals(ResourceAction.REGISTER, ResourceAction.findByCode("register"));
+    void onlyPlainReadActionsAreGrantableToAReadOnlyRole() {
+        for (ResourceAction action : ResourceAction.values()) {
+            assertEquals(READ.contains(action), action.isGrantableToReadOnlyRole(), action.name());
+        }
+    }
+
+    @Test
+    void findByCodeRoundTripsAllValues() {
+        for (ResourceAction action : ResourceAction.values()) {
+            assertEquals(action, ResourceAction.findByCode(action.getCode()), action.name());
+        }
+    }
+
+    /** findByCode resolves with findFirst, so a duplicate code would be shadowed rather than rejected. */
+    @Test
+    void actionCodesAreUnique() {
+        long distinctCodes = Arrays.stream(ResourceAction.values())
+                .map(ResourceAction::getCode)
+                .distinct()
+                .count();
+
+        assertEquals(ResourceAction.values().length, distinctCodes);
     }
 }

--- a/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
+++ b/src/test/java/com/otilm/core/model/auth/ResourceActionAccessTypeTest.java
@@ -1,0 +1,81 @@
+package com.otilm.core.model.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ResourceActionAccessTypeTest {
+
+    private static final Set<ResourceAction> NOT_GRANTABLE = EnumSet.of(
+            ResourceAction.NONE,
+            ResourceAction.ANY);
+
+    private static final Set<ResourceAction> READ = EnumSet.of(
+            ResourceAction.MEMBERS,
+            ResourceAction.LIST,
+            ResourceAction.DETAIL,
+            ResourceAction.EXPORT,
+            ResourceAction.GET_PROXY_INSTALLATION);
+
+    private static final Set<ResourceAction> SENSITIVE_READ = EnumSet.of(
+            ResourceAction.GET_SECRET_CONTENT);
+
+    @Test
+    void everyActionDeclaresAnAccessType() {
+        for (ResourceAction action : ResourceAction.values()) {
+            assertNotNull(action.getAccessType(), action.name());
+        }
+    }
+
+    @Test
+    void sentinelActionsAreNotGrantable() {
+        for (ResourceAction action : NOT_GRANTABLE) {
+            assertEquals(ResourceAction.AccessType.NOT_GRANTABLE, action.getAccessType(), action.name());
+        }
+    }
+
+    @Test
+    void readActionsAreClassifiedAsRead() {
+        for (ResourceAction action : READ) {
+            assertEquals(ResourceAction.AccessType.READ, action.getAccessType(), action.name());
+        }
+    }
+
+    @Test
+    void secretContentIsClassifiedAsSensitiveRead() {
+        assertEquals(ResourceAction.AccessType.SENSITIVE_READ, ResourceAction.GET_SECRET_CONTENT.getAccessType());
+    }
+
+    /**
+     * Complement of the read and sentinel sets. A newly added action that is mistakenly grouped with the
+     * readable actions fails here rather than silently widening what a read-only role is granted.
+     */
+    @Test
+    void everyRemainingActionIsClassifiedAsWrite() {
+        Set<ResourceAction> nonWrite = EnumSet.noneOf(ResourceAction.class);
+        nonWrite.addAll(NOT_GRANTABLE);
+        nonWrite.addAll(READ);
+        nonWrite.addAll(SENSITIVE_READ);
+
+        for (ResourceAction action : ResourceAction.values()) {
+            if (nonWrite.contains(action)) {
+                continue;
+            }
+            assertEquals(ResourceAction.AccessType.WRITE, action.getAccessType(), action.name());
+        }
+    }
+
+    @Test
+    void registerIsClassifiedAsWrite() {
+        assertEquals(ResourceAction.AccessType.WRITE, ResourceAction.REGISTER.getAccessType());
+    }
+
+    @Test
+    void registerResolvesFromItsCode() {
+        assertEquals(ResourceAction.REGISTER, ResourceAction.findByCode("register"));
+    }
+}


### PR DESCRIPTION
Closes #794.

Prerequisite for the `auditor` system role in `core` (OmniTrustILM/core#1911), which derives its grant set from this classification.

## What changes

`ResourceAction` gains a required `AccessType { READ, WRITE, SENSITIVE_READ, NOT_GRANTABLE }` constructor argument, so a new action cannot be declared without stating whether it reads or changes platform state. All 27 existing constants are classified and `REGISTER("register", "Register", WRITE)` is added.

`isGrantableToReadOnlyRole()` is exposed alongside the raw accessor. Consumers should call it rather than comparing `AccessType`: `SENSITIVE_READ` reads like a subtype of `READ` but is disjoint, so the plausible negation `!= WRITE` admits both sensitive reads and the sentinels — and a sentinel row is rejected by the auth service with `Unknown action`.

## Classification notes

- `NONE` and `ANY` are `NOT_GRANTABLE`: neither can appear in a stored permission row. The auth service excludes `ANY` from catalogue sync, and `NONE` is only an annotation default, never an explicit `action =` in any of core's 692 annotation sites.
- `MEMBERS` is `READ` — certificates, keys and secrets are listed through a parent `MEMBERS` check.
- `GET_SECRET_CONTENT` is `SENSITIVE_READ`; `DETAIL` stays plain `READ`.
- `GET_PROXY_INSTALLATION` is `SENSITIVE_READ`. Its only annotation site returns `instructions.command().shell()` verbatim, and that template interpolates a client secret, a broker SAS key and a token minted with no expiry. Reading it discloses live credentials.
- `CHECK_COMPLIANCE` is `WRITE` — all ten annotation sites are `void` evaluation triggers; results are read through `DETAIL`-gated paths.
- `EXPORT` is `READ` — its only site is `AUDIT_LOG:EXPORT`, no key material.
- `ENCRYPT`, `DECRYPT`, `SIGN`, `VERIFY`, `TIMESTAMP` are `WRITE`: they exercise platform key material even though they persist nothing. The `AccessType` contract states this explicitly, along with the rule to classify `WRITE` when uncertain — a wrong `READ` grants a write silently.

`REGISTER` carries a note that `auth-opa-policies` pairs its code with `Resource.CONNECTOR` in `resourcesWithAnonymousAccess`, so it must not be annotated on that resource. Nothing is exposed today: the rule matches the pair, and no `CONNECTOR:REGISTER` annotation exists.

## Why `REGISTER` is its own action

Certificate registration in core completes at REGISTERED without passing `CREATE` or `ISSUE`, and `acme`, `scep` and `cmp` all hold `certificates:create` — so overloading `CREATE` would hand pre-registration authority to every CSR-submitting protocol client.

## Compatibility

`ResourceAction` still serializes by `code`, and `accessType` is not exposed to Jackson or the generated schema. Adding `REGISTER` is an additive schema change: `register` becomes a permitted enum value. Verified that no consumer breaks — both entities persisting a `ResourceAction` use `@Enumerated(EnumType.STRING)`, `ResourceAction` does not implement `BitMaskEnum`, and all four `switch` statements over it in core have `default` arms, so the mid-enum insertion is safe.

## Tests

Nine tests in `ResourceActionAccessTypeTest`, developed test-first:

- every action declares an `AccessType`
- `NONE`/`ANY` are `NOT_GRANTABLE`
- the read actions are `READ`
- the sensitive-read set is asserted by iteration, so a constant added to it cannot be exempted from the complement test without being asserted anywhere
- everything outside the read and sentinel sets is `WRITE`, so a future action mistakenly grouped with the readable ones fails rather than silently widening a read-only role
- `REGISTER` is `WRITE`
- `findByCode` round-trips every value, and action codes are unique — `findFirst` would otherwise shadow a duplicate rather than reject it

Omitting an `AccessType` fails compilation, confirmed by temporarily adding a two-argument constant: `required: java.lang.String,java.lang.String,com.otilm.core.model.auth.ResourceAction.AccessType`.

Full suite: 455 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
