### PR TITLE
Fix stale czertainly package reference in CertificateOperationKind Javadoc

### DIFF
--- a/src/main/java/com/otilm/api/model/core/v2/CertificateOperationKind.java
+++ b/src/main/java/com/otilm/api/model/core/v2/CertificateOperationKind.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
  * {@link com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus} enum.
  *
  * <p>This is the operator-API wire vocabulary. Core's
- * {@code com.czertainly.core.service.handler.authority.CertificateOperation} is the
+ * {@code com.otilm.core.service.handler.authority.CertificateOperation} is the
  * matching domain enum (it additionally carries state-machine mappings) and stays in
  * Core — the contract module holds only the thin value-type.</p>
  */


### PR DESCRIPTION
## What

`CertificateOperationKind.java:19` Javadoc referenced the pre-rename package `com.czertainly.core.service.handler.authority.CertificateOperation`.

Corrected to the real package `com.otilm.core.service.handler.authority.CertificateOperation`.

## Why

Stale `com.czertainly.*` path was a leftover from the org rename. Verified the target class exists at `com.otilm.core.service.handler.authority.CertificateOperation` in Core.

## Scope

Javadoc comment only — no code or wire-contract change.