### PR TITLE
Add protocol challenge source contract for SCEP, CMP and ACME profiles

### DIFF
--- a/src/main/java/com/otilm/api/model/client/acme/AcmeProfileEditRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/acme/AcmeProfileEditRequestDto.java
@@ -2,6 +2,7 @@ package com.otilm.api.model.client.acme;
 
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Data;
@@ -130,4 +131,14 @@ public class AcmeProfileEditRequestDto {
                 .append("customAttributes", customAttributes)
                 .toString();
     }
+
+    @Schema(
+            description = "Source of the enrolment authorization ('protocolDefault' or 'certificateRegistration'). "
+                    + "'protocolDefault' uses ACME's standard order authorizations (domain validation); "
+                    + "'certificateRegistration' binds accounts to a pre-registered certificate via external account "
+                    + "binding and orders complete it. Omit to keep the stored value on edit; on create, omit to "
+                    + "default to 'protocolDefault'.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/client/acme/AcmeProfileEditRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/acme/AcmeProfileEditRequestDto.java
@@ -131,14 +131,4 @@ public class AcmeProfileEditRequestDto {
                 .append("customAttributes", customAttributes)
                 .toString();
     }
-
-    @Schema(
-            description = "Source of the enrolment authorization ('protocolDefault' or 'certificateRegistration'). "
-                    + "'protocolDefault' uses ACME's standard order authorizations (domain validation); "
-                    + "'certificateRegistration' binds accounts to a pre-registered certificate via external account "
-                    + "binding and orders complete it. Omit to keep the stored value on edit; on create, omit to "
-                    + "default to 'protocolDefault'.",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/client/acme/AcmeProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/acme/AcmeProfileRequestDto.java
@@ -121,14 +121,4 @@ public class AcmeProfileRequestDto {
     public Boolean isRequireContact() {
         return requireContact;
     }
-
-    @Schema(
-            description = "Source of the enrolment authorization ('protocolDefault' or 'certificateRegistration'). "
-                    + "'protocolDefault' uses ACME's standard order authorizations (domain validation); "
-                    + "'certificateRegistration' binds accounts to a pre-registered certificate via external account "
-                    + "binding and orders complete it. Omit to keep the stored value on edit; on create, omit to "
-                    + "default to 'protocolDefault'.",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/client/acme/AcmeProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/acme/AcmeProfileRequestDto.java
@@ -2,6 +2,7 @@ package com.otilm.api.model.client.acme;
 
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Data;
@@ -120,4 +121,14 @@ public class AcmeProfileRequestDto {
     public Boolean isRequireContact() {
         return requireContact;
     }
+
+    @Schema(
+            description = "Source of the enrolment authorization ('protocolDefault' or 'certificateRegistration'). "
+                    + "'protocolDefault' uses ACME's standard order authorizations (domain validation); "
+                    + "'certificateRegistration' binds accounts to a pre-registered certificate via external account "
+                    + "binding and orders complete it. Omit to keep the stored value on edit; on create, omit to "
+                    + "default to 'protocolDefault'.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/client/cmp/BaseCmpProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/cmp/BaseCmpProfileRequestDto.java
@@ -5,6 +5,7 @@ import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.cmp.validation.ValidUuid;
 import com.otilm.api.model.core.cmp.ProtectionMethod;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -72,6 +73,16 @@ public class BaseCmpProfileRequestDto {
             description = "UUID of the Certificate to be used as signing certificate for CMP responses. Required when Protection Method is Signature"
     )
     private String signingCertificateUuid;
+
+    @Schema(
+            description = "Source of the credential for MAC-protected requests ('protocolDefault' or 'certificateRegistration'). "
+                    + "'protocolDefault' verifies against the profile shared secret; 'certificateRegistration' requires the "
+                    + "senderKID to reference a pre-registered certificate whose challenge is the MAC secret, and forbids a "
+                    + "profile shared secret. Signature protection is independent of this setting. Omit to keep the stored "
+                    + "value on edit; on create, omit to default to 'protocolDefault'.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private ProtocolChallengeSource challengeSource;
 
     @Valid
     @Schema(description = "Associations to set for certificates issued by the protocol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
@@ -3,7 +3,7 @@ package com.otilm.api.model.client.scep;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
-import com.otilm.api.model.core.scep.ScepChallengeSource;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Data;
@@ -88,13 +88,13 @@ public class BaseScepProfileRequestDto {
     private Boolean enableChallengePassword;
 
     @Schema(
-            description = "Source of the enrolment challenge ('profileChallengePassword' or 'certificateRegistration'). "
-                    + "'profileChallengePassword' authenticates against the shared challenge password; "
+            description = "Source of the enrolment challenge ('protocolDefault' or 'certificateRegistration'). "
+                    + "'protocolDefault' authenticates against the shared challenge password; "
                     + "'certificateRegistration' requires every initial enrolment to match a pre-registered certificate and "
-                    + "forbids a profile challenge password. Omit to keep the stored value on edit; on create, omit to default to 'profileChallengePassword'.",
+                    + "forbids a profile challenge password. Omit to keep the stored value on edit; on create, omit to default to 'protocolDefault'.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    private ScepChallengeSource challengeSource;
+    private ProtocolChallengeSource challengeSource;
 
     @Schema(description = "Status of Intune")
     private Boolean enableIntune;

--- a/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
@@ -3,6 +3,7 @@ package com.otilm.api.model.client.scep;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsRequestDto;
+import com.otilm.api.model.core.scep.ScepChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Data;
@@ -85,6 +86,15 @@ public class BaseScepProfileRequestDto {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private Boolean enableChallengePassword;
+
+    @Schema(
+            description = "Source of the enrolment challenge. PROFILE_CHALLENGE_PASSWORD authenticates against "
+                    + "the shared challenge password; CERTIFICATE_REGISTRATION requires every initial enrolment "
+                    + "to match a pre-registered certificate and forbids a profile challenge password. Omit to "
+                    + "keep the stored value on edit, or for PROFILE_CHALLENGE_PASSWORD on create.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private ScepChallengeSource challengeSource;
 
     @Schema(description = "Status of Intune")
     private Boolean enableIntune;

--- a/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
+++ b/src/main/java/com/otilm/api/model/client/scep/BaseScepProfileRequestDto.java
@@ -88,10 +88,10 @@ public class BaseScepProfileRequestDto {
     private Boolean enableChallengePassword;
 
     @Schema(
-            description = "Source of the enrolment challenge. PROFILE_CHALLENGE_PASSWORD authenticates against "
-                    + "the shared challenge password; CERTIFICATE_REGISTRATION requires every initial enrolment "
-                    + "to match a pre-registered certificate and forbids a profile challenge password. Omit to "
-                    + "keep the stored value on edit, or for PROFILE_CHALLENGE_PASSWORD on create.",
+            description = "Source of the enrolment challenge ('profileChallengePassword' or 'certificateRegistration'). "
+                    + "'profileChallengePassword' authenticates against the shared challenge password; "
+                    + "'certificateRegistration' requires every initial enrolment to match a pre-registered certificate and "
+                    + "forbids a profile challenge password. Omit to keep the stored value on edit; on create, omit to default to 'profileChallengePassword'.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private ScepChallengeSource challengeSource;

--- a/src/main/java/com/otilm/api/model/common/enums/PlatformEnum.java
+++ b/src/main/java/com/otilm/api/model/common/enums/PlatformEnum.java
@@ -42,6 +42,7 @@ import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import com.otilm.api.model.core.secret.SecretState;
 import com.otilm.api.model.client.signing.profile.scheme.ManagedSigningType;
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
@@ -124,6 +125,9 @@ public enum PlatformEnum implements IPlatformEnum {
     // CMP
     CMP_PROTECTION_METHOD(ProtectionMethod.class, "CMP protection method"),
     CMP_PROFILE_VARIANT(CmpProfileVariant.class, "CMP protocol variant"),
+
+    // Protocols
+    PROTOCOL_CHALLENGE_SOURCE(ProtocolChallengeSource.class, "Protocol challenge source"),
 
     // Attributes
     ATTRIBUTE_TYPE(AttributeType.class, "Attribute Type"),

--- a/src/main/java/com/otilm/api/model/core/acme/AcmeProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/acme/AcmeProfileDto.java
@@ -78,8 +78,4 @@ public class AcmeProfileDto extends NameAndUuidDto {
                 .append("customAttributes", customAttributes)
                 .toString();
     }
-
-    @Schema(description = "Source of the enrolment authorization",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/core/acme/AcmeProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/acme/AcmeProfileDto.java
@@ -4,6 +4,7 @@ import com.otilm.api.model.client.attribute.ResponseAttribute;
 import com.otilm.api.model.client.raprofile.SimplifiedRaProfileDto;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.protocol.ProtocolCertificateAssociationsDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -77,4 +78,8 @@ public class AcmeProfileDto extends NameAndUuidDto {
                 .append("customAttributes", customAttributes)
                 .toString();
     }
+
+    @Schema(description = "Source of the enrolment authorization",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/core/cmp/CmpProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/cmp/CmpProfileDto.java
@@ -2,6 +2,7 @@ package com.otilm.api.model.core.cmp;
 
 import com.otilm.api.model.client.raprofile.SimplifiedRaProfileDto;
 import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -38,4 +39,8 @@ public class CmpProfileDto extends NameAndUuidDto {
             examples = {"https://your-domain.com/api/v1/protocols/cmp/cmpProfile"}
     )
     private String cmpUrl;
+
+    @Schema(description = "Source of the credential for MAC-protected requests",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/core/protocol/ProtocolChallengeSource.java
+++ b/src/main/java/com/otilm/api/model/core/protocol/ProtocolChallengeSource.java
@@ -1,4 +1,4 @@
-package com.otilm.api.model.core.scep;
+package com.otilm.api.model.core.protocol;
 
 import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
@@ -10,15 +10,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 
 /**
- * Source of the challenge a SCEP profile authenticates enrolments against: the profile's shared
- * challenge password, or the per-certificate challenge of a certificate registration.
+ * Source of the credential a protocol profile authenticates enrolments against: the protocol's default
+ * mechanism (SCEP shared challenge password, CMP shared secret, ACME domain validation), or the
+ * per-certificate challenge of a certificate registration.
  */
 @Schema(enumAsRef = true)
-public enum ScepChallengeSource implements IPlatformEnum {
-    PROFILE_CHALLENGE_PASSWORD("profileChallengePassword", "Profile Challenge Password"),
+public enum ProtocolChallengeSource implements IPlatformEnum {
+    PROTOCOL_DEFAULT("protocolDefault", "Protocol Default"),
     CERTIFICATE_REGISTRATION("certificateRegistration", "Certificate Registration");
 
-    private static final ScepChallengeSource[] VALUES;
+    private static final ProtocolChallengeSource[] VALUES;
 
     static {
         VALUES = values();
@@ -27,7 +28,7 @@ public enum ScepChallengeSource implements IPlatformEnum {
     private final String code;
     private final String label;
 
-    ScepChallengeSource(String code, String label) {
+    ProtocolChallengeSource(String code, String label) {
         this.code = code;
         this.label = label;
     }
@@ -49,11 +50,11 @@ public enum ScepChallengeSource implements IPlatformEnum {
     }
 
     @JsonCreator
-    public static ScepChallengeSource findByCode(String code) {
+    public static ProtocolChallengeSource findByCode(String code) {
         return Arrays.stream(VALUES)
                 .filter(k -> k.code.equals(code))
                 .findFirst()
                 .orElseThrow(() ->
-                        new ValidationException(ValidationError.create("Unknown SCEP Challenge Source code {}", code)));
+                        new ValidationException(ValidationError.create("Unknown Protocol Challenge Source code {}", code)));
     }
 }

--- a/src/main/java/com/otilm/api/model/core/scep/ScepChallengeSource.java
+++ b/src/main/java/com/otilm/api/model/core/scep/ScepChallengeSource.java
@@ -1,0 +1,59 @@
+package com.otilm.api.model.core.scep;
+
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.common.enums.IPlatformEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+
+/**
+ * Source of the challenge a SCEP profile authenticates enrolments against: the profile's shared
+ * challenge password, or the per-certificate challenge of a certificate registration.
+ */
+@Schema(enumAsRef = true)
+public enum ScepChallengeSource implements IPlatformEnum {
+    PROFILE_CHALLENGE_PASSWORD("profileChallengePassword", "Profile Challenge Password"),
+    CERTIFICATE_REGISTRATION("certificateRegistration", "Certificate Registration");
+
+    private static final ScepChallengeSource[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    private final String code;
+    private final String label;
+
+    ScepChallengeSource(String code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    @Override
+    @JsonValue
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @JsonCreator
+    public static ScepChallengeSource findByCode(String code) {
+        return Arrays.stream(VALUES)
+                .filter(k -> k.code.equals(code))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ValidationException(ValidationError.create("Unknown SCEP Challenge Source code {}", code)));
+    }
+}

--- a/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
@@ -2,6 +2,7 @@ package com.otilm.api.model.core.scep;
 
 import com.otilm.api.model.client.raprofile.SimplifiedRaProfileDto;
 import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -34,5 +35,5 @@ public class ScepProfileDto extends NameAndUuidDto {
     private boolean enableChallengePassword;
 
     @Schema(description = "Source of the enrolment challenge", requiredMode = Schema.RequiredMode.REQUIRED)
-    private ScepChallengeSource challengeSource;
+    private ProtocolChallengeSource challengeSource;
 }

--- a/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
+++ b/src/main/java/com/otilm/api/model/core/scep/ScepProfileDto.java
@@ -32,4 +32,7 @@ public class ScepProfileDto extends NameAndUuidDto {
             + "itself is write-only and never returned; this flag lets clients reflect the current state.",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean enableChallengePassword;
+
+    @Schema(description = "Source of the enrolment challenge", requiredMode = Schema.RequiredMode.REQUIRED)
+    private ScepChallengeSource challengeSource;
 }

--- a/src/test/java/com/otilm/api/model/common/enums/PlatformEnumTest.java
+++ b/src/test/java/com/otilm/api/model/common/enums/PlatformEnumTest.java
@@ -1,6 +1,7 @@
 package com.otilm.api.model.common.enums;
 
 import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.api.model.core.protocol.ProtocolChallengeSource;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -19,6 +20,15 @@ class PlatformEnumTest {
         assertNotNull(entry);
         assertEquals(NotificationDataCategory.class, entry.getEnumClass());
         assertEquals("NotificationDataCategory", entry.getCode());
+    }
+
+    @Test
+    void protocolChallengeSourceIsRegistered() {
+        PlatformEnum entry = PlatformEnum.findByClass(ProtocolChallengeSource.class);
+        assertNotNull(entry);
+        assertEquals(PlatformEnum.PROTOCOL_CHALLENGE_SOURCE, entry);
+        assertEquals(ProtocolChallengeSource.class, entry.getEnumClass());
+        assertEquals("ProtocolChallengeSource", entry.getCode());
     }
 
     @Test


### PR DESCRIPTION
Contract for OmniTrustILM/ilm#311 (protocol enrolment against pre-registrations): `ProtocolChallengeSource` enum (`protocolDefault` | `certificateRegistration`) in the protocol-neutral package, wired into the SCEP, CMP and ACME profile request/response DTOs. `protocolDefault` means each protocol's native mechanism (SCEP shared challenge password, CMP shared secret for MAC protection, ACME domain validation); `certificateRegistration` gates enrolment on pre-registered certificates. Request fields are keep-when-null; response fields are required and are populated by the per-protocol core implementations (SCEP: OmniTrustILM/core#1968; CMP and ACME follow).