### PR TITLE
Omit null objectData from the notify request JSON

### DIFF
--- a/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
+++ b/src/main/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDto.java
@@ -1,5 +1,6 @@
 package com.otilm.api.model.connector.notification;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.other.ResourceEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,8 +33,11 @@ public class NotificationProviderNotifyRequestDto {
     @Schema(description = "Data associated with notification event and resource", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Object notificationData;
 
-    // Excluded from toString: bulk object data must not leak into logs or tracing spans on accidental dumps.
+    // Excluded from toString: bulk object data must not leak into logs or tracing spans on accidental
+    // dumps. Omitted from JSON when null so payloads without enrichment stay byte-identical to the
+    // pre-enrichment wire format.
     @ToString.Exclude
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "Additional object data enabled on the notification profile", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private NotificationEventObjectDataDto objectData;
 }

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
@@ -29,6 +29,15 @@ class NotificationProviderNotifyRequestDtoTest {
     }
 
     @Test
+    void nullObjectDataIsOmittedFromJson() throws Exception {
+        // A payload without enrichment must stay byte-identical to the pre-enrichment wire format
+        // regardless of the serializer's default null handling.
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setRecipients(java.util.List.of());
+        assertFalse(mapper.writeValueAsString(request).contains("objectData"));
+    }
+
+    @Test
     void deserializationToleratesAbsentObjectData() throws Exception {
         NotificationProviderNotifyRequestDto request = mapper.readValue(
                 "{\"recipients\":[],\"eventType\":\"other\"}", NotificationProviderNotifyRequestDto.class);

--- a/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
+++ b/src/test/java/com/otilm/api/model/connector/notification/NotificationProviderNotifyRequestDtoTest.java
@@ -34,7 +34,7 @@ class NotificationProviderNotifyRequestDtoTest {
         // regardless of the serializer's default null handling.
         NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
         request.setRecipients(java.util.List.of());
-        assertFalse(mapper.writeValueAsString(request).contains("objectData"));
+        assertFalse(mapper.readTree(mapper.writeValueAsString(request)).has("objectData"));
     }
 
     @Test


### PR DESCRIPTION
Part of epic OmniTrustILM/ilm#301; follow-up to #805.

Adds a field-level `@JsonInclude(NON_NULL)` on `NotificationProviderNotifyRequestDto.objectData`, so notify payloads without enrichment omit the field instead of carrying an explicit `"objectData": null` and stay byte-identical to the pre-enrichment wire format.