### PR TITLE
Correct notification wire-contract descriptions

### DIFF
--- a/src/main/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/notification/NotificationProfileUpdateRequestDto.java
@@ -49,7 +49,7 @@ public class NotificationProfileUpdateRequestDto {
     private Integer repetitions;
 
     @Schema(description = "Notification data categories included in external notifications sent by this profile. "
-            + "Presence-aware on update: absent keeps the current value, an empty list disables enrichment",
+            + "When updating, an absent field keeps the current value and an empty list disables enrichment",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<@NotNull NotificationDataCategory> eventDataCategories;
 

--- a/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
+++ b/src/main/java/com/otilm/api/model/core/notification/NotificationDataCategory.java
@@ -26,7 +26,7 @@ public enum NotificationDataCategory implements IPlatformEnum {
     METADATA("metadata", "Metadata",
             "Include connector-provided metadata, grouped by connector and source object"),
     ASSOCIATIONS("associations", "Associations",
-            "Include owner, group, and RA profile references"),
+            "Include owner, groups, and RA profile references"),
     OBJECT_CONTENT("objectContent", "Object content",
             "Include the object's content when its type provides one, e.g. certificates as Base64 DER");
 


### PR DESCRIPTION
Part of epic OmniTrustILM/ilm#301; follow-up to #805.

Two wording corrections on the notification wire contract:

- The `ASSOCIATIONS` category description now reads "Include owner, groups, and RA profile references" (plural), matching the feature requirement — this text is served via `/v1/enums` as the profile form's help text.
- The `eventDataCategories` schema description no longer reads as update-only on the create request that inherits it: "When updating, an absent field keeps the current value and an empty list disables enrichment".