### PR TITLE
Correct and complete the client-operations v2 API documentation

### DIFF
--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -109,7 +109,22 @@ import java.util.List;
  * </ul>
  */
 @RequestMapping("/v2/operations/authorities/{authorityUuid}/raProfiles/{raProfileUuid}")
-@Tag(name = "Client Operations v2", description = "Client Operations v2 API")
+@Tag(name = "Client Operations v2", description = """
+		Certificate lifecycle operations through an RA profile: issue, renew, rekey, register, revoke,
+		finalize, confirm-revoke, and cancel.
+
+		These operations are asynchronous. A mutating request is validated, persisted, and queued; the
+		authority-connector call runs afterwards, and an approval step may first move the certificate to
+		PENDING_APPROVAL. The HTTP response therefore does not carry the outcome — a 2xx means the request
+		was accepted, not that it completed — and the issue/renew/rekey responses never carry the signed
+		certificate. Follow an operation by reading the certificate's state, and retrieve the signed
+		certificate from the certificate detail once it reaches ISSUED.
+
+		A certificate left in PENDING_ISSUE or PENDING_REVOKE is completed either by platform status-polling
+		(when the authority advertises it) or by an operator action — issue/finalize, revoke/confirm, or
+		cancel. Query availableOperations first to learn whether asynchronous completion and cancellation
+		apply to a given authority / RA profile.
+		""")
 @ApiResponses(
 		value = {
 				@ApiResponse(
@@ -158,15 +173,15 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Issue an existing certificate (REQUESTED or REGISTERED)",
 			description = """
-					Trigger issuance for an existing certificate. Behavior depends on cert state:
-					- `REQUESTED` (no body): the certificate already has a CSR attached (typically from
-					  a protocol layer such as ACME, SCEP, or CMP, or after an approval/compliance cycle).
-					  Issuance is triggered with the existing CSR.
-					- `REGISTERED` (body required): the certificate was pre-registered (v3 authorities with
-					  `CERTIFICATE_REGISTRATION` capability) and is now being finalized with an operator-
-					  supplied CSR. The CSR + sign attributes and the authorization secret from the body are attached to the existing
-					  certificate row, then issuance is triggered. The cert's identity (subject DN, SAN,
-					  extensions) and connector-supplied metadata from the registration are preserved.
+					Trigger issuance for an existing certificate; behaviour depends on its state:
+					- `REQUESTED` (no body): the certificate already carries a CSR (e.g. from an ACME/SCEP/CMP
+					  protocol layer, or after an approval/compliance cycle); issuance runs against that CSR.
+					- `REGISTERED` (body required): a pre-registered certificate is finalized with the operator's
+					  CSR, sign attributes, and authorization secret; its registered identity (subject DN, SAN,
+					  extensions) and connector metadata are preserved.
+
+					Queued and issued asynchronously like `issueCertificate` — track the result through the
+					certificate's state.
 					"""
 	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
@@ -184,7 +199,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Issue certificate",
-			description = "Submit a new certificate signing request and trigger issuance through this RA profile. If the issuance is asynchronous, the certificate is returned in state `PENDING_ISSUE` and must be finalized once it has been issued."
+			description = "Submit a new certificate signing request and request issuance through this RA profile. The request is validated, persisted, and queued; issuance runs asynchronously and an approval step may run first. This response returns only the new certificate's UUID — it never carries the signed certificate and does not indicate completion. Track the operation through the certificate's state."
 	)
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
@@ -197,7 +212,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Renew certificate",
-			description = "Renew an existing certificate using the same key pair. The original certificate stays in state `ISSUED`; the renewed certificate is returned and, if its issuance is asynchronous, ends in state `PENDING_ISSUE` until it is finalized."
+			description = "Renew a certificate using its existing key pair. The original certificate stays in state `ISSUED`; a new certificate is created, queued, and issued asynchronously. This response returns only the new certificate's UUID — track the result through its state."
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate renewed"),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
@@ -212,11 +227,11 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Rekey Certificate",
 			description = """
-					The rekey operation is used to request a new certificate with a new key pair.
-					The new certificate will be issued with the same subject and attributes as the original certificate,
-					but with a new public key. Therefore, new certificate signing request (CSR) with new key pair needs
-					to be provided, or new key pair managed by the platform needs to be selected. When the same key pair
-					is used, or the subject is changed, the rekey operation will be rejected.
+					Request a replacement certificate with a new key pair but the same subject and
+					attributes as the original. Provide a new CSR with a new key pair, or select a
+					platform-managed key pair; reusing the same key pair, or changing the subject, is
+					rejected. Queued and issued asynchronously — track the result through the new
+					certificate's state.
 					"""
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate regenerated"),
@@ -262,7 +277,7 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Revoke certificate",
-			description = "Revoke a certificate currently in state `ISSUED`. If the revocation is asynchronous, the certificate moves to state `PENDING_REVOKE` and must be confirmed once the revocation has been performed."
+			description = "Revoke a certificate currently in state `ISSUED`. The request is accepted and queued; revocation runs asynchronously and an approval step may run first. Because the response is returned before the connector call, it does not indicate completion — the certificate may end in `REVOKED` (synchronous) or `PENDING_REVOKE` (asynchronous, awaiting confirmation). Track the result through its state."
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Certificate revoked")})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
@@ -276,20 +291,15 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Finalize an asynchronous certificate issuance",
 			description = """
-					Upload an issued certificate to finalize a certificate currently in
-					state `PENDING_ISSUE`. On success, the certificate transitions to `ISSUED`
-					and is pushed to any pre-associated locations.
+					Finalize a certificate in state `PENDING_ISSUE` by uploading the issued certificate. On
+					success it transitions to `ISSUED` and is pushed to any pre-associated locations.
 
-					Validation:
-					- the certificate request's public key must match the uploaded certificate's
-					  public key (mandatory);
-					- the certificate request's subject DN should match the uploaded certificate's
-					  subject DN (warning on mismatch — some CAs canonicalise the DN);
-					- the uploaded certificate must be verifiable against the certificate
-					  authority associated with the RA profile (mandatory).
+					Validation: the certificate request's public key must match the uploaded certificate
+					(mandatory); the subject DN should match (warning only — some CAs canonicalise it); and the
+					uploaded certificate must verify against the RA profile's authority (mandatory).
 
-					Request body carries a Base64-encoded single certificate and an optional list
-					of certificate-level custom attributes.
+					The body carries a Base64-encoded single certificate and optional certificate-level custom
+					attributes.
 					"""
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate finalized"),
@@ -326,21 +336,15 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Cancel a pending certificate operation",
 			description = """
-					State-aware cancel for a certificate currently in state `PENDING_ISSUE` or
-					`PENDING_REVOKE`. Transitions:
+					State-aware cancel for a certificate in `PENDING_ISSUE` or `PENDING_REVOKE`:
 
 					- `PENDING_ISSUE` → `FAILED`
 					- `PENDING_REVOKE` → `ISSUED`
 
-					The optional `reason` from the request body is recorded in the certificate
-					event history.
-
-					If the underlying operation cannot be aborted (for example, it has
-					progressed beyond a point where cancellation is possible), the response is
-					`422 Unprocessable Entity` with the reason, and the certificate **stays in
-					its pending state**. In that case the operation can still be resolved by
-					waiting for it to complete and then finalizing or confirming
-					the certificate, or by retrying the cancel later if circumstances change.
+					The optional `reason` is recorded in the certificate event history. If the underlying
+					operation can no longer be aborted, the response is `422` and the certificate stays in its
+					pending state; it can then be resolved by letting it complete and finalizing/confirming, or
+					by retrying the cancel later.
 					"""
 	)
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Cancellation completed"),
@@ -357,14 +361,14 @@ public interface ClientOperationController extends AuthProtectedController {
 	@Operation(
 			summary = "Pre-register a certificate",
 			description = """
-					Pre-registers a certificate that will be issued later; the response carries the pre-registered
-					certificate's UUID, and completion runs through the standard issue flow.
+					Pre-register a certificate to be issued later; the response carries the pre-registered
+					certificate's UUID (no signed certificate) and completion runs through the standard issue flow.
 
-					When the authority's connector supports registration (a v3 connector advertising the
-					`CERTIFICATE_REGISTRATION` feature flag), the registration is made with the upstream CA; otherwise
-					the certificate is pre-registered at the platform level with no connector call — a platform-level
-					pre-registration does not imply a CA-side end-entity exists. Connector-side completion may be
-					asynchronous; it is tracked server-side and finished through the issue flow.
+					When the authority's connector supports registration (a v3 connector advertising
+					`CERTIFICATE_REGISTRATION`), the registration is made with the upstream CA; otherwise the
+					certificate is pre-registered at the platform level with no connector call, which does not imply
+					a CA-side end-entity exists. Connector-side completion may be asynchronous and is tracked
+					server-side.
 					"""
 	)
 	@ApiResponses(value = {

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -321,7 +321,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Pre-register a certificate",
 			description = """
 					Pre-register a certificate to be issued later; the response carries the pre-registered
-					certificate's UUID (no signed certificate) and completion runs through the standard issue flow.
+					certificate's UUID and completion runs through the standard issue flow.
 
 					When the authority's connector supports registration (a v3 connector advertising
 					`CERTIFICATE_REGISTRATION`), the registration is made with the upstream CA; otherwise the

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -42,6 +42,33 @@ import java.util.List;
  * states, see the certificate lifecycle reference:
  * <a href="https://docs.otilm.com/docs/certificate-key/concept-design/core-components/certificate">
  * Certificate lifecycle</a>.
+ *
+ * <h3>Certificate states driven by this API</h3>
+ * <pre>
+ *   Issuance (issueCertificate, renewCertificate, rekeyCertificate,
+ *             issueExistingCertificate on a REQUESTED cert):
+ *
+ *       REQUESTED --> PENDING_ISSUE --> ISSUED       connector completes (synchronously or via polling);
+ *                          |                         manuallyIssueCertificate finalizes it the same way
+ *                          +-- cancel ------------> FAILED
+ *                          +-- connector failure --> FAILED
+ *
+ *   Registration (registerCertificate, then issueExistingCertificate on a REGISTERED cert):
+ *
+ *       PENDING_REGISTRATION --> REGISTERED --> PENDING_ISSUE --> ISSUED
+ *                |               (connector 2xx or platform-level; then the issuance flow above)
+ *                +-- setup failure --> FAILED
+ *
+ *   Revocation (revokeCertificate):
+ *
+ *       ISSUED --> REVOKED                     authority completes the revocation immediately
+ *       ISSUED --> PENDING_REVOKE --> REVOKED  deferred, then manuallyConfirmRevoke
+ *       PENDING_REVOKE --> ISSUED              cancelPendingCertificateOperation
+ *
+ *   Approvals: issue / renew / rekey / revoke may pass through PENDING_APPROVAL first;
+ *              a rejected issuance ends REJECTED, a rejected revocation restores the prior state.
+ *   Terminal (no further transition via this API): REVOKED, REJECTED, FAILED.
+ * </pre>
  */
 @RequestMapping("/v2/operations/authorities/{authorityUuid}/raProfiles/{raProfileUuid}")
 @Tag(name = "Client Operations v2", description = """

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -31,82 +31,15 @@ import java.security.cert.CertificateException;
 import java.util.List;
 
 /**
- * Client API for certificate lifecycle operations through an RA profile (issue, renew,
- * rekey, revoke, finalize, confirm-revoke, cancel).
+ * Client API for certificate lifecycle operations through an RA profile: issue, renew, rekey,
+ * register, revoke, finalize, confirm-revoke, and cancel.
  *
- * <h2>Certificate state transitions exposed by this API</h2>
- *
- * <p>The following diagram shows the state transitions an operator can drive through
- * the endpoints on this controller. Synchronous paths complete in a single request;
- * asynchronous paths leave the certificate in a {@code PENDING_*} state until an
- * operator finalizes or cancels it.</p>
- *
- * <pre>
- *                                +-----------+
- *                                | REQUESTED |
- *                                +-----------+
- *                              /     |   |    \
- *            connector 200    /      |   |     \  connector 202
- *            (sync success)  /       |   |      \ (async accepted)
- *                           /        |   |       \
- *                          v         v   v        v
- *                   +--------+   +-------+   +---------------+
- *                   | ISSUED |   |FAILED |   | PENDING_ISSUE |
- *                   +--------+   +-------+   +---------------+
- *                       ^                       /         \
- *                       |                      /           \
- *                       |        manuallyIssue/             \cancelPending
- *                       |             v                      v
- *                       +-------- ISSUED                   FAILED
- *
- *   ISSUED + revokeCertificate:
- *     connector 200  -->  REVOKED                                (sync)
- *     connector 202  -->  PENDING_REVOKE                         (async)
- *                                /                       \
- *                manuallyConfirmRevoke              cancelPendingCertificateOperation
- *                              v                              v
- *                          REVOKED                          ISSUED
- * </pre>
- *
- * <p>Transitions driven by other controllers (notably {@code Issued → PendingApproval},
- * {@code PendingApproval → PendingIssue / PendingRevoke / Issued / Revoked / Rejected})
- * are part of the approval flow and are not shown here.</p>
- *
- * <h3>Synchronous paths (connector returns 200 OK)</h3>
- * <ul>
- *   <li>{@link #issueCertificate}, {@link #issueExistingCertificate},
- *       {@link #renewCertificate}, {@link #rekeyCertificate}: cert moves to
- *       {@code ISSUED}. If the connector reports a failure during the call the cert
- *       moves to {@code FAILED} instead.</li>
- *   <li>{@link #revokeCertificate}: cert moves to {@code REVOKED}.</li>
- * </ul>
- *
- * <h3>Asynchronous paths (connector returns 202 Accepted)</h3>
- * <ul>
- *   <li>{@code issueCertificate} / {@code issueExistingCertificate} /
- *       {@code renewCertificate} / {@code rekeyCertificate}: cert moves to
- *       {@code PENDING_ISSUE}. An operator finalizes it via
- *       {@link #manuallyIssueCertificate} (→ {@code ISSUED}) or aborts via
- *       {@link #cancelPendingCertificateOperation} (→ {@code FAILED}).</li>
- *   <li>{@code revokeCertificate}: cert moves to {@code PENDING_REVOKE}. An operator
- *       confirms it via {@link #manuallyConfirmRevoke} (→ {@code REVOKED}) or aborts
- *       via {@link #cancelPendingCertificateOperation} (→ {@code ISSUED}, since the
- *       certificate was never actually revoked upstream).</li>
- * </ul>
- *
- * <p>{@code rekeyCertificate} and {@code issueExistingCertificate} use the same
- * authority-provider call as {@code issueCertificate}, so they can complete either
- * synchronously or asynchronously depending on what the connector returns.</p>
- *
- * <h3>Terminal states (no transition via this API)</h3>
- * <ul>
- *   <li>{@code REVOKED} — definitive; the certificate cannot be reissued.</li>
- *   <li>{@code REJECTED} — set by approval / compliance flows; the certificate cannot
- *       be retried, a new certificate request must be created.</li>
- *   <li>{@code FAILED} — set when synchronous issuance failed at the connector or when
- *       an asynchronous issuance was cancelled; a new certificate request must be
- *       created to retry.</li>
- * </ul>
+ * <p>These operations are asynchronous - a request is validated, persisted, and queued, and the
+ * outcome is observed through the certificate's state rather than the HTTP response (see the
+ * "Client Operations v2" tag description for the async/state model). For the full certificate
+ * state machine, including the registration states, see the certificate lifecycle reference:
+ * <a href="https://docs.otilm.com/docs/certificate-key/concept-design/core-components/certificate">
+ * Certificate lifecycle</a>.
  */
 @RequestMapping("/v2/operations/authorities/{authorityUuid}/raProfiles/{raProfileUuid}")
 @Tag(name = "Client Operations v2", description = """

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -34,9 +34,10 @@ import java.util.List;
  * Client API for certificate lifecycle operations through an RA profile: issue, renew, rekey,
  * register, revoke, finalize, confirm-revoke, and cancel.
  *
- * <p>The request operations (issue, renew, rekey, register, revoke) are asynchronous - the request
- * is validated, persisted, and queued, and the outcome is observed through the certificate's state
- * rather than the HTTP response; finalize, confirm-revoke, and cancel are the synchronous operator
+ * <p>The issue, renew, rekey, and revoke operations are asynchronous - the request is validated,
+ * persisted, and queued, and the outcome is observed through the certificate's state rather than the
+ * HTTP response; register runs inline against the connector; finalize, confirm-revoke, and cancel are
+ * the synchronous operator
  * actions that complete or abort a pending operation. See the "Client Operations v2" tag description
  * for the async/state model. For the full certificate state machine, including the registration
  * states, see the certificate lifecycle reference:
@@ -51,13 +52,16 @@ import java.util.List;
 		Certificate lifecycle operations through an RA profile: issue, renew, rekey, register, revoke,
 		finalize, confirm-revoke, and cancel.
 
-		The request operations (issue, renew, rekey, register, revoke) are asynchronous. A request is
-		validated, persisted, and queued; the authority-connector call runs afterwards, and an approval
-		step may first move the certificate to
+		The issue, renew, rekey, and revoke operations are asynchronous: the request is validated,
+		persisted, and queued; the authority-connector call runs afterwards, and an approval step may
+		first move the certificate to
 		PENDING_APPROVAL. The HTTP response therefore does not carry the outcome — a 2xx means the request
 		was accepted, not that it completed — and the issue/renew/rekey responses never carry the signed
 		certificate. Follow an operation by reading the certificate's state, and retrieve the signed
 		certificate from the certificate detail once it reaches ISSUED.
+
+		register runs inline against the connector: it reaches REGISTERED synchronously (and may return
+		certificate data), or PENDING_REGISTRATION when the connector defers completion.
 
 		A certificate left in PENDING_ISSUE or PENDING_REVOKE is completed either by platform status-polling
 		(when the authority advertises it) or by an operator action — issue/finalize, revoke/confirm, or
@@ -85,7 +89,8 @@ import java.util.List;
 		  PENDING_REVOKE --> ISSUED              cancelPendingCertificateOperation
 
 		Approvals: issue / renew / rekey / revoke may pass through PENDING_APPROVAL first;
-		           a rejected issuance ends REJECTED, a rejected revocation restores the prior state.
+		           a rejected issuance ends REJECTED (a pre-registered certificate is restored to REGISTERED),
+		           a rejected revocation restores the prior state.
 		Terminal (no further transition via this API): REVOKED, REJECTED, FAILED.
 		```
 		""")
@@ -139,8 +144,9 @@ public interface ClientOperationController extends AuthProtectedController {
 					- `REQUESTED` (no body): the certificate already carries a CSR (e.g. from an ACME/SCEP/CMP
 					  protocol layer, or after an approval/compliance cycle); issuance runs against that CSR.
 					- `REGISTERED` (body required): a pre-registered certificate is finalized with the operator's
-					  CSR, sign attributes, and authorization secret; its registered identity (subject DN, SAN,
-					  extensions) and connector metadata are preserved.
+					  CSR (sign attributes as the RA profile requires, and the authorization secret only for
+					  challenge-protected registrations); its registered identity (subject DN, SAN, extensions)
+					  and connector metadata are preserved.
 
 					Queued and issued asynchronously like `issueCertificate` — track the result through the
 					certificate's state.
@@ -148,18 +154,15 @@ public interface ClientOperationController extends AuthProtectedController {
 	)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Issuance request accepted"),
-			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
-			@ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
-			@ApiResponse(responseCode = "422", description = "Unprocessable Entity — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")})),
-			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
 	@PostMapping(path = "/certificates/{certificateUuid}/issue", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto issueExistingCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
 			@Parameter(description = "RA Profile UUID") @PathVariable String raProfileUuid,
 			@Parameter(description = "Certificate UUID") @PathVariable String certificateUuid,
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(
-					description = "Issue request body. Required when cert state is REGISTERED (carries the operator's CSR + sign attributes plus the authorization secret); must be omitted when cert state is REQUESTED.",
+					description = "Issue request body. Required when cert state is REGISTERED (carries the operator's CSR, sign attributes as the RA profile requires, and — for challenge-protected registrations — the authorization secret); must be omitted when cert state is REQUESTED.",
 					required = false)
 			@RequestBody(required = false) @Valid ClientCertificateIssueRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, CertificateRequestException, NotFoundException, AttributeException;
 
@@ -187,8 +190,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			@ApiResponse(responseCode = "200", description = "Renewal request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")})),
-			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
+					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
 	@PostMapping(path = "/certificates/{certificateUuid}/renew", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto renewCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -261,8 +263,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			@ApiResponse(responseCode = "204", description = "Revoke request accepted and queued — observe the certificate state for the outcome."),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples = {@ExampleObject(value = "[\"Cannot perform operation revoke on certificate in state ...\"]")})),
-			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
+					examples = {@ExampleObject(value = "[\"Cannot perform operation revoke on certificate in state ...\"]")}))})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	void revokeCertificate(
@@ -361,9 +362,8 @@ public interface ClientOperationController extends AuthProtectedController {
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Registration request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
-			@ApiResponse(responseCode = "422", description = "Invalid registration request — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object",
-					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
-			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))
+			@ApiResponse(responseCode = "422", description = "Invalid registration request",
+					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
 	})
 	@PostMapping(path = "/certificates/register", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto registerCertificate(
@@ -376,7 +376,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "List operations supported by this authority/RA profile",
 			description = """
 					Returns per-operation support flags (issue/renew/revoke/register) including whether
-					each may complete asynchronously and whether each can be cancelled mid-flight. Operators
+					the platform polls for its asynchronous completion and whether each can be cancelled mid-flight. Operators
 					use this to drive UI affordances and validate flows before invoking them.
 					"""
 	)

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -43,32 +43,8 @@ import java.util.List;
  * <a href="https://docs.otilm.com/docs/certificate-key/concept-design/core-components/certificate">
  * Certificate lifecycle</a>.
  *
- * <h3>Certificate states driven by this API</h3>
- * <pre>
- *   Issuance (issueCertificate, renewCertificate, rekeyCertificate,
- *             issueExistingCertificate on a REQUESTED cert):
- *
- *       REQUESTED --> PENDING_ISSUE --> ISSUED       connector completes (synchronously or via polling);
- *                          |                         manuallyIssueCertificate finalizes it the same way
- *                          +-- cancel ------------> FAILED
- *                          +-- connector failure --> FAILED
- *
- *   Registration (registerCertificate, then issueExistingCertificate on a REGISTERED cert):
- *
- *       PENDING_REGISTRATION --> REGISTERED --> PENDING_ISSUE --> ISSUED
- *                |               (connector 2xx or platform-level; then the issuance flow above)
- *                +-- setup failure --> FAILED
- *
- *   Revocation (revokeCertificate):
- *
- *       ISSUED --> REVOKED                     authority completes the revocation immediately
- *       ISSUED --> PENDING_REVOKE --> REVOKED  deferred, then manuallyConfirmRevoke
- *       PENDING_REVOKE --> ISSUED              cancelPendingCertificateOperation
- *
- *   Approvals: issue / renew / rekey / revoke may pass through PENDING_APPROVAL first;
- *              a rejected issuance ends REJECTED, a rejected revocation restores the prior state.
- *   Terminal (no further transition via this API): REVOKED, REJECTED, FAILED.
- * </pre>
+ * <p>The state-transition diagram for these operations lives in the "Client Operations v2" tag
+ * description, from which it is generated into the API reference.
  */
 @RequestMapping("/v2/operations/authorities/{authorityUuid}/raProfiles/{raProfileUuid}")
 @Tag(name = "Client Operations v2", description = """
@@ -87,6 +63,31 @@ import java.util.List;
 		(when the authority advertises it) or by an operator action — issue/finalize, revoke/confirm, or
 		cancel. Query availableOperations first to learn whether asynchronous completion and cancellation
 		apply to a given authority / RA profile.
+
+		Certificate states driven by this API:
+
+		```
+		Issuance (issueCertificate, renewCertificate, rekeyCertificate,
+		          issueExistingCertificate on a REQUESTED cert):
+		  REQUESTED --> PENDING_ISSUE --> ISSUED       connector completes (synchronously or via polling);
+		                     |                         manuallyIssueCertificate finalizes it the same way
+		                     +-- cancel ------------> FAILED
+		                     +-- connector failure --> FAILED
+
+		Registration (registerCertificate, then issueExistingCertificate on a REGISTERED cert):
+		  PENDING_REGISTRATION --> REGISTERED --> PENDING_ISSUE --> ISSUED
+		           |               (connector 2xx or platform-level; then the issuance flow above)
+		           +-- setup failure --> FAILED
+
+		Revocation (revokeCertificate):
+		  ISSUED --> REVOKED                     authority completes the revocation immediately
+		  ISSUED --> PENDING_REVOKE --> REVOKED  deferred, then manuallyConfirmRevoke
+		  PENDING_REVOKE --> ISSUED              cancelPendingCertificateOperation
+
+		Approvals: issue / renew / rekey / revoke may pass through PENDING_APPROVAL first;
+		           a rejected issuance ends REJECTED, a rejected revocation restores the prior state.
+		Terminal (no further transition via this API): REVOKED, REJECTED, FAILED.
+		```
 		""")
 @ApiResponses(
 		value = {

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -34,10 +34,12 @@ import java.util.List;
  * Client API for certificate lifecycle operations through an RA profile: issue, renew, rekey,
  * register, revoke, finalize, confirm-revoke, and cancel.
  *
- * <p>These operations are asynchronous - a request is validated, persisted, and queued, and the
- * outcome is observed through the certificate's state rather than the HTTP response (see the
- * "Client Operations v2" tag description for the async/state model). For the full certificate
- * state machine, including the registration states, see the certificate lifecycle reference:
+ * <p>The request operations (issue, renew, rekey, register, revoke) are asynchronous - the request
+ * is validated, persisted, and queued, and the outcome is observed through the certificate's state
+ * rather than the HTTP response; finalize, confirm-revoke, and cancel are the synchronous operator
+ * actions that complete or abort a pending operation. See the "Client Operations v2" tag description
+ * for the async/state model. For the full certificate state machine, including the registration
+ * states, see the certificate lifecycle reference:
  * <a href="https://docs.otilm.com/docs/certificate-key/concept-design/core-components/certificate">
  * Certificate lifecycle</a>.
  */
@@ -46,8 +48,9 @@ import java.util.List;
 		Certificate lifecycle operations through an RA profile: issue, renew, rekey, register, revoke,
 		finalize, confirm-revoke, and cancel.
 
-		These operations are asynchronous. A mutating request is validated, persisted, and queued; the
-		authority-connector call runs afterwards, and an approval step may first move the certificate to
+		The request operations (issue, renew, rekey, register, revoke) are asynchronous. A request is
+		validated, persisted, and queued; the authority-connector call runs afterwards, and an approval
+		step may first move the certificate to
 		PENDING_APPROVAL. The HTTP response therefore does not carry the outcome — a 2xx means the request
 		was accepted, not that it completed — and the issue/renew/rekey responses never carry the signed
 		certificate. Follow an operation by reading the certificate's state, and retrieve the signed
@@ -116,7 +119,7 @@ public interface ClientOperationController extends AuthProtectedController {
 					"""
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Certificate issued"),
+			@ApiResponse(responseCode = "200", description = "Issuance request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
@@ -137,7 +140,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			description = "Submit a new certificate signing request and request issuance through this RA profile. The request is validated, persisted, and queued; issuance runs asynchronously and an approval step may run first. This response returns only the new certificate's UUID — it never carries the signed certificate and does not indicate completion. Track the operation through the certificate's state."
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Certificate issued"),
+			@ApiResponse(responseCode = "200", description = "Issuance request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")})),
@@ -153,7 +156,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			description = "Renew a certificate using its existing key pair. The original certificate stays in state `ISSUED`; a new certificate is created, queued, and issued asynchronously. This response returns only the new certificate's UUID — track the result through its state."
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Certificate renewed"),
+			@ApiResponse(responseCode = "200", description = "Renewal request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")})),
@@ -176,7 +179,7 @@ public interface ClientOperationController extends AuthProtectedController {
 					"""
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Certificate regenerated"),
+			@ApiResponse(responseCode = "200", description = "Rekey request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
 					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")})),
@@ -224,13 +227,14 @@ public interface ClientOperationController extends AuthProtectedController {
 
 	@Operation(
 			summary = "Revoke certificate",
-			description = "Revoke a certificate currently in state `ISSUED`. The request is accepted and queued; revocation runs asynchronously and an approval step may run first. Because the response is returned before the connector call, it does not indicate completion — the certificate may end in `REVOKED` (synchronous) or `PENDING_REVOKE` (asynchronous, awaiting confirmation). Track the result through its state."
+			description = "Revoke a certificate currently in state `ISSUED`. The request is accepted and queued; revocation runs through the authority and an approval step may run first. This response is returned before the authority call completes, so it does not indicate completion — the certificate ends in `REVOKED` if the authority completes the revocation immediately, or `PENDING_REVOKE` if completion is deferred and later confirmed. Track the result through its state."
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "204", description = "Revoke request accepted and queued — not yet revoked. The certificate becomes REVOKED (synchronous) or PENDING_REVOKE (asynchronous, awaiting confirmation); observe its state."),
+			@ApiResponse(responseCode = "204", description = "Revoke request accepted and queued — observe the certificate state for the outcome."),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples = {@ExampleObject(value = "[\"Cannot revoke certificate in state ...\"]")}))})
+					examples = {@ExampleObject(value = "[\"Cannot perform operation revoke on certificate in state ...\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	void revokeCertificate(
@@ -327,10 +331,11 @@ public interface ClientOperationController extends AuthProtectedController {
 					"""
 	)
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Certificate pre-registered"),
+			@ApiResponse(responseCode = "200", description = "Registration request accepted"),
 			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Invalid registration request — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object",
-					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))
 	})
 	@PostMapping(path = "/certificates/register", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto registerCertificate(

--- a/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
+++ b/src/main/java/com/otilm/api/interfaces/core/client/v2/ClientOperationController.java
@@ -149,9 +149,7 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Get issue certificate attributes",
 			description = "Return the list of attributes the client must populate when requesting an issuance through this RA profile. The list reflects the certificate authority's current attribute schema."
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes list obtained"),
-			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes list obtained")})
 	@GetMapping(path = "/attributes/issue", produces = {"application/json"})
 	List<BaseAttribute> listIssueCertificateAttributes(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -184,9 +182,13 @@ public interface ClientOperationController extends AuthProtectedController {
 					certificate's state.
 					"""
 	)
-	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
-			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Certificate issued"),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
+			@ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates/{certificateUuid}/issue", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto issueExistingCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -201,9 +203,12 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Issue certificate",
 			description = "Submit a new certificate signing request and request issuance through this RA profile. The request is validated, persisted, and queued; issuance runs asynchronously and an approval step may run first. This response returns only the new certificate's UUID — it never carries the signed certificate and does not indicate completion. Track the operation through the certificate's state."
 	)
-	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Certificate issued"),
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Certificate issued"),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
+					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto issueCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -214,9 +219,12 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Renew certificate",
 			description = "Renew a certificate using its existing key pair. The original certificate stays in state `ISSUED`; a new certificate is created, queued, and issued asynchronously. This response returns only the new certificate's UUID — track the result through its state."
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate renewed"),
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Certificate renewed"),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
+					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates/{certificateUuid}/renew", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto renewCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -234,9 +242,12 @@ public interface ClientOperationController extends AuthProtectedController {
 					certificate's state.
 					"""
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate regenerated"),
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Certificate regenerated"),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")}))})
+					examples={@ExampleObject(value="[\"Error Message 1\",\"Error Message 2\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates/{certificateUuid}/rekey", consumes = {"application/json"}, produces = {"application/json"})
 	ClientCertificateDataResponseDto rekeyCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -258,7 +269,10 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Validate revocation attributes",
 			description = "Validate a candidate set of revocation attributes against this RA profile's schema before submitting a revocation request."
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Attributes validated")})
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Attributes validated"),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples = {@ExampleObject(value = "[\"Error Message 1\",\"Error Message 2\"]")}))})
 	@PostMapping(path = "/attributes/revoke/validate", consumes = {"application/json"}, produces = {"application/json"})
 	void validateRevokeCertificateAttributes(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -279,7 +293,11 @@ public interface ClientOperationController extends AuthProtectedController {
 			summary = "Revoke certificate",
 			description = "Revoke a certificate currently in state `ISSUED`. The request is accepted and queued; revocation runs asynchronously and an approval step may run first. Because the response is returned before the connector call, it does not indicate completion — the certificate may end in `REVOKED` (synchronous) or `PENDING_REVOKE` (asynchronous, awaiting confirmation). Track the result through its state."
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Certificate revoked")})
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "Revoke request accepted and queued — not yet revoked. The certificate becomes REVOKED (synchronous) or PENDING_REVOKE (asynchronous, awaiting confirmation); observe its state."),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
+			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+					examples = {@ExampleObject(value = "[\"Cannot revoke certificate in state ...\"]")}))})
 	@PostMapping(path = "/certificates/{certificateUuid}/revoke", consumes = {"application/json"}, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	void revokeCertificate(
@@ -302,9 +320,13 @@ public interface ClientOperationController extends AuthProtectedController {
 					attributes.
 					"""
 	)
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Certificate finalized"),
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Certificate finalized"),
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
+			@ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
 			@ApiResponse(responseCode = "422", description = "Unprocessable Entity", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
-					examples={@ExampleObject(value="[\"Certificate is not in PENDING_ISSUE state\",\"Public key mismatch with certificate request\"]")}))})
+					examples={@ExampleObject(value="[\"Certificate is not in PENDING_ISSUE state\",\"Public key mismatch with certificate request\"]")})),
+			@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class)))})
 	@PostMapping(path = "/certificates/{certificateUuid}/issue/finalize", consumes = {"application/json"}, produces = {"application/json"})
 	CertificateDetailDto manuallyIssueCertificate(
 			@Parameter(description = "Authority Instance UUID") @PathVariable String authorityUuid,
@@ -373,7 +395,8 @@ public interface ClientOperationController extends AuthProtectedController {
 	)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Certificate pre-registered"),
-			@ApiResponse(responseCode = "422", description = "Invalid registration request",
+			@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessageDto.class))),
+			@ApiResponse(responseCode = "422", description = "Invalid registration request — validation errors as a string array; request-body validation instead returns an ErrorMessageDto object",
 					content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
 	})
 	@PostMapping(path = "/certificates/register", consumes = {"application/json"}, produces = {"application/json"})

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
@@ -19,10 +19,10 @@ import java.util.UUID;
 @Setter
 public class ClientCertificateDataResponseDto implements Loggable {
 
-    @Schema(description = "Base64-encoded signed certificate. Not populated by the client operations that return "
-            + "this response (issue, renew, rekey, register): they complete asynchronously through later issuance, "
-            + "so the field is left empty and never carries the signed certificate. Retrieve the signed certificate "
-            + "from the certificate detail once the certificate reaches the ISSUED state.",
+    @Schema(description = "Base64-encoded signed certificate. The issue/renew/rekey operations complete "
+            + "asynchronously and leave this empty; register leaves it empty too unless the authority returns "
+            + "certificate data synchronously. Retrieve the signed certificate from the certificate detail once "
+            + "the certificate reaches the ISSUED state.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String certificateData;
 

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
@@ -19,7 +19,10 @@ import java.util.UUID;
 @Setter
 public class ClientCertificateDataResponseDto implements Loggable {
 
-    @Schema(description = "Base64 encoded Certificate content",
+    @Schema(description = "Base64-encoded signed certificate. Not populated by the client operations that return "
+            + "this response (issue, renew, rekey, register): they complete asynchronously through later issuance, "
+            + "so the field is left empty and never carries the signed certificate. Retrieve the signed certificate "
+            + "from the certificate detail once the certificate reaches the ISSUED state.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String certificateData;
 

--- a/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
+++ b/src/main/java/com/otilm/api/model/core/v2/ClientCertificateDataResponseDto.java
@@ -13,16 +13,17 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Response containing signed certificate data
+ * Response for the queued client certificate operations. Carries the certificate UUID; the signed
+ * certificate is not returned here — retrieve it from the certificate detail.
  */
 @Getter
 @Setter
 public class ClientCertificateDataResponseDto implements Loggable {
 
-    @Schema(description = "Base64-encoded signed certificate. The issue/renew/rekey operations complete "
-            + "asynchronously and leave this empty; register leaves it empty too unless the authority returns "
-            + "certificate data synchronously. Retrieve the signed certificate from the certificate detail once "
-            + "the certificate reaches the ISSUED state.",
+    @Schema(description = "Base64-encoded signed certificate. The issuance operations complete asynchronously "
+            + "and leave this empty; register leaves it empty too unless the authority returns certificate data "
+            + "synchronously. Retrieve the signed certificate from the certificate detail once the certificate "
+            + "reaches the ISSUED state.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String certificateData;
 

--- a/src/main/java/com/otilm/api/model/core/v2/OperationSupport.java
+++ b/src/main/java/com/otilm/api/model/core/v2/OperationSupport.java
@@ -34,9 +34,10 @@ public class OperationSupport {
     private boolean supported;
 
     @Schema(
-            description = "Whether the operation may complete asynchronously. When it does, the certificate "
-                    + "is left in a pending state and completion is observed through the certificate's state "
-                    + "(by platform status-polling or an operator finalize/confirm action)."
+            description = "Whether the platform provides managed status-polling for this operation's asynchronous "
+                    + "completion (the authority is v3 and advertises status polling). A connector may still "
+                    + "complete asynchronously without this — the certificate is then left in a pending state for "
+                    + "an operator finalize/confirm action."
     )
     private boolean asyncSupported;
 

--- a/src/main/java/com/otilm/api/model/core/v2/OperationSupport.java
+++ b/src/main/java/com/otilm/api/model/core/v2/OperationSupport.java
@@ -34,7 +34,9 @@ public class OperationSupport {
     private boolean supported;
 
     @Schema(
-            description = "Whether the operation may complete asynchronously (HTTP 202 + status polling)."
+            description = "Whether the operation may complete asynchronously. When it does, the certificate "
+                    + "is left in a pending state and completion is observed through the certificate's state "
+                    + "(by platform status-polling or an operator finalize/confirm action)."
     )
     private boolean asyncSupported;
 


### PR DESCRIPTION
## What

Documentation-only changes to the v2 Client Operations controller that feed the generated OpenAPI. **No behavior change.** Grounded in the delivered controller, service, and exception-handling code; findings independently verified against source.

### Async contract (commit 1)
The v2 client operations are fire-and-enqueue: a mutating request is validated, persisted, and queued, and the connector call runs afterward (an approval step may run first). The HTTP response never conveys the outcome, and issue/renew/rekey/register never return the signed certificate — yet the descriptions claimed a `PENDING_ISSUE` state was "returned" and the response schema advertised "Base64 encoded Certificate content" it never populates.
- Added the async/state model to the tag description.
- Corrected the `certificateData` and `OperationSupport.asyncSupported` schema text (dropped the "HTTP 202" hint — the client API never emits 202).
- Rewrote the mutating-operation descriptions to say the outcome is observed through the certificate's state; trimmed the longer ones.

### Response coverage (commit 2)
Operations documented only 200/422 (plus class-level 404/502/503), but the exception→status mapping reaches more:
- **+400** (AttributeException, CertificateOperationException, CertificateRequestException, connector 4xx) on the mutating ops;
- **+409** (AlreadyExistException) on issue-existing and finalize;
- **+500** (CertificateException and the crypto/IO checked exceptions) on issue/renew/rekey/issue-existing/finalize;
- **+422** on validate-revoke-attributes (it throws ValidationException, like validate-issue which already documented it);
- reworded the revoke **204** — the request is only accepted-and-queued, so the certificate is not yet revoked and may end REVOKED or PENDING_REVOKE;
- dropped the spurious **422** on list-issue-attributes, aligning the three list-attribute GETs on 200 only;
- noted the 422 body shape differs (string array for domain validation, `ErrorMessageDto` object for `@Valid` bean validation).

### State diagram (commit 3)
Replaced the hand-maintained ASCII state-transition diagram in the class Javadoc — which had drifted (never covered register / PENDING_REGISTRATION) — with a link to the certificate lifecycle reference, the single source of truth.

## Follow-up
Two shipped code bugs found during this review are fixed in core PR #1927 (handler NPE returning 500 instead of 400; a copy-pasted revoke wrong-state message).

## Testing
`mvn -o clean verify` — BUILD SUCCESS, 457 tests green.
