### PR TITLE
Add notification event object data wire contract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>interfaces</artifactId>
-    <version>2.19.0</version>
+    <version>2.20.0-SNAPSHOT</version>
     <name>interfaces</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/otilm/api/model/client/notification/NotificationProfileDetailDto.java
+++ b/src/main/java/com/otilm/api/model/client/notification/NotificationProfileDetailDto.java
@@ -1,6 +1,7 @@
 package com.otilm.api.model.client.notification;
 
 import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -43,4 +44,8 @@ public class NotificationProfileDetailDto {
 
     @Schema(description = "Maximum number of repetitions of same notification", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer repetitions;
+
+    @Schema(description = "Notification data categories included in external notifications sent by this profile",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<NotificationDataCategory> eventDataCategories;
 }

--- a/src/main/java/com/otilm/api/model/client/notification/NotificationProfileDto.java
+++ b/src/main/java/com/otilm/api/model/client/notification/NotificationProfileDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.client.notification;
 
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -46,5 +47,9 @@ public class NotificationProfileDto {
     @Schema(description = "Is notification profile sending internal notifications",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean internalNotification;
+
+    @Schema(description = "Notification data categories included in external notifications sent by this profile",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<NotificationDataCategory> eventDataCategories;
 
 }

--- a/src/main/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package com.otilm.api.model.client.notification;
 
 import com.otilm.api.model.client.notification.validation.ValidFrequency;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,6 +47,11 @@ public class NotificationProfileUpdateRequestDto {
     @Positive
     @Schema(description = "Maximum number of repetitions of same notification", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Integer repetitions;
+
+    @Schema(description = "Notification data categories included in external notifications sent by this profile. "
+            + "Presence-aware on update: absent keeps the current value, an empty list disables enrichment",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<@NotNull NotificationDataCategory> eventDataCategories;
 
     @AssertTrue(message = "Recipient UUID is required when recipient type is not Owner, None, Default or Object")
     private boolean isRecipientValid() {

--- a/src/main/java/com/otilm/api/model/common/enums/PlatformEnum.java
+++ b/src/main/java/com/otilm/api/model/common/enums/PlatformEnum.java
@@ -38,6 +38,7 @@ import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.logging.enums.*;
 import com.otilm.api.model.core.logging.enums.Module;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.other.ResourceEvent;
@@ -138,6 +139,7 @@ public enum PlatformEnum implements IPlatformEnum {
 
     // notifications
     RECIPIENT_TYPE(RecipientType.class, "Recipient type"),
+    NOTIFICATION_DATA_CATEGORY(NotificationDataCategory.class, "Notification data category"),
 
     // workflows
     TRIGGER_TYPE(TriggerType.class, "Trigger Type"),

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationAssociationDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationAssociationDto.java
@@ -5,8 +5,10 @@ import com.otilm.api.model.core.auth.Resource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Data
 @Schema(description = "Reference to an object associated with the notification subject")
 public class NotificationAssociationDto extends NameAndUuidDto {

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationAssociationDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationAssociationDto.java
@@ -1,0 +1,16 @@
+package com.otilm.api.model.connector.notification;
+
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.auth.Resource;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Schema(description = "Reference to an object associated with the notification subject")
+public class NotificationAssociationDto extends NameAndUuidDto {
+
+    @Schema(description = "Resource type of the referenced object", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Resource resource;
+}

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationAttributeDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationAttributeDto.java
@@ -1,0 +1,28 @@
+package com.otilm.api.model.connector.notification;
+
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(description = "Attribute values prepared for notification templates: plain scalar values or reference strings only, decoupled from internal attribute content versioning")
+public class NotificationAttributeDto {
+
+    @Schema(description = "Attribute name", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Schema(description = "Human-readable attribute label", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String label;
+
+    @Schema(description = "Attribute content type", requiredMode = Schema.RequiredMode.REQUIRED)
+    private AttributeContentType contentType;
+
+    @Schema(description = "Extracted values; scalar types carry raw data, complex types carry the human-readable reference string", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<Object> values;
+
+    @Schema(description = "Metadata only: aggregate set of source objects that contributed any value to this attribute. NOT positionally paired with values — values are deduplicated independently of source accumulation", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<NameAndUuidDto> sourceObjects;
+}

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDto.java
@@ -1,0 +1,27 @@
+package com.otilm.api.model.connector.notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Schema(description = "Object data enabled on the notification profile, describing the event's subject object. Best-effort: categories the subject does not support, that are disabled, or that failed to load are absent")
+public class NotificationEventObjectDataDto {
+
+    @Schema(description = "The object this data describes: the event object, or for approval events the approval's target object", requiredMode = Schema.RequiredMode.REQUIRED)
+    private NotificationAssociationDto subject;
+
+    @Schema(description = "The subject's custom attributes keyed by attribute name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Map<String, NotificationAttributeDto> customAttributes;
+
+    @Schema(description = "The subject's connector-sourced metadata, grouped by connector and source object type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<NotificationMetadataGroupDto> metadata;
+
+    @Schema(description = "The subject's associated objects: owner, groups, RA profile", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<NotificationAssociationDto> associations;
+
+    @Schema(description = "The subject's content representation when its resource type provides one", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private NotificationObjectContentDto content;
+}

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationMetadataGroupDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationMetadataGroupDto.java
@@ -1,0 +1,21 @@
+package com.otilm.api.model.connector.notification;
+
+import com.otilm.api.model.core.auth.Resource;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@Schema(description = "Connector-sourced metadata grouped by connector and source object type; same-named attributes from different connectors live in different groups")
+public class NotificationMetadataGroupDto {
+
+    @Schema(description = "Name of the connector that produced the metadata", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String connectorName;
+
+    @Schema(description = "Resource type of the source object the metadata originates from", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Resource sourceObjectType;
+
+    @Schema(description = "Metadata attributes keyed by attribute name", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Map<String, NotificationAttributeDto> attributes;
+}

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationObjectContentDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationObjectContentDto.java
@@ -1,0 +1,15 @@
+package com.otilm.api.model.connector.notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Content representation of the notification subject, produced by the platform's content exporter for the subject's resource type")
+public class NotificationObjectContentDto {
+
+    @Schema(description = "Content format identifier declared by the exporter", requiredMode = Schema.RequiredMode.REQUIRED, examples = {"X509_DER_BASE64"})
+    private String format;
+
+    @Schema(description = "Content data; encoding is defined by the format", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String data;
+}

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
@@ -4,6 +4,7 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.other.ResourceEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -27,4 +28,9 @@ public class NotificationProviderNotifyRequestDto {
 
     @Schema(description = "Data associated with notification event and resource", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Object notificationData;
+
+    // Excluded from toString: bulk object data must not leak into logs or tracing spans on accidental dumps.
+    @ToString.Exclude
+    @Schema(description = "Additional object data enabled on the notification profile", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private NotificationEventObjectDataDto objectData;
 }

--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
@@ -26,6 +26,9 @@ public class NotificationProviderNotifyRequestDto {
     @Schema(description = "Resource which is represented by data", requiredMode = Schema.RequiredMode.NOT_REQUIRED, examples = {"certificate"})
     private Resource resource;
 
+    // Excluded from toString: the untyped payload can carry sensitive values (e.g. a registration
+    // credential) that a typed event class would exclude from its own toString.
+    @ToString.Exclude
     @Schema(description = "Data associated with notification event and resource", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Object notificationData;
 

--- a/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
+++ b/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
@@ -13,6 +13,10 @@ import java.util.Arrays;
  * Category of event object data a notification profile can include in external
  * notifications. Categories are opt-in per profile and resource-neutral: a category
  * that the event's subject object does not support simply yields no data.
+ *
+ * <p>Deserialization is strict, matching every platform enum: an unrecognized code fails
+ * with a validation error rather than being skipped. A client on an older version of this
+ * artifact must upgrade before it can read profiles that enable categories added later.
  */
 @Schema(enumAsRef = true)
 public enum NotificationDataCategory implements IPlatformEnum {
@@ -32,9 +36,6 @@ public enum NotificationDataCategory implements IPlatformEnum {
         VALUES = values();
     }
 
-    @Schema(description = "Notification data category code",
-            examples = {"customAttributes", "metadata", "associations", "objectContent"},
-            requiredMode = Schema.RequiredMode.REQUIRED)
     private final String code;
     private final String label;
     private final String description;

--- a/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
+++ b/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
@@ -1,0 +1,72 @@
+package com.otilm.api.model.core.notification;
+
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.common.enums.IPlatformEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+
+/**
+ * Category of event object data a notification profile can include in external
+ * notifications. Categories are opt-in per profile and resource-neutral: a category
+ * that the event's subject object does not support simply yields no data.
+ */
+@Schema(enumAsRef = true)
+public enum NotificationDataCategory implements IPlatformEnum {
+
+    CUSTOM_ATTRIBUTES("customAttributes", "Custom attributes",
+            "Include the event object's custom attribute values"),
+    METADATA("metadata", "Metadata",
+            "Include connector-provided metadata, grouped by connector and source object"),
+    ASSOCIATIONS("associations", "Associations",
+            "Include owner, group, and RA profile references"),
+    OBJECT_CONTENT("objectContent", "Object content",
+            "Include the object's content when its type provides one, e.g. certificates as Base64 DER");
+
+    private static final NotificationDataCategory[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    @Schema(description = "Notification data category code",
+            examples = {"customAttributes", "metadata", "associations", "objectContent"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String code;
+    private final String label;
+    private final String description;
+
+    NotificationDataCategory(String code, String label, String description) {
+        this.code = code;
+        this.label = label;
+        this.description = description;
+    }
+
+    @Override
+    @JsonValue
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getLabel() {
+        return this.label;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @JsonCreator
+    public static NotificationDataCategory findByCode(String code) {
+        return Arrays.stream(VALUES)
+                .filter(k -> k.code.equals(code))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ValidationException(ValidationError.create("Unknown notification data category {}", code)));
+    }
+}

--- a/src/test/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDtoTest.java
@@ -1,0 +1,47 @@
+package com.otilm.api.model.client.notification;
+
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NotificationProfileUpdateRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void absentCategoriesDeserializeAsNull() throws Exception {
+        NotificationProfileUpdateRequestDto dto = mapper.readValue("{}", NotificationProfileUpdateRequestDto.class);
+        assertNull(dto.getEventDataCategories());
+    }
+
+    @Test
+    void emptyCategoriesDeserializeAsEmptyList() throws Exception {
+        NotificationProfileUpdateRequestDto dto = mapper.readValue(
+                "{\"eventDataCategories\":[]}", NotificationProfileUpdateRequestDto.class);
+        assertNotNull(dto.getEventDataCategories());
+        assertTrue(dto.getEventDataCategories().isEmpty());
+    }
+
+    @Test
+    void categoriesRideWireCodes() throws Exception {
+        NotificationProfileUpdateRequestDto dto = new NotificationProfileUpdateRequestDto();
+        dto.setEventDataCategories(List.of(
+                NotificationDataCategory.CUSTOM_ATTRIBUTES, NotificationDataCategory.OBJECT_CONTENT));
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"eventDataCategories\":[\"customAttributes\",\"objectContent\"]"), json);
+    }
+
+    @Test
+    void createRequestInheritsCategories() throws Exception {
+        NotificationProfileRequestDto dto = mapper.readValue(
+                "{\"name\":\"profile\",\"eventDataCategories\":[\"metadata\"]}", NotificationProfileRequestDto.class);
+        assertNotNull(dto.getEventDataCategories());
+        assertTrue(dto.getEventDataCategories().contains(NotificationDataCategory.METADATA));
+    }
+}

--- a/src/test/java/com/otilm/api/model/common/enums/PlatformEnumTest.java
+++ b/src/test/java/com/otilm/api/model/common/enums/PlatformEnumTest.java
@@ -1,0 +1,41 @@
+package com.otilm.api.model.common.enums;
+
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlatformEnumTest {
+
+    @Test
+    void notificationDataCategoryIsRegistered() {
+        PlatformEnum entry = PlatformEnum.findByClass(NotificationDataCategory.class);
+        assertNotNull(entry);
+        assertEquals(NotificationDataCategory.class, entry.getEnumClass());
+        assertEquals("NotificationDataCategory", entry.getCode());
+    }
+
+    @Test
+    void everyEntryHasEnumClassAndLabel() {
+        for (PlatformEnum entry : PlatformEnum.values()) {
+            assertNotNull(entry.getEnumClass(), "enum class missing for " + entry.name());
+            assertTrue(entry.getEnumClass().isEnum(), "not an enum: " + entry.name());
+            assertFalse(entry.getLabel().isBlank(), "label missing for " + entry.name());
+        }
+    }
+
+    @Test
+    void registeredEnumClassesAreUnique() {
+        Set<Class<?>> seen = new HashSet<>();
+        for (PlatformEnum entry : PlatformEnum.values()) {
+            assertTrue(seen.add(entry.getEnumClass()),
+                    "enum class registered twice: " + entry.getEnumClass().getSimpleName());
+        }
+    }
+}

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDtoTest.java
@@ -1,0 +1,71 @@
+package com.otilm.api.model.connector.notification;
+
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.core.auth.Resource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NotificationEventObjectDataDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void roundTripsAllCategories() throws Exception {
+        NotificationAttributeDto attribute = new NotificationAttributeDto();
+        attribute.setName("department");
+        attribute.setLabel("Department");
+        attribute.setContentType(AttributeContentType.STRING);
+        attribute.setValues(List.of("E-Commerce"));
+
+        NotificationAttributeDto meta = new NotificationAttributeDto();
+        meta.setName("discoverySource");
+        meta.setLabel("Discovery Source");
+        meta.setContentType(AttributeContentType.STRING);
+        meta.setValues(List.of("10.20.30.0/24"));
+        meta.setSourceObjects(List.of(new NameAndUuidDto("3c1e88f0-0000-0000-0000-000000000001", "weekly-dc1-sweep")));
+
+        NotificationMetadataGroupDto group = new NotificationMetadataGroupDto();
+        group.setConnectorName("Network-Discovery");
+        group.setSourceObjectType(Resource.DISCOVERY);
+        group.setAttributes(Map.of("discoverySource", meta));
+
+        NotificationAssociationDto subject = new NotificationAssociationDto();
+        subject.setResource(Resource.CERTIFICATE);
+        subject.setUuid("e1f6a7c2-0000-0000-0000-000000000002");
+        subject.setName("shop.acme.example");
+
+        NotificationObjectContentDto content = new NotificationObjectContentDto();
+        content.setFormat("X509_DER_BASE64");
+        content.setData("MIIBmTCCAT+gAwIBAgIUfake");
+
+        NotificationEventObjectDataDto dto = new NotificationEventObjectDataDto();
+        dto.setSubject(subject);
+        dto.setCustomAttributes(Map.of("department", attribute));
+        dto.setMetadata(List.of(group));
+        dto.setAssociations(List.of(subject));
+        dto.setContent(content);
+
+        String json = mapper.writeValueAsString(dto);
+        NotificationEventObjectDataDto back = mapper.readValue(json, NotificationEventObjectDataDto.class);
+
+        assertEquals(dto, back);
+        // Enum fields ride their @JsonValue codes on the wire.
+        assertTrue(json.contains("\"resource\":\"certificates\""), json);
+        assertTrue(json.contains("\"contentType\":\"string\""), json);
+        assertTrue(json.contains("\"sourceObjectType\":\"discoveries\""), json);
+    }
+
+    @Test
+    void emptyDtoRoundTripsWithoutFailure() throws Exception {
+        String json = mapper.writeValueAsString(new NotificationEventObjectDataDto());
+        assertNotNull(mapper.readValue(json, NotificationEventObjectDataDto.class));
+    }
+}

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationEventObjectDataDtoTest.java
@@ -68,4 +68,35 @@ class NotificationEventObjectDataDtoTest {
         String json = mapper.writeValueAsString(new NotificationEventObjectDataDto());
         assertNotNull(mapper.readValue(json, NotificationEventObjectDataDto.class));
     }
+
+    @Test
+    void nonStringScalarValuesKeepTheirWireTypes() throws Exception {
+        NotificationAttributeDto attribute = new NotificationAttributeDto();
+        attribute.setName("port");
+        attribute.setLabel("Port");
+        attribute.setContentType(AttributeContentType.INTEGER);
+        attribute.setValues(List.of(443, true, 1.5));
+
+        String json = mapper.writeValueAsString(attribute);
+        assertTrue(json.contains("\"values\":[443,true,1.5]"), json);
+
+        NotificationAttributeDto back = mapper.readValue(json, NotificationAttributeDto.class);
+        // Untyped scalars land as their natural JSON Java types -- the contract template
+        // authors and providers can rely on across artifact versions.
+        assertEquals(Integer.valueOf(443), back.getValues().get(0));
+        assertEquals(Boolean.TRUE, back.getValues().get(1));
+        assertEquals(Double.valueOf(1.5), back.getValues().get(2));
+    }
+
+    @Test
+    void associationToStringIncludesInheritedIdentity() {
+        NotificationAssociationDto association = new NotificationAssociationDto();
+        association.setResource(Resource.GROUP);
+        association.setUuid("0aa13f77-0000-0000-0000-000000000003");
+        association.setName("web-team");
+
+        String printed = association.toString();
+        assertTrue(printed.contains("web-team"), printed);
+        assertTrue(printed.contains("0aa13f77"), printed);
+    }
 }

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
@@ -12,16 +12,20 @@ class NotificationProviderNotifyRequestDtoTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    void objectDataIsExcludedFromToString() {
+    void payloadFieldsAreExcludedFromToString() {
         NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
         NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
         NotificationAssociationDto subject = new NotificationAssociationDto();
         subject.setName("marker-subject-name");
         objectData.setSubject(subject);
         request.setObjectData(objectData);
+        request.setNotificationData(java.util.Map.of("credential", "marker-credential-value"));
 
-        assertFalse(request.toString().contains("marker-subject-name"), request.toString());
-        assertFalse(request.toString().contains("objectData"), request.toString());
+        String printed = request.toString();
+        assertFalse(printed.contains("marker-subject-name"), printed);
+        assertFalse(printed.contains("objectData"), printed);
+        assertFalse(printed.contains("marker-credential-value"), printed);
+        assertFalse(printed.contains("notificationData"), printed);
     }
 
     @Test

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
@@ -1,0 +1,47 @@
+package com.otilm.api.model.connector.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NotificationProviderNotifyRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void objectDataIsExcludedFromToString() {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
+        NotificationAssociationDto subject = new NotificationAssociationDto();
+        subject.setName("marker-subject-name");
+        objectData.setSubject(subject);
+        request.setObjectData(objectData);
+
+        assertFalse(request.toString().contains("marker-subject-name"), request.toString());
+        assertFalse(request.toString().contains("objectData"), request.toString());
+    }
+
+    @Test
+    void deserializationToleratesAbsentObjectData() throws Exception {
+        NotificationProviderNotifyRequestDto request = mapper.readValue(
+                "{\"recipients\":[],\"eventType\":\"other\"}", NotificationProviderNotifyRequestDto.class);
+        assertNull(request.getObjectData());
+    }
+
+    @Test
+    void objectDataRoundTrips() throws Exception {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
+        NotificationAssociationDto subject = new NotificationAssociationDto();
+        subject.setUuid("e1f6a7c2-0000-0000-0000-000000000002");
+        objectData.setSubject(subject);
+        request.setObjectData(objectData);
+
+        NotificationProviderNotifyRequestDto back = mapper.readValue(
+                mapper.writeValueAsString(request), NotificationProviderNotifyRequestDto.class);
+        assertEquals(request.getObjectData(), back.getObjectData());
+    }
+}

--- a/src/test/java/com/otilm/api/model/core/notification/NotificationDataCategoryTest.java
+++ b/src/test/java/com/otilm/api/model/core/notification/NotificationDataCategoryTest.java
@@ -1,0 +1,60 @@
+package com.otilm.api.model.core.notification;
+
+import com.otilm.api.exception.ValidationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NotificationDataCategoryTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesToJsonValueCode() throws Exception {
+        assertEquals("\"customAttributes\"", mapper.writeValueAsString(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        assertEquals("\"metadata\"", mapper.writeValueAsString(NotificationDataCategory.METADATA));
+        assertEquals("\"associations\"", mapper.writeValueAsString(NotificationDataCategory.ASSOCIATIONS));
+        assertEquals("\"objectContent\"", mapper.writeValueAsString(NotificationDataCategory.OBJECT_CONTENT));
+    }
+
+    @Test
+    void deserializesFromJsonValueCode() throws Exception {
+        assertEquals(NotificationDataCategory.CUSTOM_ATTRIBUTES,
+                mapper.readValue("\"customAttributes\"", NotificationDataCategory.class));
+        assertEquals(NotificationDataCategory.METADATA,
+                mapper.readValue("\"metadata\"", NotificationDataCategory.class));
+        assertEquals(NotificationDataCategory.ASSOCIATIONS,
+                mapper.readValue("\"associations\"", NotificationDataCategory.class));
+        assertEquals(NotificationDataCategory.OBJECT_CONTENT,
+                mapper.readValue("\"objectContent\"", NotificationDataCategory.class));
+    }
+
+    @Test
+    void unknownCodeThrowsValidationException() {
+        // Deserializing an unknown code surfaces a Jackson mapping error whose root
+        // cause carries the validation failure raised by the enum factory method.
+        JsonMappingException ex = assertThrows(JsonMappingException.class,
+                () -> mapper.readValue("\"bogus\"", NotificationDataCategory.class));
+        assertInstanceOf(ValidationException.class, ex.getCause(),
+                "expected the underlying cause to be ValidationException, got: " + ex.getCause());
+    }
+
+    @Test
+    void findByCodeRejectsUnknownDirectly() {
+        assertThrows(ValidationException.class,
+                () -> NotificationDataCategory.findByCode("bogus"));
+    }
+
+    @Test
+    void labelsAndDescriptionsArePopulated() {
+        for (NotificationDataCategory category : NotificationDataCategory.values()) {
+            assertFalse(category.getLabel().isBlank(), "label missing for " + category.name());
+            assertFalse(category.getDescription().isBlank(), "description missing for " + category.name());
+        }
+    }
+}


### PR DESCRIPTION
Closes #786. Part of epic OmniTrustILM/ilm#301.

Adds the additive wire contract for enriched notification data:

- `NotificationDataCategory` enum (`customAttributes`, `metadata`, `associations`, `objectContent`), registered in the `PlatformEnum` registry so the FE can discover labels and help texts via `/v1/enums`.
- Wire DTOs for the enriched payload: `NotificationEventObjectDataDto` (subject reference, name-keyed custom attributes, connector-grouped metadata, associations, content), `NotificationAttributeDto` (plain values with aggregate `sourceObjects` provenance, documented as not positionally paired), `NotificationMetadataGroupDto`, `NotificationAssociationDto`, `NotificationObjectContentDto`.
- New nullable `objectData` field on `NotificationProviderNotifyRequestDto`, beside the unchanged `notificationData`, excluded from `toString` so bulk object data cannot leak through accidental dumps.
- `eventDataCategories` on the notification profile request/update/detail/list DTOs with presence-aware update semantics documented in the schema (absent keeps the current value, an empty list disables enrichment); null entries rejected by bean validation.
- Version moved to `2.20.0-SNAPSHOT`.

The change is purely additive: no existing field is modified or removed, and connectors tolerating unknown JSON properties keep working unchanged.