### PR TITLE
Discovery v2 API clients and shared client settings

### DIFF
--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -72,8 +72,8 @@ public abstract class BaseApiClient {
     private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
     private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
 
-    // Bound for the cause-chain walk in findInCauseChain. Chains this deep do not occur in practice;
-    // the cap is there so a cyclic chain cannot spin forever inside an exception handler.
+    // Bound for the cause-chain walk in findInCauseChain. Chains are never this deep in practice.
+    // The cap exists so a cyclic chain cannot spin forever inside an exception handler.
     private static final int MAX_CAUSE_CHAIN_DEPTH = 32;
 
     // Applied once (first prepareWebClient wins). The tuned HttpClient is the single source the
@@ -539,19 +539,24 @@ public abstract class BaseApiClient {
      * {@code processRequest}'s catch-all and surface as a Spring-internal type, which is the exact
      * gap this branch exists to close, so the whole chain is walked.
      */
-    /**
-     * True for a Jackson {@link JsonProcessingException} — covering {@code MismatchedInputException},
-     * {@code InvalidTypeIdException}, {@code ValueInstantiationException} and
-     * {@code InvalidFormatException} — either bare or as the cause of another exception. Spring's
-     * {@code Jackson2JsonDecoder} wraps body-decode failures in {@code DecodingException}, so both forms
-     * have to match.
-     */
-    private static boolean isJsonTypeResolutionFailure(Throwable t) {
-        return t instanceof JsonProcessingException || t.getCause() instanceof JsonProcessingException;
-    }
-
     private static boolean isOversizedResponse(Throwable t) {
         return findInCauseChain(t, DataBufferLimitException.class) != null;
+    }
+
+    /**
+     * True when a Jackson {@link JsonProcessingException} appears anywhere in {@code t}'s cause chain —
+     * covering {@code MismatchedInputException}, {@code InvalidTypeIdException},
+     * {@code ValueInstantiationException} and {@code InvalidFormatException}, whatever wrapped them.
+     *
+     * <p>The whole chain is walked, not one level, because the wrapping is not always a single layer:
+     * {@code WebClient.retrieve()} can surface a {@code WebClientResponseException} around the
+     * {@code DecodingException} that Spring's {@code Jackson2JsonDecoder} raises around the Jackson
+     * failure. Missing that shape would be worse than a misclassification — it falls through to
+     * {@code processRequest}'s catch-all, which logs the exception's message, and a Jackson message
+     * quotes fragments of the connector's response body.
+     */
+    private static boolean isJsonTypeResolutionFailure(Throwable t) {
+        return findInCauseChain(t, JsonProcessingException.class) != null;
     }
 
     /**

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -509,6 +509,10 @@ public abstract class BaseApiClient {
      * breach can sit several levels deep; anything missed escapes to {@code processRequest}'s
      * catch-all and surfaces as a Spring-internal type.
      */
+    private static boolean isOversizedResponse(Throwable t) {
+        return findInCauseChain(t, DataBufferLimitException.class) != null;
+    }
+
     /**
      * The connector's location with anything secret stripped: scheme, host, port and path only, never
      * user-info and never the query string. Internal topology is fine in a server-side log and is what
@@ -544,10 +548,6 @@ public abstract class BaseApiClient {
         } catch (IllegalArgumentException e) {
             return "<unparseable url>";
         }
-    }
-
-    private static boolean isOversizedResponse(Throwable t) {
-        return findInCauseChain(t, DataBufferLimitException.class) != null;
     }
 
     /**

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -444,11 +444,11 @@ public abstract class BaseApiClient {
                 //
                 // The log carries the failure type, never the exception's message: Jackson's message
                 // quotes fragments of the response body, which for discovery can include key material.
-                logger.error("Connector {} response failed type resolution: {}",
-                        connector.getName(), unwrapped.getClass().getName());
+                logger.error("Connector {} response failed type resolution at {}: {}",
+                        connector.getName(), connector.getUrl(), unwrapped.getClass().getName());
                 ConnectorServerException typeFailure = new ConnectorServerException(
-                        "Connector %s returned a response that could not be parsed against the expected type. URL: %s"
-                                .formatted(connector.getName(), connector.getUrl()),
+                        "Connector %s returned a response that could not be parsed against the expected type"
+                                .formatted(connector.getName()),
                         unwrapped,
                         HttpStatus.BAD_GATEWAY);
                 typeFailure.setConnector(connector);
@@ -468,9 +468,10 @@ public abstract class BaseApiClient {
                 // connector fault, not a communication failure. Unmapped it would escape as
                 // WebClientResponseException or a bare DataBufferLimitException, which callers declaring
                 // `throws ConnectorException` cannot catch and which carries no connector attribution.
-                logger.error("Connector {} response exceeded the configured read limit: {}", connector.getName(), unwrapped.toString());
+                logger.error("Connector {} response exceeded the configured read limit at {}: {}",
+                        connector.getName(), connector.getUrl(), unwrapped.toString());
                 ConnectorServerException cse = new ConnectorServerException(
-                        "Connector %s response exceeded the configured read limit. URL: %s".formatted(connector.getName(), connector.getUrl()),
+                        "Connector %s response exceeded the configured read limit".formatted(connector.getName()),
                         unwrapped,
                         upstreamStatus(unwrapped));
                 cse.setConnector(connector);
@@ -616,7 +617,9 @@ public abstract class BaseApiClient {
      */
     private static Mono<ClientResponse> handleLegacyErrorResponse(ClientResponse clientResponse) {
         if (HttpStatus.UNPROCESSABLE_ENTITY.equals(clientResponse.statusCode())) {
-            return clientResponse.bodyToMono(ERROR_LIST_TYPE_REF).flatMap(body ->
+            return clientResponse.bodyToMono(ERROR_LIST_TYPE_REF)
+                    .defaultIfEmpty(List.of("Connector returned 422 with an empty body"))
+                    .flatMap(body ->
                     Mono.error(new ValidationException(body.stream()
                                     .map(ValidationError::create)
                                     .toList()
@@ -643,7 +646,29 @@ public abstract class BaseApiClient {
     }
 
     private static Mono<ClientResponse> handleProblemDetailResponse(ClientResponse clientResponse) {
+        HttpStatus status = HttpStatus.valueOf(clientResponse.statusCode().value());
         return clientResponse.bodyToMono(ProblemDetailExtended.class)
-                .flatMap(problemDetail -> Mono.error(new ConnectorProblemException(problemDetail)));
+                .<ClientResponse>flatMap(problemDetail -> Mono.error(new ConnectorProblemException(problemDetail)))
+                .switchIfEmpty(Mono.error(() -> emptyProblemBodyFailure(status)));
+    }
+
+    /**
+     * A response labelled {@code application/problem+json} whose body is empty cannot become a
+     * {@link ConnectorProblemException} — there is no {@code ErrorCode} to carry — so it maps by status
+     * alone, as {@link #handleLegacyErrorResponse} does. Without this it completed empty and the status
+     * vanished into an unmapped {@link IllegalStateException}.
+     *
+     * <p>Derived from the status rather than by re-reading the body: a {@link ClientResponse} body can
+     * be consumed only once, so delegating to the legacy handler here would fail on the second read.
+     */
+    private static ConnectorException emptyProblemBodyFailure(HttpStatus status) {
+        String message = "Connector returned %s with an empty application/problem+json body".formatted(status);
+        if (HttpStatus.NOT_FOUND.equals(status)) {
+            return new ConnectorEntityNotFoundException(message);
+        }
+        if (status.is4xxClientError()) {
+            return new ConnectorClientException(message, status);
+        }
+        return new ConnectorServerException(message, status);
     }
 }

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -461,8 +461,10 @@ public abstract class BaseApiClient {
                 // Connect, response, and pool-acquire failures. Netty timeouts aren't IOExceptions and
                 // the pool pending-limit is a plain RuntimeException, so match them explicitly. Log
                 // type+message; the full cause rides on the exception thrown below.
-                logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
-                throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
+                logger.error("Connector {} communication failure at {}: {}",
+                        connector.getName(), connector.getUrl(), unwrapped.toString());
+                throw new ConnectorCommunicationException(
+                        "Error in connector %s communication".formatted(connector.getName()), unwrapped, connector);
             } else if (isOversizedResponse(unwrapped)) {
                 // The codec's maxInMemorySize (ClientTuning) was exceeded while decoding the body — a
                 // connector fault, not a communication failure. Unmapped it would escape as

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -72,8 +72,7 @@ public abstract class BaseApiClient {
     private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
     private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
 
-    // Bound for the cause-chain walk in findInCauseChain. Chains are never this deep in practice.
-    // The cap exists so a cyclic chain cannot spin forever inside an exception handler.
+    // Bounds findInCauseChain so a cyclic cause chain cannot spin forever inside an exception handler.
     private static final int MAX_CAUSE_CHAIN_DEPTH = 32;
 
     // Applied once (first prepareWebClient wins). The tuned HttpClient is the single source the
@@ -334,9 +333,8 @@ public abstract class BaseApiClient {
         } else if (!appliedTuning.equals(tuning)) {
             logger.warn("Connector WebClient already tuned with {}; ignoring differing request {}", appliedTuning, tuning);
         }
-        // appliedTuning (the tuning that won), not the tuning passed to this call, so every knob —
-        // pool sizing and maxInMemorySize alike — stays consistent with the single baseHttpClient
-        // built above, even when a later, differently-tuned caller was warned-and-ignored.
+        // appliedTuning, not the argument: a warned-and-ignored caller must still receive a client
+        // whose knobs match the single live baseHttpClient.
         return buildWebClient(baseHttpClient, appliedTuning);
     }
 
@@ -400,29 +398,11 @@ public abstract class BaseApiClient {
      * would throw an opaque NPE. Surfacing a clear IllegalStateException at the call site makes
      * a misbehaving connector (no response) diagnosable instead of producing a bare NPE.
      *
-     * <p><b>Known discrepancy with the MQ clients, not resolvable here.</b> The MQ discovery client's
-     * equivalent guard throws {@code ConnectorException(message, connector)} — checked, so it travels
-     * the channel every client method already declares, and attributed to the connector that produced
-     * the failure. That is the better shape, and this method (with {@link #requireBody}) deliberately
-     * does not adopt it. The {@link IllegalStateException} thrown here is unchecked, so it escapes
-     * methods declaring {@code throws ConnectorException} and falls through
-     * {@link #processRequest}'s catch-all unmapped and unattributed to any connector.
-     *
-     * <p>Switching to a checked {@code ConnectorException} does not compile. Every call site of these
-     * two methods across this library — 14 in {@code v3.CertificateApiClient}, 9 in
-     * {@code discovery.v2.DiscoveryApiClient}, 5 in {@code v3.AuthorityApiClient}, 3 in
-     * {@code v2.AttributesApiClient} — sits inside the {@link Function} lambda handed to
-     * {@link #processRequest}, and {@code Function.apply} declares no checked exception, so each one
-     * fails with "unreported exception ... must be caught or declared to be thrown". Fixing that means
-     * changing {@code processRequest} to take a checked-exception-throwing functional interface, and
-     * {@code processRequest} is public API of the contract Core and every external connector compile
-     * against: an added overload would make every existing lambda call site ambiguous, and a replaced
-     * parameter type would break any caller that passes a {@code Function} value rather than a lambda.
-     * That is a deliberate, separately-planned contract change, not a cleanup to slip in here.
-     *
-     * <p>Until then a caller that must distinguish a bodiless response has to catch
-     * {@link IllegalStateException} alongside {@code ConnectorException}, and the connector's identity
-     * has to come from the call site rather than from the exception.
+     * <p>The {@link IllegalStateException} is unchecked, so it escapes methods declaring
+     * {@code throws ConnectorException} and is not attributed to a connector. A caller that must
+     * distinguish a bodiless response has to catch it alongside {@code ConnectorException}, and take
+     * the connector's identity from the call site. (The MQ discovery client's equivalent guard throws
+     * a checked, connector-attributed {@code ConnectorException} instead.)
      */
     protected static <T> ResponseEntity<T> requireResponse(Mono<ResponseEntity<T>> mono, String context) {
         ResponseEntity<T> entity = mono.block();
@@ -437,11 +417,6 @@ public abstract class BaseApiClient {
      * response must carry a payload (attribute lists, operation status, identify, CRL, CA certs).
      * An empty body on success is a connector contract violation; fail clearly rather than
      * returning null to the caller (which would NPE later, far from the cause).
-     *
-     * <p>Throws an unchecked, connector-less {@link IllegalStateException} where the MQ discovery
-     * client's counterpart throws a checked, connector-attributed {@code ConnectorException}. The
-     * discrepancy is known and stands for the reason set out on {@link #requireResponse}: the change
-     * cannot compile without first reworking {@link #processRequest}'s public functional interface.
      */
     protected static <T> T requireBody(Mono<ResponseEntity<T>> mono, String context) {
         ResponseEntity<T> entity = requireResponse(mono, context);
@@ -463,15 +438,12 @@ public abstract class BaseApiClient {
                 // Must precede the IOException branch: JsonProcessingException extends IOException, so a
                 // decode failure would otherwise be reported as a transport failure it is not.
                 //
-                // 502, not 422: the connector answered, and its answer does not conform to the contract —
-                // which is what Bad Gateway means. A 422 would be wrong twice over, because Core serves 422
-                // for a caller's own invalid input, so a connector fault would read as the user's mistake
-                // and the retry signal would invert. Checked, so callers declaring throws ConnectorException
-                // still catch it.
+                // 502, not 422: the connector answered and its answer does not conform. Core serves 422
+                // for a caller's own invalid input, so 422 here would blame the user and invert the
+                // retry signal.
                 //
-                // The log carries the failure type and the connector, never the exception's message:
-                // Jackson's message quotes fragments of the response body, which for discovery can include
-                // key material. The full cause rides on the thrown exception for diagnostics.
+                // The log carries the failure type, never the exception's message: Jackson's message
+                // quotes fragments of the response body, which for discovery can include key material.
                 logger.error("Connector {} response failed type resolution: {}",
                         connector.getName(), unwrapped.getClass().getName());
                 ConnectorServerException typeFailure = new ConnectorServerException(
@@ -492,12 +464,10 @@ public abstract class BaseApiClient {
                 logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
             } else if (isOversizedResponse(unwrapped)) {
-                // The response existed (2xx or otherwise) but the codec's maxInMemorySize (ClientTuning)
-                // was exceeded while decoding its body — a connector fault (oversized/malicious page),
-                // not a communication failure. Unmapped, this would escape as WebClientResponseException
-                // (or a bare DataBufferLimitException), which callers declaring `throws ConnectorException`
-                // cannot catch, which never gets attributed to a connector via setConnector, and whose
-                // full stack a hostile connector could repeatedly trigger at ERROR level.
+                // The codec's maxInMemorySize (ClientTuning) was exceeded while decoding the body — a
+                // connector fault, not a communication failure. Unmapped it would escape as
+                // WebClientResponseException or a bare DataBufferLimitException, which callers declaring
+                // `throws ConnectorException` cannot catch and which carries no connector attribution.
                 logger.error("Connector {} response exceeded the configured read limit: {}", connector.getName(), unwrapped.toString());
                 ConnectorServerException cse = new ConnectorServerException(
                         "Connector %s response exceeded the configured read limit. URL: %s".formatted(connector.getName(), connector.getUrl()),
@@ -529,15 +499,11 @@ public abstract class BaseApiClient {
      * True when a {@link DataBufferLimitException} appears anywhere in {@code t}'s cause chain — a
      * codec {@code maxInMemorySize} breach, whatever wrapped it.
      *
-     * <p>{@code WebClient.retrieve()} wraps a body-decode failure into a
-     * {@link WebClientResponseException} so the failure still carries the response's status and
-     * headers, and the bare form reaches here when some other codepath surfaces it unwrapped — but
-     * those are not the only two shapes. Spring's {@code Jackson2JsonDecoder} raises a
-     * {@code DecodingException} around a decode failure as well (the reason
-     * {@link #isJsonTypeResolutionFailure} has to look one level down), so a breach can sit two or
-     * more levels deep. Matching only the bare form and one level of wrapping let those escape to
-     * {@code processRequest}'s catch-all and surface as a Spring-internal type, which is the exact
-     * gap this branch exists to close, so the whole chain is walked.
+     * <p>The whole chain is walked, not one or two levels. {@code WebClient.retrieve()} wraps a
+     * body-decode failure into a {@link WebClientResponseException}, and Spring's
+     * {@code Jackson2JsonDecoder} raises a {@code DecodingException} around a decode failure, so a
+     * breach can sit several levels deep; anything missed escapes to {@code processRequest}'s
+     * catch-all and surfaces as a Spring-internal type.
      */
     private static boolean isOversizedResponse(Throwable t) {
         return findInCauseChain(t, DataBufferLimitException.class) != null;
@@ -548,10 +514,10 @@ public abstract class BaseApiClient {
      * covering {@code MismatchedInputException}, {@code InvalidTypeIdException},
      * {@code ValueInstantiationException} and {@code InvalidFormatException}, whatever wrapped them.
      *
-     * <p>The whole chain is walked, not one level, because the wrapping is not always a single layer:
+     * <p>The whole chain is walked because the wrapping is not a single layer:
      * {@code WebClient.retrieve()} can surface a {@code WebClientResponseException} around the
      * {@code DecodingException} that Spring's {@code Jackson2JsonDecoder} raises around the Jackson
-     * failure. Missing that shape would be worse than a misclassification — it falls through to
+     * failure. Missing that shape is worse than a misclassification — it falls through to
      * {@code processRequest}'s catch-all, which logs the exception's message, and a Jackson message
      * quotes fragments of the connector's response body.
      */
@@ -561,19 +527,16 @@ public abstract class BaseApiClient {
 
     /**
      * The status the connector actually answered with, for a failure raised while decoding its
-     * response. Core's {@code ExceptionHandlingAdvice} renders this verbatim as an "Original response
-     * code ..." suffix on the operator-facing error, so it must not be invented: a read-limit breach
-     * is typically hit on a {@code 200}, and reporting {@code 413 PAYLOAD_TOO_LARGE} there would
-     * assert an upstream status that never existed and point operators at a request-size problem
-     * rather than at this client's own read cap — which the exception message already names, so
-     * carrying the real status loses nothing.
+     * response. It must not be invented: Core's {@code ExceptionHandlingAdvice} renders it verbatim
+     * as an "Original response code ..." suffix on the operator-facing error, and a read-limit breach
+     * is typically hit on a {@code 200}, so a synthesized {@code 413 PAYLOAD_TOO_LARGE} would assert
+     * a status that never existed and point operators at a request-size problem rather than at this
+     * client's own read cap.
      *
-     * <p>{@code WebClient.retrieve()} wraps a body-decode failure into a
-     * {@link WebClientResponseException} precisely so the response's status survives, which is where
-     * the real status comes from. {@link HttpStatus#BAD_GATEWAY} is the fallback when no such wrapper
-     * is in the chain (a bare codec failure carries no status) or when the connector answered a
-     * non-standard code {@link HttpStatus} cannot represent: the response was unusable and the
-     * connector is upstream of us, which is what 502 says.
+     * <p>The real status comes from the {@link WebClientResponseException} that
+     * {@code WebClient.retrieve()} wraps a body-decode failure into. {@link HttpStatus#BAD_GATEWAY}
+     * is the fallback when no such wrapper is in the chain (a bare codec failure carries no status)
+     * or when the connector answered a code {@link HttpStatus} cannot represent.
      */
     private static HttpStatus upstreamStatus(Throwable t) {
         WebClientResponseException responseException = findInCauseChain(t, WebClientResponseException.class);
@@ -587,10 +550,8 @@ public abstract class BaseApiClient {
      * The first throwable of the given type in {@code t}'s cause chain, {@code t} itself included, or
      * {@code null} when there is none.
      *
-     * <p>The walk is deliberately bounded. Every caller runs inside an exception handler, where an
-     * infinite loop on a cyclic cause chain would be a far worse failure than the misclassification
-     * the walk prevents — so {@link #MAX_CAUSE_CHAIN_DEPTH} caps a cycle of any length, and the
-     * self-cause check short-circuits the common one-node case.
+     * <p>{@link #MAX_CAUSE_CHAIN_DEPTH} caps a cycle of any length; the self-cause check
+     * short-circuits the common one-node case.
      */
     private static <E extends Throwable> E findInCauseChain(Throwable t, Class<E> type) {
         Throwable current = t;
@@ -631,8 +592,7 @@ public abstract class BaseApiClient {
         }
         if (contentType.contains(MediaType.TEXT_HTML_VALUE)) {
             // defaultIfEmpty for the same reason as the legacy branches below: bodyToMono completes
-            // empty for a zero-length body, so without it flatMap never runs and the failure escapes
-            // unmapped as an IllegalStateException.
+            // empty for a zero-length body, so flatMap never runs and the failure escapes unmapped.
             return clientResponse.bodyToMono(String.class)
                     .defaultIfEmpty("")
                     .flatMap(body -> Mono.error(new ConnectorCommunicationException("Received response with unexpected content type '%s'.".formatted(contentType), null)));
@@ -646,16 +606,13 @@ public abstract class BaseApiClient {
      * Map a non-2xx response with no {@code application/problem+json} body onto the connector
      * exception its status means.
      *
-     * <p>Each branch below reads the body as a {@code String} for the exception message and needs
+     * <p>Each branch reads the body as a {@code String} for the exception message and needs
      * {@code defaultIfEmpty} to do it: {@code bodyToMono(String.class)} completes <em>empty</em> for a
      * zero-length body, and an empty source never runs {@code flatMap}, so without the default the
-     * whole filter completes empty and no exception is ever raised. The error status then vanishes —
-     * {@code requireResponse}/{@code requireBody} see a null entity and throw
-     * {@link IllegalStateException}, which {@code processRequest} rethrows unmapped, past every
-     * caller that catches {@code ConnectorException} and past the discovery client's {@code cancel}
-     * not-tracked handling. A bodiless error status is an ordinary shape, not a curiosity: a Go
-     * connector's {@code w.WriteHeader(404)} sends no body at all, and discovery's {@code cancel} is
-     * declared bodiless even on success.
+     * filter completes empty and no exception is raised — the status then vanishes into an unmapped
+     * {@link IllegalStateException}. Bodiless error statuses are ordinary: a Go connector's
+     * {@code w.WriteHeader(404)} sends no body, and discovery's {@code cancel} is declared bodiless
+     * even on success.
      */
     private static Mono<ClientResponse> handleLegacyErrorResponse(ClientResponse clientResponse) {
         if (HttpStatus.UNPROCESSABLE_ENTITY.equals(clientResponse.statusCode())) {

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -33,6 +33,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -445,7 +446,7 @@ public abstract class BaseApiClient {
                 // The log carries the failure type, never the exception's message: Jackson's message
                 // quotes fragments of the response body, which for discovery can include key material.
                 logger.error("Connector {} response failed type resolution at {}: {}",
-                        connector.getName(), connector.getUrl(), unwrapped.getClass().getName());
+                        connector.getName(), safeLocation(connector), unwrapped.getClass().getName());
                 ConnectorServerException typeFailure = new ConnectorServerException(
                         "Connector %s returned a response that could not be parsed against the expected type"
                                 .formatted(connector.getName()),
@@ -462,7 +463,7 @@ public abstract class BaseApiClient {
                 // the pool pending-limit is a plain RuntimeException, so match them explicitly. Log
                 // type+message; the full cause rides on the exception thrown below.
                 logger.error("Connector {} communication failure at {}: {}",
-                        connector.getName(), connector.getUrl(), unwrapped.toString());
+                        connector.getName(), safeLocation(connector), unwrapped.toString());
                 throw new ConnectorCommunicationException(
                         "Error in connector %s communication".formatted(connector.getName()), unwrapped, connector);
             } else if (isOversizedResponse(unwrapped)) {
@@ -471,7 +472,7 @@ public abstract class BaseApiClient {
                 // WebClientResponseException or a bare DataBufferLimitException, which callers declaring
                 // `throws ConnectorException` cannot catch and which carries no connector attribution.
                 logger.error("Connector {} response exceeded the configured read limit at {}: {}",
-                        connector.getName(), connector.getUrl(), unwrapped.toString());
+                        connector.getName(), safeLocation(connector), unwrapped.toString());
                 ConnectorServerException cse = new ConnectorServerException(
                         "Connector %s response exceeded the configured read limit".formatted(connector.getName()),
                         unwrapped,
@@ -508,6 +509,43 @@ public abstract class BaseApiClient {
      * breach can sit several levels deep; anything missed escapes to {@code processRequest}'s
      * catch-all and surfaces as a Spring-internal type.
      */
+    /**
+     * The connector's location with anything secret stripped: scheme, host, port and path only, never
+     * user-info and never the query string. Internal topology is fine in a server-side log and is what
+     * an operator needs to place a failure; a credential is not, and a log outlives the request that
+     * wrote it. Nothing stops a configured connector URL carrying {@code user:password@} or a token in
+     * a query parameter, so this never trusts the raw value.
+     *
+     * <p>Package-private so it can be tested directly — the log line itself is not assertable, because
+     * slf4j-simple binds its stream at initialization.
+     */
+    static String safeLocation(ApiClientConnectorInfo connector) {
+        String raw = connector.getUrl();
+        if (raw == null) {
+            return "<no url>";
+        }
+        try {
+            URI uri = URI.create(raw);
+            if (uri.getHost() == null) {
+                return "<unparseable url>";
+            }
+            StringBuilder location = new StringBuilder();
+            if (uri.getScheme() != null) {
+                location.append(uri.getScheme()).append("://");
+            }
+            location.append(uri.getHost());
+            if (uri.getPort() != -1) {
+                location.append(':').append(uri.getPort());
+            }
+            if (uri.getPath() != null) {
+                location.append(uri.getPath());
+            }
+            return location.toString();
+        } catch (IllegalArgumentException e) {
+            return "<unparseable url>";
+        }
+    }
+
     private static boolean isOversizedResponse(Throwable t) {
         return findInCauseChain(t, DataBufferLimitException.class) != null;
     }

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -1,6 +1,7 @@
 package com.otilm.api.clients;
 
 import com.otilm.api.exception.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.otilm.api.model.client.attribute.ResponseAttribute;
 import com.otilm.api.model.common.attribute.v2.content.FileAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.SecretAttributeContentV2;
@@ -458,6 +459,28 @@ public abstract class BaseApiClient {
             if (unwrapped instanceof ConnectorProblemException pde) {
                 pde.setConnector(connector);
                 throw pde;
+            } else if (isJsonTypeResolutionFailure(unwrapped)) {
+                // Must precede the IOException branch: JsonProcessingException extends IOException, so a
+                // decode failure would otherwise be reported as a transport failure it is not.
+                //
+                // 502, not 422: the connector answered, and its answer does not conform to the contract —
+                // which is what Bad Gateway means. A 422 would be wrong twice over, because Core serves 422
+                // for a caller's own invalid input, so a connector fault would read as the user's mistake
+                // and the retry signal would invert. Checked, so callers declaring throws ConnectorException
+                // still catch it.
+                //
+                // The log carries the failure type and the connector, never the exception's message:
+                // Jackson's message quotes fragments of the response body, which for discovery can include
+                // key material. The full cause rides on the thrown exception for diagnostics.
+                logger.error("Connector {} response failed type resolution: {}",
+                        connector.getName(), unwrapped.getClass().getName());
+                ConnectorServerException typeFailure = new ConnectorServerException(
+                        "Connector %s returned a response that could not be parsed against the expected type. URL: %s"
+                                .formatted(connector.getName(), connector.getUrl()),
+                        unwrapped,
+                        HttpStatus.BAD_GATEWAY);
+                typeFailure.setConnector(connector);
+                throw typeFailure;
             } else if (unwrapped instanceof IOException
                     || unwrapped instanceof WebClientRequestException
                     || unwrapped instanceof io.netty.handler.timeout.TimeoutException
@@ -516,6 +539,17 @@ public abstract class BaseApiClient {
      * {@code processRequest}'s catch-all and surface as a Spring-internal type, which is the exact
      * gap this branch exists to close, so the whole chain is walked.
      */
+    /**
+     * True for a Jackson {@link JsonProcessingException} — covering {@code MismatchedInputException},
+     * {@code InvalidTypeIdException}, {@code ValueInstantiationException} and
+     * {@code InvalidFormatException} — either bare or as the cause of another exception. Spring's
+     * {@code Jackson2JsonDecoder} wraps body-decode failures in {@code DecodingException}, so both forms
+     * have to match.
+     */
+    private static boolean isJsonTypeResolutionFailure(Throwable t) {
+        return t instanceof JsonProcessingException || t.getCause() instanceof JsonProcessingException;
+    }
+
     private static boolean isOversizedResponse(Throwable t) {
         return findInCauseChain(t, DataBufferLimitException.class) != null;
     }

--- a/src/main/java/com/otilm/api/clients/BaseApiClient.java
+++ b/src/main/java/com/otilm/api/clients/BaseApiClient.java
@@ -15,6 +15,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -62,8 +63,6 @@ public abstract class BaseApiClient {
     public static final String ATTRIBUTE_API_KEY_HEADER = "apiKeyHeader";
     public static final String ATTRIBUTE_API_KEY = "apiKey";
 
-    private static final int CODEC_MAX_IN_MEMORY = 16 * 1024 * 1024;
-
     // Pool hygiene (not deployment-specific): evict idle and age-cap connections so a server-closed
     // keep-alive is not reused (PrematureCloseException).
     private static final Duration POOL_MAX_IDLE = Duration.ofSeconds(30);
@@ -71,6 +70,10 @@ public abstract class BaseApiClient {
     private static final Duration POOL_EVICT_INTERVAL = Duration.ofSeconds(30);
     private static final Duration POOL_DISPOSE_INTERVAL = Duration.ofSeconds(120);
     private static final Duration POOL_DISPOSE_AFTER = Duration.ofSeconds(300);
+
+    // Bound for the cause-chain walk in findInCauseChain. Chains this deep do not occur in practice;
+    // the cap is there so a cyclic chain cannot spin forever inside an exception handler.
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 32;
 
     // Applied once (first prepareWebClient wins). The tuned HttpClient is the single source the
     // CERTIFICATE path derives from, built lazily so a tuned deployment never leaves an orphaned
@@ -330,7 +333,10 @@ public abstract class BaseApiClient {
         } else if (!appliedTuning.equals(tuning)) {
             logger.warn("Connector WebClient already tuned with {}; ignoring differing request {}", appliedTuning, tuning);
         }
-        return buildWebClient(baseHttpClient);
+        // appliedTuning (the tuning that won), not the tuning passed to this call, so every knob —
+        // pool sizing and maxInMemorySize alike — stays consistent with the single baseHttpClient
+        // built above, even when a later, differently-tuned caller was warned-and-ignored.
+        return buildWebClient(baseHttpClient, appliedTuning);
     }
 
     /** Lazily initialize with defaults if a client is used before any prepareWebClient call. */
@@ -362,9 +368,9 @@ public abstract class BaseApiClient {
                 .responseTimeout(tuning.responseTimeout());
     }
 
-    private static WebClient buildWebClient(HttpClient httpClient) {
+    private static WebClient buildWebClient(HttpClient httpClient, ClientTuning tuning) {
         ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(CODEC_MAX_IN_MEMORY))
+                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(tuning.maxInMemorySize()))
                 .build();
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
@@ -392,6 +398,30 @@ public abstract class BaseApiClient {
      * {@code Mono.block()} returns null when the publisher completes empty; dereferencing that
      * would throw an opaque NPE. Surfacing a clear IllegalStateException at the call site makes
      * a misbehaving connector (no response) diagnosable instead of producing a bare NPE.
+     *
+     * <p><b>Known discrepancy with the MQ clients, not resolvable here.</b> The MQ discovery client's
+     * equivalent guard throws {@code ConnectorException(message, connector)} — checked, so it travels
+     * the channel every client method already declares, and attributed to the connector that produced
+     * the failure. That is the better shape, and this method (with {@link #requireBody}) deliberately
+     * does not adopt it. The {@link IllegalStateException} thrown here is unchecked, so it escapes
+     * methods declaring {@code throws ConnectorException} and falls through
+     * {@link #processRequest}'s catch-all unmapped and unattributed to any connector.
+     *
+     * <p>Switching to a checked {@code ConnectorException} does not compile. Every call site of these
+     * two methods across this library — 14 in {@code v3.CertificateApiClient}, 9 in
+     * {@code discovery.v2.DiscoveryApiClient}, 5 in {@code v3.AuthorityApiClient}, 3 in
+     * {@code v2.AttributesApiClient} — sits inside the {@link Function} lambda handed to
+     * {@link #processRequest}, and {@code Function.apply} declares no checked exception, so each one
+     * fails with "unreported exception ... must be caught or declared to be thrown". Fixing that means
+     * changing {@code processRequest} to take a checked-exception-throwing functional interface, and
+     * {@code processRequest} is public API of the contract Core and every external connector compile
+     * against: an added overload would make every existing lambda call site ambiguous, and a replaced
+     * parameter type would break any caller that passes a {@code Function} value rather than a lambda.
+     * That is a deliberate, separately-planned contract change, not a cleanup to slip in here.
+     *
+     * <p>Until then a caller that must distinguish a bodiless response has to catch
+     * {@link IllegalStateException} alongside {@code ConnectorException}, and the connector's identity
+     * has to come from the call site rather than from the exception.
      */
     protected static <T> ResponseEntity<T> requireResponse(Mono<ResponseEntity<T>> mono, String context) {
         ResponseEntity<T> entity = mono.block();
@@ -406,6 +436,11 @@ public abstract class BaseApiClient {
      * response must carry a payload (attribute lists, operation status, identify, CRL, CA certs).
      * An empty body on success is a connector contract violation; fail clearly rather than
      * returning null to the caller (which would NPE later, far from the cause).
+     *
+     * <p>Throws an unchecked, connector-less {@link IllegalStateException} where the MQ discovery
+     * client's counterpart throws a checked, connector-attributed {@code ConnectorException}. The
+     * discrepancy is known and stands for the reason set out on {@link #requireResponse}: the change
+     * cannot compile without first reworking {@link #processRequest}'s public functional interface.
      */
     protected static <T> T requireBody(Mono<ResponseEntity<T>> mono, String context) {
         ResponseEntity<T> entity = requireResponse(mono, context);
@@ -433,6 +468,20 @@ public abstract class BaseApiClient {
                 // type+message; the full cause rides on the exception thrown below.
                 logger.error("Connector {} communication failure: {}", connector.getName(), unwrapped.toString());
                 throw new ConnectorCommunicationException("Error in connector %s communication. URL: %s".formatted(connector.getName(), connector.getUrl()), unwrapped, connector);
+            } else if (isOversizedResponse(unwrapped)) {
+                // The response existed (2xx or otherwise) but the codec's maxInMemorySize (ClientTuning)
+                // was exceeded while decoding its body — a connector fault (oversized/malicious page),
+                // not a communication failure. Unmapped, this would escape as WebClientResponseException
+                // (or a bare DataBufferLimitException), which callers declaring `throws ConnectorException`
+                // cannot catch, which never gets attributed to a connector via setConnector, and whose
+                // full stack a hostile connector could repeatedly trigger at ERROR level.
+                logger.error("Connector {} response exceeded the configured read limit: {}", connector.getName(), unwrapped.toString());
+                ConnectorServerException cse = new ConnectorServerException(
+                        "Connector %s response exceeded the configured read limit. URL: %s".formatted(connector.getName(), connector.getUrl()),
+                        unwrapped,
+                        upstreamStatus(unwrapped));
+                cse.setConnector(connector);
+                throw cse;
             } else if (unwrapped instanceof ConnectorException ce) {
                 ce.setConnector(connector);
                 throw ce;
@@ -451,6 +500,71 @@ public abstract class BaseApiClient {
                 throw e;
             }
         }
+    }
+
+    /**
+     * True when a {@link DataBufferLimitException} appears anywhere in {@code t}'s cause chain — a
+     * codec {@code maxInMemorySize} breach, whatever wrapped it.
+     *
+     * <p>{@code WebClient.retrieve()} wraps a body-decode failure into a
+     * {@link WebClientResponseException} so the failure still carries the response's status and
+     * headers, and the bare form reaches here when some other codepath surfaces it unwrapped — but
+     * those are not the only two shapes. Spring's {@code Jackson2JsonDecoder} raises a
+     * {@code DecodingException} around a decode failure as well (the reason
+     * {@link #isJsonTypeResolutionFailure} has to look one level down), so a breach can sit two or
+     * more levels deep. Matching only the bare form and one level of wrapping let those escape to
+     * {@code processRequest}'s catch-all and surface as a Spring-internal type, which is the exact
+     * gap this branch exists to close, so the whole chain is walked.
+     */
+    private static boolean isOversizedResponse(Throwable t) {
+        return findInCauseChain(t, DataBufferLimitException.class) != null;
+    }
+
+    /**
+     * The status the connector actually answered with, for a failure raised while decoding its
+     * response. Core's {@code ExceptionHandlingAdvice} renders this verbatim as an "Original response
+     * code ..." suffix on the operator-facing error, so it must not be invented: a read-limit breach
+     * is typically hit on a {@code 200}, and reporting {@code 413 PAYLOAD_TOO_LARGE} there would
+     * assert an upstream status that never existed and point operators at a request-size problem
+     * rather than at this client's own read cap — which the exception message already names, so
+     * carrying the real status loses nothing.
+     *
+     * <p>{@code WebClient.retrieve()} wraps a body-decode failure into a
+     * {@link WebClientResponseException} precisely so the response's status survives, which is where
+     * the real status comes from. {@link HttpStatus#BAD_GATEWAY} is the fallback when no such wrapper
+     * is in the chain (a bare codec failure carries no status) or when the connector answered a
+     * non-standard code {@link HttpStatus} cannot represent: the response was unusable and the
+     * connector is upstream of us, which is what 502 says.
+     */
+    private static HttpStatus upstreamStatus(Throwable t) {
+        WebClientResponseException responseException = findInCauseChain(t, WebClientResponseException.class);
+        HttpStatus resolved = responseException == null
+                ? null
+                : HttpStatus.resolve(responseException.getStatusCode().value());
+        return resolved != null ? resolved : HttpStatus.BAD_GATEWAY;
+    }
+
+    /**
+     * The first throwable of the given type in {@code t}'s cause chain, {@code t} itself included, or
+     * {@code null} when there is none.
+     *
+     * <p>The walk is deliberately bounded. Every caller runs inside an exception handler, where an
+     * infinite loop on a cyclic cause chain would be a far worse failure than the misclassification
+     * the walk prevents — so {@link #MAX_CAUSE_CHAIN_DEPTH} caps a cycle of any length, and the
+     * self-cause check short-circuits the common one-node case.
+     */
+    private static <E extends Throwable> E findInCauseChain(Throwable t, Class<E> type) {
+        Throwable current = t;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++) {
+            if (type.isInstance(current)) {
+                return type.cast(current);
+            }
+            if (current == current.getCause()) {
+                return null;
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     /**
@@ -477,8 +591,11 @@ public abstract class BaseApiClient {
             return handleProblemDetailResponse(clientResponse);
         }
         if (contentType.contains(MediaType.TEXT_HTML_VALUE)) {
-            // Attempt to parse legacy error format
+            // defaultIfEmpty for the same reason as the legacy branches below: bodyToMono completes
+            // empty for a zero-length body, so without it flatMap never runs and the failure escapes
+            // unmapped as an IllegalStateException.
             return clientResponse.bodyToMono(String.class)
+                    .defaultIfEmpty("")
                     .flatMap(body -> Mono.error(new ConnectorCommunicationException("Received response with unexpected content type '%s'.".formatted(contentType), null)));
         }
 
@@ -486,6 +603,21 @@ public abstract class BaseApiClient {
         return handleLegacyErrorResponse(clientResponse);
     }
 
+    /**
+     * Map a non-2xx response with no {@code application/problem+json} body onto the connector
+     * exception its status means.
+     *
+     * <p>Each branch below reads the body as a {@code String} for the exception message and needs
+     * {@code defaultIfEmpty} to do it: {@code bodyToMono(String.class)} completes <em>empty</em> for a
+     * zero-length body, and an empty source never runs {@code flatMap}, so without the default the
+     * whole filter completes empty and no exception is ever raised. The error status then vanishes —
+     * {@code requireResponse}/{@code requireBody} see a null entity and throw
+     * {@link IllegalStateException}, which {@code processRequest} rethrows unmapped, past every
+     * caller that catches {@code ConnectorException} and past the discovery client's {@code cancel}
+     * not-tracked handling. A bodiless error status is an ordinary shape, not a curiosity: a Go
+     * connector's {@code w.WriteHeader(404)} sends no body at all, and discovery's {@code cancel} is
+     * declared bodiless even on success.
+     */
     private static Mono<ClientResponse> handleLegacyErrorResponse(ClientResponse clientResponse) {
         if (HttpStatus.UNPROCESSABLE_ENTITY.equals(clientResponse.statusCode())) {
             return clientResponse.bodyToMono(ERROR_LIST_TYPE_REF).flatMap(body ->
@@ -498,14 +630,17 @@ public abstract class BaseApiClient {
         }
         if (HttpStatus.NOT_FOUND.equals(clientResponse.statusCode())) {
             return clientResponse.bodyToMono(String.class)
+                    .defaultIfEmpty("")
                     .flatMap(body -> Mono.error(new ConnectorEntityNotFoundException(body)));
         }
         if (clientResponse.statusCode().is4xxClientError()) {
             return clientResponse.bodyToMono(String.class)
+                    .defaultIfEmpty("")
                     .flatMap(body -> Mono.error(new ConnectorClientException(body, HttpStatus.valueOf(clientResponse.statusCode().value()))));
         }
         if (clientResponse.statusCode().is5xxServerError()) {
             return clientResponse.bodyToMono(String.class)
+                    .defaultIfEmpty("")
                     .flatMap(body -> Mono.error(new ConnectorServerException(body, HttpStatus.valueOf(clientResponse.statusCode().value()))));
         }
         return Mono.just(clientResponse);

--- a/src/main/java/com/otilm/api/clients/ClientTuning.java
+++ b/src/main/java/com/otilm/api/clients/ClientTuning.java
@@ -10,43 +10,18 @@ import java.time.Duration;
  * not deployment-specific. Deployment code supplies these values from configuration;
  * {@link #defaults()} backs tests and any caller that does not tune.
  *
- * <p><b>Which of these a deployment can actually set, as of this writing.</b> The four timeout/pool
- * components only. Core binds {@code connector.api-client.*} into its
- * {@code ConnectorApiClientProperties} record — {@code connectTimeout}, {@code responseTimeout},
- * {@code maxConnections}, {@code pendingAcquireTimeout}, nothing else — and its
- * {@code ApplicationConfig.webClient} bean passes exactly those to the four-argument constructor
- * below. There is no {@code connector.api-client.max-in-memory-size} property, no
- * {@code CONNECTOR_API_CLIENT_MAX_IN_MEMORY_SIZE} environment variable, and no helm value for it, so
- * <em>{@code maxInMemorySize} is not settable by any deployment surface</em>: every deployment runs
- * on {@link #DEFAULT_MAX_IN_MEMORY} whatever its configuration says. The sentence above about
- * deployment code supplying these values from configuration therefore does not hold for this one
- * component. Exposing it means adding the property, the env var and the helm value together with a
- * fifth argument at that call site.
- *
- * <p><b>The "keep the two in sync" claim on core's side is currently false.</b>
- * {@code ConnectorApiClientProperties}' javadoc states that its {@code application.yml} defaults
- * mirror {@link #defaults()} and that the two must be kept in sync. They cannot mirror each other any
- * more: this record has five components and that one has four, so the mirror only covers the four
- * they share, and {@code maxInMemorySize} has no counterpart to stay in sync with. Read the claim as
- * applying to the four timeout/pool values alone until core's record grows the fifth.
+ * <p>{@code maxInMemorySize} is not yet settable by any deployment surface, tracked in core#1961.
  *
  * <p>{@code maxConnections} is <em>per remote host</em> (Reactor-Netty pools per destination), not a
  * global cap, so it is sized against the per-connector concurrent load rather than a single queue's
  * listener concurrency.
  *
  * <p>{@code maxInMemorySize} bounds how many bytes of a single response {@link BaseApiClient} will
- * buffer while decoding it (Spring's codec {@code maxInMemorySize}) — shared by every client built
- * on the WebClient this tuning produces, so one setting protects all of them against an oversized or
- * malicious connector response (a connector like discovery's {@code results}/drain page is the
- * motivating case, but the bound is not endpoint-specific). A response exceeding it fails the call
- * rather than buffering without limit; {@link BaseApiClient#processRequest} maps that failure to
+ * buffer while decoding it (Spring's codec {@code maxInMemorySize}). It is shared by every client
+ * built on the WebClient this tuning produces, so one setting bounds all of them. A response
+ * exceeding it fails the call rather than buffering without limit;
+ * {@link BaseApiClient#processRequest} maps that failure to
  * {@link com.otilm.api.exception.ConnectorServerException}.
- *
- * <p>The four-argument constructor below is a source-compatible overload for callers built against
- * the version of this record before {@code maxInMemorySize} existed — it applies
- * {@link #DEFAULT_MAX_IN_MEMORY}. A shared-library addition to a public record should not force a
- * simultaneous edit in every consuming repository; callers who care about the response bound
- * should construct with the canonical five-argument constructor (or {@link #defaults()}) instead.
  */
 public record ClientTuning(
         Duration connectTimeout,
@@ -55,9 +30,10 @@ public record ClientTuning(
         Duration pendingAcquireTimeout,
         int maxInMemorySize) {
 
-    /** 16 MiB: generous for attribute/status/CRL payloads, bounded against an oversized or malicious
-     * connector response. The single source of the default in-memory response cap — used by both
-     * {@link #defaults()} and the four-argument convenience constructor. */
+    /**
+     * 16 MiB: generous for attribute/status/CRL payloads, bounded against an oversized or malicious
+     * connector response.
+     */
     private static final int DEFAULT_MAX_IN_MEMORY = 16 * 1024 * 1024;
 
     public ClientTuning {
@@ -74,9 +50,7 @@ public record ClientTuning(
 
     /**
      * Source-compatible overload for callers compiled against this record before
-     * {@code maxInMemorySize} was added — applies {@link #DEFAULT_MAX_IN_MEMORY}. Do not remove:
-     * a shared-library record gaining a component must not force every consuming repository to
-     * change its constructor call in lockstep with the library bump.
+     * {@code maxInMemorySize} was added; applies {@link #DEFAULT_MAX_IN_MEMORY}.
      */
     public ClientTuning(Duration connectTimeout, Duration responseTimeout, int maxConnections, Duration pendingAcquireTimeout) {
         this(connectTimeout, responseTimeout, maxConnections, pendingAcquireTimeout, DEFAULT_MAX_IN_MEMORY);

--- a/src/main/java/com/otilm/api/clients/ClientTuning.java
+++ b/src/main/java/com/otilm/api/clients/ClientTuning.java
@@ -10,15 +10,55 @@ import java.time.Duration;
  * not deployment-specific. Deployment code supplies these values from configuration;
  * {@link #defaults()} backs tests and any caller that does not tune.
  *
+ * <p><b>Which of these a deployment can actually set, as of this writing.</b> The four timeout/pool
+ * components only. Core binds {@code connector.api-client.*} into its
+ * {@code ConnectorApiClientProperties} record — {@code connectTimeout}, {@code responseTimeout},
+ * {@code maxConnections}, {@code pendingAcquireTimeout}, nothing else — and its
+ * {@code ApplicationConfig.webClient} bean passes exactly those to the four-argument constructor
+ * below. There is no {@code connector.api-client.max-in-memory-size} property, no
+ * {@code CONNECTOR_API_CLIENT_MAX_IN_MEMORY_SIZE} environment variable, and no helm value for it, so
+ * <em>{@code maxInMemorySize} is not settable by any deployment surface</em>: every deployment runs
+ * on {@link #DEFAULT_MAX_IN_MEMORY} whatever its configuration says. The sentence above about
+ * deployment code supplying these values from configuration therefore does not hold for this one
+ * component. Exposing it means adding the property, the env var and the helm value together with a
+ * fifth argument at that call site.
+ *
+ * <p><b>The "keep the two in sync" claim on core's side is currently false.</b>
+ * {@code ConnectorApiClientProperties}' javadoc states that its {@code application.yml} defaults
+ * mirror {@link #defaults()} and that the two must be kept in sync. They cannot mirror each other any
+ * more: this record has five components and that one has four, so the mirror only covers the four
+ * they share, and {@code maxInMemorySize} has no counterpart to stay in sync with. Read the claim as
+ * applying to the four timeout/pool values alone until core's record grows the fifth.
+ *
  * <p>{@code maxConnections} is <em>per remote host</em> (Reactor-Netty pools per destination), not a
  * global cap, so it is sized against the per-connector concurrent load rather than a single queue's
  * listener concurrency.
+ *
+ * <p>{@code maxInMemorySize} bounds how many bytes of a single response {@link BaseApiClient} will
+ * buffer while decoding it (Spring's codec {@code maxInMemorySize}) — shared by every client built
+ * on the WebClient this tuning produces, so one setting protects all of them against an oversized or
+ * malicious connector response (a connector like discovery's {@code results}/drain page is the
+ * motivating case, but the bound is not endpoint-specific). A response exceeding it fails the call
+ * rather than buffering without limit; {@link BaseApiClient#processRequest} maps that failure to
+ * {@link com.otilm.api.exception.ConnectorServerException}.
+ *
+ * <p>The four-argument constructor below is a source-compatible overload for callers built against
+ * the version of this record before {@code maxInMemorySize} existed — it applies
+ * {@link #DEFAULT_MAX_IN_MEMORY}. A shared-library addition to a public record should not force a
+ * simultaneous edit in every consuming repository; callers who care about the response bound
+ * should construct with the canonical five-argument constructor (or {@link #defaults()}) instead.
  */
 public record ClientTuning(
         Duration connectTimeout,
         Duration responseTimeout,
         int maxConnections,
-        Duration pendingAcquireTimeout) {
+        Duration pendingAcquireTimeout,
+        int maxInMemorySize) {
+
+    /** 16 MiB: generous for attribute/status/CRL payloads, bounded against an oversized or malicious
+     * connector response. The single source of the default in-memory response cap — used by both
+     * {@link #defaults()} and the four-argument convenience constructor. */
+    private static final int DEFAULT_MAX_IN_MEMORY = 16 * 1024 * 1024;
 
     public ClientTuning {
         requirePositive(connectTimeout, "connectTimeout");
@@ -27,6 +67,19 @@ public record ClientTuning(
         if (maxConnections <= 0) {
             throw new IllegalArgumentException("maxConnections must be positive, was " + maxConnections);
         }
+        if (maxInMemorySize <= 0) {
+            throw new IllegalArgumentException("maxInMemorySize must be positive, was " + maxInMemorySize);
+        }
+    }
+
+    /**
+     * Source-compatible overload for callers compiled against this record before
+     * {@code maxInMemorySize} was added — applies {@link #DEFAULT_MAX_IN_MEMORY}. Do not remove:
+     * a shared-library record gaining a component must not force every consuming repository to
+     * change its constructor call in lockstep with the library bump.
+     */
+    public ClientTuning(Duration connectTimeout, Duration responseTimeout, int maxConnections, Duration pendingAcquireTimeout) {
+        this(connectTimeout, responseTimeout, maxConnections, pendingAcquireTimeout, DEFAULT_MAX_IN_MEMORY);
     }
 
     private static void requirePositive(Duration value, String name) {
@@ -37,6 +90,6 @@ public record ClientTuning(
 
     public static ClientTuning defaults() {
         // 35s response ~ authority connector per-call budget (30s) + margin; 3s connect fails fast on unreachable hosts.
-        return new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10));
+        return new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10), DEFAULT_MAX_IN_MEMORY);
     }
 }

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
@@ -1,0 +1,290 @@
+package com.otilm.api.clients.discovery.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.BaseApiClient;
+import com.otilm.api.exception.ConnectorEntityNotFoundException;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.error.ConnectorOperationErrorCodes;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryDrainRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryRunRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStopResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
+import com.otilm.api.model.core.auth.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+
+import javax.net.ssl.TrustManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * WebClient (HTTP) implementation of the v2 Discovery API client.
+ *
+ * <p>Path constants are part of the v2 discovery connector API contract — they describe the
+ * routes a v2 discovery connector implementation must expose, not configurable URIs.
+ *
+ * <p>This client uses the injected, shared {@code webClient} unmodified — it does not mutate or
+ * fork it. The in-memory response-size bound that protects {@code results} (whose pages can run to
+ * multiple megabytes) is a {@link com.otilm.api.clients.ClientTuning#maxInMemorySize()} setting on
+ * that shared {@code WebClient}, not something this class owns: every client sharing the WebClient
+ * shares the same bound. A per-client override was considered and rejected — {@link BaseApiClient}
+ * caches CERTIFICATE-auth WebClients process-wide keyed only by connector UUID, on the documented
+ * assumption that all clients share one base WebClient; a connector can implement more than one
+ * provider interface (e.g. both authority and discovery) under a single UUID, so a per-client cap
+ * could silently land on — or silently vanish from — a different client's connector depending on
+ * cache-population order. A response that exceeds the shared bound fails the call; see
+ * {@link BaseApiClient#processRequest} for how that failure is mapped to
+ * {@link com.otilm.api.exception.ConnectorServerException}.
+ *
+ * <p><b>Why the list operations decode arrays rather than streaming element lists.</b> That bound
+ * only covers a whole response on the {@code toEntity} path, which joins the response into one
+ * buffer before decoding it. {@code toEntityList(X.class)} instead streams the array through
+ * Spring's {@code Jackson2Tokenizer}, and the tokenizer resets its byte counter every time a
+ * top-level element completes, so the cap degrades into a per-element cap and the {@code collectList}
+ * that assembles the result is unbounded — a connector returning a million tiny attribute objects
+ * would not be bounded at all. The three list operations therefore request an array type
+ * ({@code X[].class}) and wrap the result, which routes through the codec's bounded
+ * {@code decodeToMono} path and holds the documented "single response" meaning of the cap. The
+ * wrapper returns a mutable {@link ArrayList}, matching the MQ client, so a caller that sorts or
+ * filters the result in place behaves the same on both transports.
+ *
+ * <p><b>No per-operation timeout budget over REST.</b> The MQ client sizes every call with
+ * {@link com.otilm.api.clients.mq.discovery.v2.DiscoveryMqTimeouts} — a short control/status budget,
+ * a deliberately long drain budget. This client has no per-request timeout at all: every call,
+ * including a {@code results} drain that legitimately runs far longer than a status poll, is capped
+ * by the single global {@link com.otilm.api.clients.ClientTuning#responseTimeout()} read guard on the
+ * shared {@code WebClient} (35s by default). Raising the effective drain budget therefore means
+ * raising that shared {@code responseTimeout}, which lengthens the read guard for every connector
+ * client built on the same WebClient, not just discovery. Documenting the asymmetry is the chosen
+ * resolution — a per-request override is deliberately not implemented, for the same shared-WebClient
+ * reason the response-size bound above is not per-client.
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
+public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncApiClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(DiscoveryApiClient.class);
+
+    public DiscoveryApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        this.webClient = webClient;
+        this.defaultTrustManagers = defaultTrustManagers;
+    }
+
+    @Override
+    public List<DiscoverySupportedResourceDto> listSupportedResources(ApiClientConnectorInfo connector) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
+
+        return processRequest(r -> toMutableList(requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.RESOURCES)
+                        .retrieve()
+                        .toEntity(DiscoverySupportedResourceDto[].class), "listSupportedResources")),
+                request,
+                connector);
+    }
+
+    @Override
+    public List<BaseAttribute> listRunAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
+
+        return processRequest(r -> toMutableList(requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.ATTRIBUTES)
+                        .retrieve()
+                        .toEntity(BaseAttribute[].class), "listRunAttributes")),
+                request,
+                connector);
+    }
+
+    /**
+     * {@code resource} binds to the URL by its wire code ({@code "certificates"}, {@code "keys"}),
+     * never the Java enum name — {@link Resource#getCode()}.
+     */
+    @Override
+    public List<BaseAttribute> listResourceAttributes(ApiClientConnectorInfo connector, Resource resource) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
+
+        return processRequest(r -> toMutableList(requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.resourceAttributes(resource))
+                        .retrieve()
+                        .toEntity(BaseAttribute[].class), "listResourceAttributes")),
+                request,
+                connector);
+    }
+
+    @Override
+    public DiscoveryInitiateResponseDto initiate(ApiClientConnectorInfo connector, DiscoveryInitiateRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.INITIATE)
+                        .body(Mono.just(requestDto), DiscoveryInitiateRequestDto.class)
+                        .retrieve()
+                        .toEntity(DiscoveryInitiateResponseDto.class), "initiate"),
+                request,
+                connector);
+    }
+
+    @Override
+    public DiscoveryStatusResponseDto status(ApiClientConnectorInfo connector, DiscoveryRunRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.STATUS)
+                        .body(Mono.just(requestDto), DiscoveryRunRequestDto.class)
+                        .retrieve()
+                        .toEntity(DiscoveryStatusResponseDto.class), "status"),
+                request,
+                connector);
+    }
+
+    @Override
+    public DiscoveryResultsResponseDto results(ApiClientConnectorInfo connector, DiscoveryDrainRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.RESULTS)
+                        .body(Mono.just(requestDto), DiscoveryDrainRequestDto.class)
+                        .retrieve()
+                        .toEntity(DiscoveryResultsResponseDto.class), "results"),
+                request,
+                connector);
+    }
+
+    @Override
+    public DiscoveryStopResponseDto stop(ApiClientConnectorInfo connector, DiscoveryRunRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.STOP)
+                        .body(Mono.just(requestDto), DiscoveryRunRequestDto.class)
+                        .retrieve()
+                        .toEntity(DiscoveryStopResponseDto.class), "stop"),
+                request,
+                connector);
+    }
+
+    @Override
+    public DiscoveryInitiateResponseDto resume(ApiClientConnectorInfo connector, DiscoveryRunRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+
+        return processRequest(r -> requireBody(r
+                        .uri(connector.getUrl() + DiscoveryPaths.RESUME)
+                        .body(Mono.just(requestDto), DiscoveryRunRequestDto.class)
+                        .retrieve()
+                        .toEntity(DiscoveryInitiateResponseDto.class), "resume"),
+                request,
+                connector);
+    }
+
+    /**
+     * A 404 on cancel means the connector no longer tracks the run — Core treats that as an
+     * already-terminal cancellation, i.e. success, not a failure. That is surfaced through the
+     * returned {@code ResponseEntity}'s status rather than as a thrown exception (the reason this
+     * method returns {@code ResponseEntity<Void>} instead of {@code void}), so a mapped "not
+     * tracked" failure is caught here and turned back into a normal response. That mapping can
+     * arrive as either of two shapes depending on how the connector answers the 404: a
+     * {@link ConnectorProblemException} carrying a not-tracked {@code errorCode} for a conformant
+     * {@code application/problem+json} body (checked by error code through
+     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}, not by transport status, since the
+     * error code is the one thing both this and every other lifecycle call's 404 agree on), or a
+     * {@link ConnectorEntityNotFoundException} for a terse/non-problem-json 404 —
+     * {@code BaseApiClient}'s legacy fallback for exactly that case. Every other failure (422
+     * refusal, transport errors, ...) still flows through the standard
+     * {@link BaseApiClient#processRequest} mapping unchanged.
+     *
+     * <p>The terse shape is genuinely ambiguous, which is why the lenient fallback is kept but logged.
+     * The shared connector contract also documents 404 as "endpoint not found or not implemented"
+     * (see {@code AuthProtectedConnectorController}), and Spring's own unmapped-route error page is a
+     * bare 404 too, so a connector that never implemented {@code /discoveries/cancel} — or one reached
+     * through a stale base URL — is indistinguishable at this point from a run that really is gone.
+     * Swallowing it silently would report a failed abort to Core as a successful one, so every
+     * swallowed 404 that did not carry a conformant not-tracked error code is logged at WARN naming
+     * the connector and the path.
+     *
+     * <p><b>Divergence from the v3 certificate family, deliberate.</b>
+     * {@link com.otilm.api.clients.v3.CertificateApiClient} propagates a 404 from its
+     * {@code cancelIssue}/{@code cancelRevoke}/{@code cancelRegister} calls as a
+     * {@link ConnectorProblemException} instead of swallowing it. Core consumes both clients, so two
+     * opposite cancel contracts in one library need justifying rather than merely tolerating:
+     * cancelling a discovery run is idempotent-terminal — a run the connector no longer tracks is
+     * already in the state cancel asked for, so there is nothing left to stop and nothing for Core to
+     * reconcile. A certificate issue/revoke/register cancellation is not: there the 404 only says the
+     * operation handle is unknown, which does not mean the operation stopped, and Core may still have
+     * an issued certificate to reconcile. Reporting that as a successful abort would lose work, so
+     * the certificate client must keep propagating it.
+     */
+    @Override
+    public ResponseEntity<Void> cancel(ApiClientConnectorInfo connector, DiscoveryRunRequestDto requestDto) throws ConnectorException {
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
+        String cancelUrl = connector.getUrl() + DiscoveryPaths.CANCEL;
+
+        return processRequest(r -> {
+            // The 404 swallow is attached to the exchange stage alone rather than to the assembled
+            // chain, so only a not-found raised by this request's own response can be intercepted.
+            Mono<ResponseEntity<Void>> exchange = r
+                    .uri(cancelUrl)
+                    .body(Mono.just(requestDto), DiscoveryRunRequestDto.class)
+                    .retrieve()
+                    .toBodilessEntity();
+
+            return requireResponse(exchange
+                    .onErrorResume(ex -> isRunNotTracked(ex, connector, cancelUrl)
+                            ? Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND).<Void>build())
+                            : Mono.error(ex)), "cancel");
+        }, request, connector);
+    }
+
+    /**
+     * True when a cancel failure should be read as "the connector no longer tracks this run" and
+     * turned back into a 404 response.
+     *
+     * <p>{@link Exceptions#unwrap} runs first because Reactor wraps propagated errors and
+     * {@link BaseApiClient#processRequest} unwraps for exactly that reason. The filter that maps
+     * connector responses happens to emit unwrapped into {@code onErrorResume} today, so matching the
+     * raw throwable works by accident; any future wrapping would silently turn a swallowed 404 back
+     * into a hard failure.
+     *
+     * <p>The conformant shape is recognised by error code via
+     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}, the single definition of that rule.
+     * The terse shape is accepted too, but logged — see this class's {@code cancel} javadoc for why a
+     * bare 404 is ambiguous and why it is nonetheless not fatal.
+     */
+    private static boolean isRunNotTracked(Throwable error, ApiClientConnectorInfo connector, String cancelUrl) {
+        Throwable unwrapped = Exceptions.unwrap(error);
+        if (unwrapped instanceof ConnectorProblemException cpe) {
+            return ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
+        }
+        if (unwrapped instanceof ConnectorEntityNotFoundException) {
+            logger.warn("Connector {} answered cancel at {} with a 404 that carries no not-tracked error code;"
+                            + " treating the run as already terminal. An unimplemented cancel endpoint or a stale"
+                            + " connector URL produces the same 404, so confirm the endpoint exists before trusting"
+                            + " this cancellation.",
+                    connector.getName(), cancelUrl);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Wrap a decoded response array as the mutable list the interface promises.
+     *
+     * <p>Identical to the MQ client's helper on purpose: a fresh {@link ArrayList} rather than an
+     * {@link Arrays#asList} view, and an absent array read as "no items", so a caller that sorts or
+     * filters the result in place cannot break on one transport only.
+     */
+    private static <T> List<T> toMutableList(T[] result) {
+        return result == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(result));
+    }
+}

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
@@ -215,7 +215,7 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
                     .toBodilessEntity();
 
             return requireResponse(exchange
-                    .onErrorResume(ex -> isRunNotTracked(ex, connector, cancelUrl)
+                    .onErrorResume(ex -> isRunNotTracked(ex, connector)
                             ? Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND).<Void>build())
                             : Mono.error(ex)), "cancel");
         }, request, connector);
@@ -234,7 +234,7 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
      * {@link ConnectorOperationErrorCodes#isOperationNotTracked}. The terse shape is accepted too but
      * logged — see {@code cancel} for why a bare 404 is ambiguous yet not fatal.
      */
-    private static boolean isRunNotTracked(Throwable error, ApiClientConnectorInfo connector, String cancelUrl) {
+    private static boolean isRunNotTracked(Throwable error, ApiClientConnectorInfo connector) {
         Throwable unwrapped = Exceptions.unwrap(error);
         if (unwrapped instanceof ConnectorProblemException cpe) {
             // The status gates the code, not the other way round. A not-tracked code is only ever
@@ -246,9 +246,11 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
                     && ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
         }
         if (unwrapped instanceof ConnectorEntityNotFoundException) {
-            logger.warn("Connector {} answered cancel at {} with a 404 carrying no not-tracked error code;"
+            // The contract path, not the resolved URL: a configured connector URL can carry user-info
+            // or a token in its query string, and this line only needs to say which operation answered.
+            logger.warn("Connector {} answered {} with a 404 carrying no not-tracked error code;"
                             + " treating the run as already terminal on weaker evidence.",
-                    connector.getName(), cancelUrl);
+                    connector.getName(), DiscoveryPaths.CANCEL);
             return true;
         }
         return false;

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
@@ -34,44 +34,31 @@ import java.util.List;
 /**
  * WebClient (HTTP) implementation of the v2 Discovery API client.
  *
- * <p>Path constants are part of the v2 discovery connector API contract — they describe the
- * routes a v2 discovery connector implementation must expose, not configurable URIs.
+ * <p>This client uses the injected, shared {@code webClient} unmodified. The in-memory
+ * response-size bound is a {@link com.otilm.api.clients.ClientTuning#maxInMemorySize()} setting on
+ * that shared {@code WebClient}, so every client sharing it shares the same bound; a response
+ * exceeding it fails the call, mapped by {@link BaseApiClient#processRequest} to
+ * {@link com.otilm.api.exception.ConnectorServerException}. The bound cannot be made per-client:
+ * {@link BaseApiClient} caches CERTIFICATE-auth WebClients process-wide keyed only by connector
+ * UUID, and one connector can implement several provider interfaces under a single UUID, so a
+ * per-client cap would land on another client's connector depending on cache-population order.
  *
- * <p>This client uses the injected, shared {@code webClient} unmodified — it does not mutate or
- * fork it. The in-memory response-size bound that protects {@code results} (whose pages can run to
- * multiple megabytes) is a {@link com.otilm.api.clients.ClientTuning#maxInMemorySize()} setting on
- * that shared {@code WebClient}, not something this class owns: every client sharing the WebClient
- * shares the same bound. A per-client override was considered and rejected — {@link BaseApiClient}
- * caches CERTIFICATE-auth WebClients process-wide keyed only by connector UUID, on the documented
- * assumption that all clients share one base WebClient; a connector can implement more than one
- * provider interface (e.g. both authority and discovery) under a single UUID, so a per-client cap
- * could silently land on — or silently vanish from — a different client's connector depending on
- * cache-population order. A response that exceeds the shared bound fails the call; see
- * {@link BaseApiClient#processRequest} for how that failure is mapped to
- * {@link com.otilm.api.exception.ConnectorServerException}.
- *
- * <p><b>Why the list operations decode arrays rather than streaming element lists.</b> That bound
+ * <p><b>Why the list operations decode arrays rather than streaming element lists.</b> The bound
  * only covers a whole response on the {@code toEntity} path, which joins the response into one
- * buffer before decoding it. {@code toEntityList(X.class)} instead streams the array through
- * Spring's {@code Jackson2Tokenizer}, and the tokenizer resets its byte counter every time a
- * top-level element completes, so the cap degrades into a per-element cap and the {@code collectList}
- * that assembles the result is unbounded — a connector returning a million tiny attribute objects
- * would not be bounded at all. The three list operations therefore request an array type
- * ({@code X[].class}) and wrap the result, which routes through the codec's bounded
- * {@code decodeToMono} path and holds the documented "single response" meaning of the cap. The
- * wrapper returns a mutable {@link ArrayList}, matching the MQ client, so a caller that sorts or
- * filters the result in place behaves the same on both transports.
+ * buffer before decoding. {@code toEntityList(X.class)} streams the array through Spring's
+ * {@code Jackson2Tokenizer}, which resets its byte counter every time a top-level element
+ * completes, so the cap degrades into a per-element cap and the {@code collectList} assembling the
+ * result is unbounded — a connector returning a million tiny objects would not be bounded at all.
+ * The three list operations therefore request an array type ({@code X[].class}) and wrap the
+ * result, routing through the codec's bounded {@code decodeToMono} path.
  *
- * <p><b>No per-operation timeout budget over REST.</b> The MQ client sizes every call with
- * {@link com.otilm.api.clients.mq.discovery.v2.DiscoveryMqTimeouts} — a short control/status budget,
- * a deliberately long drain budget. This client has no per-request timeout at all: every call,
- * including a {@code results} drain that legitimately runs far longer than a status poll, is capped
- * by the single global {@link com.otilm.api.clients.ClientTuning#responseTimeout()} read guard on the
- * shared {@code WebClient} (35s by default). Raising the effective drain budget therefore means
- * raising that shared {@code responseTimeout}, which lengthens the read guard for every connector
- * client built on the same WebClient, not just discovery. Documenting the asymmetry is the chosen
- * resolution — a per-request override is deliberately not implemented, for the same shared-WebClient
- * reason the response-size bound above is not per-client.
+ * <p><b>No per-operation timeout budget over REST.</b> Unlike the MQ client, which sizes each call
+ * with {@link com.otilm.api.clients.mq.discovery.v2.DiscoveryMqTimeouts}, every call here —
+ * including a {@code results} drain that legitimately runs far longer than a status poll — is capped
+ * by the single global {@link com.otilm.api.clients.ClientTuning#responseTimeout()} read guard on
+ * the shared {@code WebClient} (35s by default). Raising the drain budget means raising that shared
+ * {@code responseTimeout}, which lengthens the read guard for every client built on the same
+ * WebClient.
  */
 @SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncApiClient {
@@ -189,41 +176,29 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
     }
 
     /**
-     * A 404 on cancel means the connector no longer tracks the run — Core treats that as an
-     * already-terminal cancellation, i.e. success, not a failure. That is surfaced through the
-     * returned {@code ResponseEntity}'s status rather than as a thrown exception (the reason this
-     * method returns {@code ResponseEntity<Void>} instead of {@code void}), so a mapped "not
-     * tracked" failure is caught here and turned back into a normal response. That mapping can
-     * arrive as either of two shapes depending on how the connector answers the 404: a
+     * A 404 on cancel means the connector no longer tracks the run — an already-terminal
+     * cancellation, i.e. success. It is surfaced through the returned {@code ResponseEntity}'s status
+     * rather than as a thrown exception, which is why this method returns {@code ResponseEntity<Void>}
+     * instead of {@code void}. The 404 arrives in either of two shapes: a
      * {@link ConnectorProblemException} carrying a not-tracked {@code errorCode} for a conformant
-     * {@code application/problem+json} body (checked by error code through
-     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}, not by transport status, since the
-     * error code is the one thing both this and every other lifecycle call's 404 agree on), or a
-     * {@link ConnectorEntityNotFoundException} for a terse/non-problem-json 404 —
-     * {@code BaseApiClient}'s legacy fallback for exactly that case. Every other failure (422
-     * refusal, transport errors, ...) still flows through the standard
-     * {@link BaseApiClient#processRequest} mapping unchanged.
+     * {@code application/problem+json} body, matched by error code through
+     * {@link ConnectorOperationErrorCodes#isOperationNotTracked} rather than by transport status; or a
+     * {@link ConnectorEntityNotFoundException} for a terse non-problem-json 404,
+     * {@code BaseApiClient}'s legacy fallback. Every other failure (422 refusal, transport errors)
+     * flows through the standard {@link BaseApiClient#processRequest} mapping unchanged.
      *
-     * <p>The terse shape is genuinely ambiguous, which is why the lenient fallback is kept but logged.
-     * The shared connector contract also documents 404 as "endpoint not found or not implemented"
-     * (see {@code AuthProtectedConnectorController}), and Spring's own unmapped-route error page is a
-     * bare 404 too, so a connector that never implemented {@code /discoveries/cancel} — or one reached
-     * through a stale base URL — is indistinguishable at this point from a run that really is gone.
-     * Swallowing it silently would report a failed abort to Core as a successful one, so every
-     * swallowed 404 that did not carry a conformant not-tracked error code is logged at WARN naming
-     * the connector and the path.
+     * <p>The terse shape is ambiguous: the shared connector contract also documents 404 as "endpoint
+     * not found or not implemented" (see {@code AuthProtectedConnectorController}), so a connector
+     * that never implemented {@code /discoveries/cancel}, or one reached through a stale base URL, is
+     * indistinguishable from a run that really is gone. Swallowing it silently would report a failed
+     * abort as a successful one, so it is accepted but logged at WARN naming the connector and path.
      *
-     * <p><b>Divergence from the v3 certificate family, deliberate.</b>
-     * {@link com.otilm.api.clients.v3.CertificateApiClient} propagates a 404 from its
-     * {@code cancelIssue}/{@code cancelRevoke}/{@code cancelRegister} calls as a
-     * {@link ConnectorProblemException} instead of swallowing it. Core consumes both clients, so two
-     * opposite cancel contracts in one library need justifying rather than merely tolerating:
-     * cancelling a discovery run is idempotent-terminal — a run the connector no longer tracks is
-     * already in the state cancel asked for, so there is nothing left to stop and nothing for Core to
-     * reconcile. A certificate issue/revoke/register cancellation is not: there the 404 only says the
-     * operation handle is unknown, which does not mean the operation stopped, and Core may still have
-     * an issued certificate to reconcile. Reporting that as a successful abort would lose work, so
-     * the certificate client must keep propagating it.
+     * <p>{@link com.otilm.api.clients.v3.CertificateApiClient} deliberately does the opposite and
+     * propagates a 404 from its {@code cancelIssue}/{@code cancelRevoke}/{@code cancelRegister}
+     * calls. Cancelling a discovery run is idempotent-terminal — a run the connector no longer tracks
+     * is already in the state cancel asked for. A certificate cancellation is not: there the 404 only
+     * says the operation handle is unknown, not that the operation stopped, and Core may still have an
+     * issued certificate to reconcile, so reporting a successful abort would lose work.
      */
     @Override
     public ResponseEntity<Void> cancel(ApiClientConnectorInfo connector, DiscoveryRunRequestDto requestDto) throws ConnectorException {
@@ -231,8 +206,8 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
         String cancelUrl = connector.getUrl() + DiscoveryPaths.CANCEL;
 
         return processRequest(r -> {
-            // The 404 swallow is attached to the exchange stage alone rather than to the assembled
-            // chain, so only a not-found raised by this request's own response can be intercepted.
+            // Attached to the exchange stage alone, not the assembled chain, so only a not-found
+            // raised by this request's own response can be intercepted.
             Mono<ResponseEntity<Void>> exchange = r
                     .uri(cancelUrl)
                     .body(Mono.just(requestDto), DiscoveryRunRequestDto.class)
@@ -250,16 +225,14 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
      * True when a cancel failure should be read as "the connector no longer tracks this run" and
      * turned back into a 404 response.
      *
-     * <p>{@link Exceptions#unwrap} runs first because Reactor wraps propagated errors and
-     * {@link BaseApiClient#processRequest} unwraps for exactly that reason. The filter that maps
-     * connector responses happens to emit unwrapped into {@code onErrorResume} today, so matching the
-     * raw throwable works by accident; any future wrapping would silently turn a swallowed 404 back
-     * into a hard failure.
+     * <p>{@link Exceptions#unwrap} runs first because Reactor wraps propagated errors. The response
+     * filter happens to emit unwrapped into {@code onErrorResume} today, so matching the raw
+     * throwable works by accident; any future wrapping would silently turn a swallowed 404 back into
+     * a hard failure.
      *
      * <p>The conformant shape is recognised by error code via
-     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}, the single definition of that rule.
-     * The terse shape is accepted too, but logged — see this class's {@code cancel} javadoc for why a
-     * bare 404 is ambiguous and why it is nonetheless not fatal.
+     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}. The terse shape is accepted too but
+     * logged — see {@code cancel} for why a bare 404 is ambiguous yet not fatal.
      */
     private static boolean isRunNotTracked(Throwable error, ApiClientConnectorInfo connector, String cancelUrl) {
         Throwable unwrapped = Exceptions.unwrap(error);
@@ -267,10 +240,8 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
             return ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
         }
         if (unwrapped instanceof ConnectorEntityNotFoundException) {
-            logger.warn("Connector {} answered cancel at {} with a 404 that carries no not-tracked error code;"
-                            + " treating the run as already terminal. An unimplemented cancel endpoint or a stale"
-                            + " connector URL produces the same 404, so confirm the endpoint exists before trusting"
-                            + " this cancellation.",
+            logger.warn("Connector {} answered cancel at {} with a 404 carrying no not-tracked error code;"
+                            + " treating the run as already terminal on weaker evidence.",
                     connector.getName(), cancelUrl);
             return true;
         }
@@ -278,11 +249,10 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
     }
 
     /**
-     * Wrap a decoded response array as the mutable list the interface promises.
-     *
-     * <p>Identical to the MQ client's helper on purpose: a fresh {@link ArrayList} rather than an
-     * {@link Arrays#asList} view, and an absent array read as "no items", so a caller that sorts or
-     * filters the result in place cannot break on one transport only.
+     * Wrap a decoded response array as the mutable list the interface promises: a fresh
+     * {@link ArrayList} rather than an {@link Arrays#asList} view, with an absent array read as "no
+     * items". Matches the MQ client's helper, so in-place sorting or filtering behaves the same on
+     * both transports.
      */
     private static <T> List<T> toMutableList(T[] result) {
         return result == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(result));

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClient.java
@@ -237,7 +237,13 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
     private static boolean isRunNotTracked(Throwable error, ApiClientConnectorInfo connector, String cancelUrl) {
         Throwable unwrapped = Exceptions.unwrap(error);
         if (unwrapped instanceof ConnectorProblemException cpe) {
-            return ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
+            // The status gates the code, not the other way round. A not-tracked code is only ever
+            // legitimate on a 404: cancel's own 422 means the run is past the point of no return and
+            // must reach the caller, and REGISTRATION_NOT_FOUND — which the shared predicate accepts,
+            // because it is authority's flavour of not-tracked — is declared 422. Without this guard a
+            // 422 would be answered as a successful cancellation.
+            return HttpStatus.NOT_FOUND.equals(cpe.getHttpStatus())
+                    && ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
         }
         if (unwrapped instanceof ConnectorEntityNotFoundException) {
             logger.warn("Connector {} answered cancel at {} with a 404 carrying no not-tracked error code;"
@@ -249,12 +255,12 @@ public class DiscoveryApiClient extends BaseApiClient implements DiscoverySyncAp
     }
 
     /**
-     * Wrap a decoded response array as the mutable list the interface promises: a fresh
-     * {@link ArrayList} rather than an {@link Arrays#asList} view, with an absent array read as "no
-     * items". Matches the MQ client's helper, so in-place sorting or filtering behaves the same on
-     * both transports.
+     * Wrap an already-required response array in the mutable list {@link DiscoverySyncApiClient}
+     * documents: a fresh {@link ArrayList} rather than an {@link Arrays#asList} view, so a caller may
+     * sort or filter in place. Every caller passes the array through {@code requireBody} first, which
+     * rejects an absent body as non-conformant, so nothing null reaches here.
      */
     private static <T> List<T> toMutableList(T[] result) {
-        return result == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(result));
+        return new ArrayList<>(Arrays.asList(result));
     }
 }

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
@@ -18,9 +18,12 @@ import java.util.Set;
 @SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public final class DiscoveryPaths {
 
+    /** Both the run-level and the per-resource attribute routes end in this segment. */
+    private static final String ATTRIBUTES_SEGMENT = "/attributes";
+
     public static final String BASE = "/v2/discoveryProvider";
     public static final String RESOURCES = BASE + "/resources";
-    public static final String ATTRIBUTES = BASE + "/attributes";
+    public static final String ATTRIBUTES = BASE + ATTRIBUTES_SEGMENT;
 
     public static final String RUNS = BASE + "/discoveries";
     public static final String INITIATE = RUNS + "/initiate";
@@ -29,8 +32,6 @@ public final class DiscoveryPaths {
     public static final String STOP = RUNS + "/stop";
     public static final String RESUME = RUNS + "/resume";
     public static final String CANCEL = RUNS + "/cancel";
-
-    private static final String RESOURCE_ATTRIBUTES_SUFFIX = "/attributes";
 
     /**
      * The resources a discovery run can report, pinned by the {@code @JsonSubTypes} registered on
@@ -58,6 +59,6 @@ public final class DiscoveryPaths {
             throw new IllegalArgumentException(
                     "Resource " + resource + " is not discoverable; expected one of " + DISCOVERABLE);
         }
-        return BASE + "/" + resource.getCode() + RESOURCE_ATTRIBUTES_SUFFIX;
+        return BASE + "/" + resource.getCode() + ATTRIBUTES_SEGMENT;
     }
 }

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
@@ -1,0 +1,63 @@
+package com.otilm.api.clients.discovery.v2;
+
+import com.otilm.api.model.core.auth.Resource;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * The discovery v2 connector routes, defined once for both transports.
+ *
+ * <p>The REST and MQ clients address the same connector contract, so a route that differs between
+ * them is a defect no test in either suite would catch. Both import these constants rather than
+ * declaring their own, which is what makes divergence impossible rather than merely unlikely.
+ *
+ * <p>Streaming ({@code POST /v2/discoveryProvider/discoveries/stream}) is deliberately absent: no
+ * client implements it yet. See {@link com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient}.
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
+public final class DiscoveryPaths {
+
+    public static final String BASE = "/v2/discoveryProvider";
+    public static final String RESOURCES = BASE + "/resources";
+    public static final String ATTRIBUTES = BASE + "/attributes";
+
+    public static final String RUNS = BASE + "/discoveries";
+    public static final String INITIATE = RUNS + "/initiate";
+    public static final String STATUS = RUNS + "/status";
+    public static final String RESULTS = RUNS + "/results";
+    public static final String STOP = RUNS + "/stop";
+    public static final String RESUME = RUNS + "/resume";
+    public static final String CANCEL = RUNS + "/cancel";
+
+    private static final String RESOURCE_ATTRIBUTES_SUFFIX = "/attributes";
+
+    /**
+     * The resources a discovery run can report, pinned by the {@code @JsonSubTypes} registered on
+     * {@code DiscoveredItemPayloadDto} — a payload type exists for exactly these two.
+     */
+    private static final Set<Resource> DISCOVERABLE =
+            EnumSet.of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY);
+
+    private DiscoveryPaths() {
+    }
+
+    /**
+     * The per-resource attribute route, bound by the resource's wire code ({@code "certificates"},
+     * {@code "keys"}) rather than its Java enum name.
+     *
+     * <p>Rejects a resource that discovery cannot report. Without the check, {@code Resource.DISCOVERY}
+     * (code {@code "discoveries"}) would compose to {@code /v2/discoveryProvider/discoveries/attributes}
+     * — a path inside the run-lifecycle namespace — so a caller mistake would surface as a puzzling 404
+     * from what looks like a lifecycle route instead of as the argument error it is.
+     *
+     * @throws IllegalArgumentException if {@code resource} is not discoverable
+     */
+    public static String resourceAttributes(Resource resource) {
+        if (!DISCOVERABLE.contains(resource)) {
+            throw new IllegalArgumentException(
+                    "Resource " + resource + " is not discoverable; expected one of " + DISCOVERABLE);
+        }
+        return BASE + "/" + resource.getCode() + RESOURCE_ATTRIBUTES_SUFFIX;
+    }
+}

--- a/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
+++ b/src/main/java/com/otilm/api/clients/discovery/v2/DiscoveryPaths.java
@@ -10,7 +10,7 @@ import java.util.Set;
  *
  * <p>The REST and MQ clients address the same connector contract, so a route that differs between
  * them is a defect no test in either suite would catch. Both import these constants rather than
- * declaring their own, which is what makes divergence impossible rather than merely unlikely.
+ * declaring their own.
  *
  * <p>Streaming ({@code POST /v2/discoveryProvider/discoveries/stream}) is deliberately absent: no
  * client implements it yet. See {@link com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient}.
@@ -47,10 +47,10 @@ public final class DiscoveryPaths {
      * The per-resource attribute route, bound by the resource's wire code ({@code "certificates"},
      * {@code "keys"}) rather than its Java enum name.
      *
-     * <p>Rejects a resource that discovery cannot report. Without the check, {@code Resource.DISCOVERY}
-     * (code {@code "discoveries"}) would compose to {@code /v2/discoveryProvider/discoveries/attributes}
-     * — a path inside the run-lifecycle namespace — so a caller mistake would surface as a puzzling 404
-     * from what looks like a lifecycle route instead of as the argument error it is.
+     * <p>Rejects a resource discovery cannot report. Unchecked, {@code Resource.DISCOVERY} (code
+     * {@code "discoveries"}) would compose to {@code /v2/discoveryProvider/discoveries/attributes},
+     * inside the run-lifecycle namespace, so a caller mistake would surface as a 404 from an apparent
+     * lifecycle route rather than as the argument error it is.
      *
      * @throws IllegalArgumentException if {@code resource} is not discoverable
      */

--- a/src/main/java/com/otilm/api/clients/mq/ProxyClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/ProxyClient.java
@@ -76,6 +76,41 @@ public interface ProxyClient {
     }
 
     /**
+     * Send a request to the connector and wait for response synchronously with custom timeout,
+     * preserving the upstream HTTP status. Required for callers that distinguish {@code 200 OK}
+     * (synchronous completion) from {@code 202 Accepted} (asynchronous completion) while also
+     * needing an explicit, operation-specific timeout instead of the proxy's default.
+     *
+     * <p>The default implementation falls back to {@link #sendRequest(ApiClientConnectorInfo, String, String, Object, Class, Duration)}
+     * and wraps the result in {@code ResponseEntity.ok(...)}, which collapses every successful upstream status to
+     * {@code 200}. Implementations that need true status fidelity (e.g. for the asynchronous
+     * authority-provider operations contract) <b>must</b> override this method and propagate
+     * the actual upstream status code.</p>
+     *
+     * @param connector    Connector configuration with URL, auth, and proxyId
+     * @param path         Request path (e.g., "/v1/health")
+     * @param method       HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param body         Request body (can be null for GET requests)
+     * @param responseType Expected response type class
+     * @param timeout      Custom timeout duration
+     * @param <T>          Response type
+     * @return ResponseEntity carrying the upstream status and deserialized body
+     *         (the body may be {@code null} when the upstream response had no body, e.g. 204)
+     * @throws ConnectorException If request fails or times out
+     */
+    default <T> ResponseEntity<T> sendRequestForEntity(
+            ApiClientConnectorInfo connector,
+            String path,
+            String method,
+            Object body,
+            Class<T> responseType,
+            Duration timeout
+    ) throws ConnectorException {
+        T result = sendRequest(connector, path, method, body, responseType, timeout);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
      * Send a request to the connector and wait for response synchronously with custom timeout.
      *
      * @param connector    Connector configuration with URL, auth, and proxyId

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
@@ -29,24 +29,19 @@ import java.util.Objects;
 /**
  * MQ-based implementation of the v2 Discovery API client.
  *
- * <p>Path constants mirror {@link com.otilm.api.clients.discovery.v2.DiscoveryApiClient}
- * character-for-character — both transports must address the same connector contract.
- *
  * <p>No {@code stream} method exists here: NDJSON streaming has no MQ representation (a
  * request/response proxy hop cannot carry a chunked stream). Core selects the REST client when it
  * needs streaming; see {@link DiscoverySyncApiClient}.
  *
  * <p>Every call passes an explicit {@code Duration} sized by {@link DiscoveryMqTimeouts} — this
  * client never invokes a {@link ProxyClient} overload that falls back to the proxy's default
- * timeout, since a discovery drain can legitimately take far longer than a status poll or a
- * lifecycle control call.
+ * timeout, since a discovery drain can legitimately take far longer than a status poll.
  *
  * <p>The proxy hands back {@code null} for a relayed response that carried no body, so every
- * operation guards it and fails naming the operation, rather than passing {@code null} on to Core
- * where it would resurface as a {@link NullPointerException} far from its cause. A list route that
- * answers with no body at all is non-conformant, not empty — REST rejects it the same way, so the
- * two transports report an identical failure. Lists that do arrive are mutable, matching the
- * mutable Jackson list REST returns, so a caller sorting in place behaves the same on both.
+ * operation guards it and fails naming the operation rather than passing {@code null} on to Core,
+ * where it would resurface as a {@link NullPointerException} far from its cause. A list route
+ * answering with no body is non-conformant, not empty. Lists that do arrive are mutable, matching
+ * the Jackson list REST returns.
  */
 @SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public class DiscoveryApiClient implements DiscoverySyncApiClient {
@@ -60,19 +55,15 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
     private final DiscoveryMqTimeouts timeouts;
 
     /**
-     * Both collaborators are validated eagerly — as {@link DiscoveryMqTimeouts} and
-     * {@link com.otilm.api.clients.ClientTuning} validate their own arguments — so misconfigured
-     * wiring fails at bean construction instead of on the first connector call.
+     * Both collaborators are validated eagerly, so misconfigured wiring fails at bean construction
+     * instead of on the first connector call.
      */
     public DiscoveryApiClient(ProxyClient proxyClient, DiscoveryMqTimeouts timeouts) {
         this.proxyClient = Objects.requireNonNull(proxyClient, "proxyClient is required");
         this.timeouts = Objects.requireNonNull(timeouts, "timeouts is required");
     }
 
-    /**
-     * Convenience constructor using {@link DiscoveryMqTimeouts#defaults()}, so Core can adopt this
-     * client before it exposes timeout configuration properties.
-     */
+    /** Convenience constructor using {@link DiscoveryMqTimeouts#defaults()}. */
     public DiscoveryApiClient(ProxyClient proxyClient) {
         this(proxyClient, DiscoveryMqTimeouts.defaults());
     }
@@ -138,23 +129,21 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
      * rather than {@code sendRequest} because the caller needs the status, not the (absent) body.
      *
      * <p>A 404 means the connector no longer tracks the run — the terminal state cancel was asking
-     * for, so Core reads it as an already-terminal cancellation rather than an error. The proxy
-     * classifies that 404 into a thrown {@link ConnectorEntityNotFoundException}, and would raise a
+     * for, so it reads as an already-terminal cancellation rather than an error. The proxy classifies
+     * that 404 into a thrown {@link ConnectorEntityNotFoundException}, and would raise a
      * {@link ConnectorProblemException} once it relays {@code application/problem+json}; both shapes
      * are caught here (the problem one by error code, via
      * {@link ConnectorOperationErrorCodes#isOperationNotTracked}) and returned as a {@code 404}
-     * response, exactly as the REST client does. Otherwise the identical call would succeed on REST
-     * and hard-fail on MQ, defeating the sole reason this method returns {@code ResponseEntity<Void>}.
-     * Every other failure — the {@code 422} past-the-point-of-no-return refusal, transport errors,
-     * ... — propagates untouched.
+     * response, exactly as the REST client does — otherwise the identical call would succeed on REST
+     * and hard-fail on MQ. Every other failure, including the {@code 422}
+     * past-the-point-of-no-return refusal, propagates untouched.
      *
      * <p>Any successful status the proxy reports is normalized to {@code 204}, cancel's only contract
      * success status. The {@code Duration} overload of {@code sendRequestForEntity} is a
      * {@code default} method that wraps the body in {@code ResponseEntity.ok}, so without this an MQ
-     * cancel would answer {@code 200} where the controller declares {@code 204} — and a Core adapter
-     * that branches on exact status values would reject it. Normalizing here makes both transports
-     * agree regardless of when (or whether) Core overrides that overload, which is why
-     * {@link ProxyClient} itself is left alone.
+     * cancel would answer {@code 200} where the controller declares {@code 204}, and a Core adapter
+     * branching on exact status values would reject it. Normalizing here keeps both transports in
+     * agreement whether or not Core overrides that overload.
      */
     @Override
     public ResponseEntity<Void> cancel(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException {
@@ -171,8 +160,8 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
         if (response == null) {
             throw new ConnectorException("No response received from connector for cancel", connector);
         }
-        // A non-2xx entity (a proxy that one day relays the 404 instead of throwing it) already
-        // carries the status the caller reads, so it passes through unchanged.
+        // A non-2xx entity (a proxy that relays the 404 instead of throwing it) already carries the
+        // status the caller reads, so it passes through unchanged.
         return response.getStatusCode().is2xxSuccessful()
                 ? ResponseEntity.noContent().build()
                 : response;
@@ -189,13 +178,12 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
     /**
      * An absent body is a non-conformant response, not "no items": a list route must return a JSON
      * array, and reading a missing body as empty would make a broken connector indistinguishable from
-     * one that genuinely reports nothing — for {@code listSupportedResources} that is a distinction
-     * Core acts on. REST rejects it identically via {@code BaseApiClient.requireBody}, and the
-     * single-DTO operations here already throw, so all three agree.
+     * one that genuinely reports nothing — for {@code listSupportedResources} a distinction Core acts
+     * on. REST rejects it identically via {@code BaseApiClient.requireBody}.
      *
      * <p>The list is a fresh {@link ArrayList} rather than an {@link Arrays#asList} view because REST
-     * hands back a mutable Jackson list: a caller that sorts or filters in place must behave the same
-     * on both transports.
+     * hands back a mutable Jackson list, so in-place sorting or filtering behaves the same on both
+     * transports.
      */
     private static <T> List<T> toMutableList(T[] result, String operation, ApiClientConnectorInfo connector)
             throws ConnectorException {
@@ -207,8 +195,7 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
      * must carry a payload, a bodiless response is a connector contract violation, so it fails here
      * naming the operation instead of returning the proxy's {@code null}. Unlike the REST side's
      * {@link IllegalStateException} this uses the declared {@link ConnectorException} channel and
-     * attributes the failure to the connector, so a caller can both catch it and tell which
-     * connector produced it.
+     * attributes the failure to the connector.
      */
     private static <T> T requireBody(T body, String operation, ApiClientConnectorInfo connector) throws ConnectorException {
         if (body == null) {

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
@@ -1,0 +1,219 @@
+package com.otilm.api.clients.mq.discovery.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.discovery.v2.DiscoveryPaths;
+import com.otilm.api.clients.mq.ProxyClient;
+import com.otilm.api.exception.ConnectorEntityNotFoundException;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.error.ConnectorOperationErrorCodes;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryDrainRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryRunRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStopResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
+import com.otilm.api.model.core.auth.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * MQ-based implementation of the v2 Discovery API client.
+ *
+ * <p>Path constants mirror {@link com.otilm.api.clients.discovery.v2.DiscoveryApiClient}
+ * character-for-character — both transports must address the same connector contract.
+ *
+ * <p>No {@code stream} method exists here: NDJSON streaming has no MQ representation (a
+ * request/response proxy hop cannot carry a chunked stream). Core selects the REST client when it
+ * needs streaming; see {@link DiscoverySyncApiClient}.
+ *
+ * <p>Every call passes an explicit {@code Duration} sized by {@link DiscoveryMqTimeouts} — this
+ * client never invokes a {@link ProxyClient} overload that falls back to the proxy's default
+ * timeout, since a discovery drain can legitimately take far longer than a status poll or a
+ * lifecycle control call.
+ *
+ * <p>The proxy hands back {@code null} for a relayed response that carried no body, so every
+ * operation guards it and fails naming the operation, rather than passing {@code null} on to Core
+ * where it would resurface as a {@link NullPointerException} far from its cause. A list route that
+ * answers with no body at all is non-conformant, not empty — REST rejects it the same way, so the
+ * two transports report an identical failure. Lists that do arrive are mutable, matching the
+ * mutable Jackson list REST returns, so a caller sorting in place behaves the same on both.
+ */
+@SuppressWarnings("java:S1075") // contract paths, not configurable URIs
+public class DiscoveryApiClient implements DiscoverySyncApiClient {
+
+
+
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String HTTP_METHOD_POST = "POST";
+
+    private final ProxyClient proxyClient;
+    private final DiscoveryMqTimeouts timeouts;
+
+    /**
+     * Both collaborators are validated eagerly — as {@link DiscoveryMqTimeouts} and
+     * {@link com.otilm.api.clients.ClientTuning} validate their own arguments — so misconfigured
+     * wiring fails at bean construction instead of on the first connector call.
+     */
+    public DiscoveryApiClient(ProxyClient proxyClient, DiscoveryMqTimeouts timeouts) {
+        this.proxyClient = Objects.requireNonNull(proxyClient, "proxyClient is required");
+        this.timeouts = Objects.requireNonNull(timeouts, "timeouts is required");
+    }
+
+    /**
+     * Convenience constructor using {@link DiscoveryMqTimeouts#defaults()}, so Core can adopt this
+     * client before it exposes timeout configuration properties.
+     */
+    public DiscoveryApiClient(ProxyClient proxyClient) {
+        this(proxyClient, DiscoveryMqTimeouts.defaults());
+    }
+
+    @Override
+    public List<DiscoverySupportedResourceDto> listSupportedResources(ApiClientConnectorInfo connector) throws ConnectorException {
+        DiscoverySupportedResourceDto[] result = proxyClient.sendRequest(connector, DiscoveryPaths.RESOURCES, HTTP_METHOD_GET, null,
+                DiscoverySupportedResourceDto[].class, timeouts.control());
+        return toMutableList(result, "listSupportedResources", connector);
+    }
+
+    @Override
+    public List<BaseAttribute> listRunAttributes(ApiClientConnectorInfo connector) throws ConnectorException {
+        BaseAttribute[] result = proxyClient.sendRequest(connector, DiscoveryPaths.ATTRIBUTES, HTTP_METHOD_GET, null,
+                BaseAttribute[].class, timeouts.control());
+        return toMutableList(result, "listRunAttributes", connector);
+    }
+
+    /**
+     * {@code resource} binds to the path by its wire code ({@code "certificates"}, {@code "keys"}),
+     * never the Java enum name — {@link Resource#getCode()}.
+     */
+    @Override
+    public List<BaseAttribute> listResourceAttributes(ApiClientConnectorInfo connector, Resource resource) throws ConnectorException {
+        String path = DiscoveryPaths.resourceAttributes(resource);
+        BaseAttribute[] result = proxyClient.sendRequest(connector, path, HTTP_METHOD_GET, null,
+                BaseAttribute[].class, timeouts.control());
+        return toMutableList(result, "listResourceAttributes", connector);
+    }
+
+    @Override
+    public DiscoveryInitiateResponseDto initiate(ApiClientConnectorInfo connector, DiscoveryInitiateRequestDto request) throws ConnectorException {
+        return requireBody(proxyClient.sendRequest(connector, DiscoveryPaths.INITIATE, HTTP_METHOD_POST, request,
+                DiscoveryInitiateResponseDto.class, timeouts.control()), "initiate", connector);
+    }
+
+    @Override
+    public DiscoveryStatusResponseDto status(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException {
+        return requireBody(proxyClient.sendRequest(connector, DiscoveryPaths.STATUS, HTTP_METHOD_POST, request,
+                DiscoveryStatusResponseDto.class, timeouts.status()), "status", connector);
+    }
+
+    @Override
+    public DiscoveryResultsResponseDto results(ApiClientConnectorInfo connector, DiscoveryDrainRequestDto request) throws ConnectorException {
+        return requireBody(proxyClient.sendRequest(connector, DiscoveryPaths.RESULTS, HTTP_METHOD_POST, request,
+                DiscoveryResultsResponseDto.class, timeouts.drain()), "results", connector);
+    }
+
+    @Override
+    public DiscoveryStopResponseDto stop(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException {
+        return requireBody(proxyClient.sendRequest(connector, DiscoveryPaths.STOP, HTTP_METHOD_POST, request,
+                DiscoveryStopResponseDto.class, timeouts.control()), "stop", connector);
+    }
+
+    @Override
+    public DiscoveryInitiateResponseDto resume(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException {
+        return requireBody(proxyClient.sendRequest(connector, DiscoveryPaths.RESUME, HTTP_METHOD_POST, request,
+                DiscoveryInitiateResponseDto.class, timeouts.control()), "resume", connector);
+    }
+
+    /**
+     * Uses {@link ProxyClient#sendRequestForEntity(ApiClientConnectorInfo, String, String, Object, Class, java.time.Duration)}
+     * rather than {@code sendRequest} because the caller needs the status, not the (absent) body.
+     *
+     * <p>A 404 means the connector no longer tracks the run — the terminal state cancel was asking
+     * for, so Core reads it as an already-terminal cancellation rather than an error. The proxy
+     * classifies that 404 into a thrown {@link ConnectorEntityNotFoundException}, and would raise a
+     * {@link ConnectorProblemException} once it relays {@code application/problem+json}; both shapes
+     * are caught here (the problem one by error code, via
+     * {@link ConnectorOperationErrorCodes#isOperationNotTracked}) and returned as a {@code 404}
+     * response, exactly as the REST client does. Otherwise the identical call would succeed on REST
+     * and hard-fail on MQ, defeating the sole reason this method returns {@code ResponseEntity<Void>}.
+     * Every other failure — the {@code 422} past-the-point-of-no-return refusal, transport errors,
+     * ... — propagates untouched.
+     *
+     * <p>Any successful status the proxy reports is normalized to {@code 204}, cancel's only contract
+     * success status. The {@code Duration} overload of {@code sendRequestForEntity} is a
+     * {@code default} method that wraps the body in {@code ResponseEntity.ok}, so without this an MQ
+     * cancel would answer {@code 200} where the controller declares {@code 204} — and a Core adapter
+     * that branches on exact status values would reject it. Normalizing here makes both transports
+     * agree regardless of when (or whether) Core overrides that overload, which is why
+     * {@link ProxyClient} itself is left alone.
+     */
+    @Override
+    public ResponseEntity<Void> cancel(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException {
+        ResponseEntity<Void> response;
+        try {
+            response = proxyClient.sendRequestForEntity(connector, DiscoveryPaths.CANCEL, HTTP_METHOD_POST, request,
+                    Void.class, timeouts.control());
+        } catch (ConnectorEntityNotFoundException | ConnectorProblemException e) {
+            if (!isRunNotTracked(e)) {
+                throw e;
+            }
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).<Void>build();
+        }
+        if (response == null) {
+            throw new ConnectorException("No response received from connector for cancel", connector);
+        }
+        // A non-2xx entity (a proxy that one day relays the 404 instead of throwing it) already
+        // carries the status the caller reads, so it passes through unchanged.
+        return response.getStatusCode().is2xxSuccessful()
+                ? ResponseEntity.noContent().build()
+                : response;
+    }
+
+    private static boolean isRunNotTracked(ConnectorException ex) {
+        if (ex instanceof ConnectorEntityNotFoundException) {
+            return true;
+        }
+        return ex instanceof ConnectorProblemException cpe
+                && ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
+    }
+
+    /**
+     * An absent body is a non-conformant response, not "no items": a list route must return a JSON
+     * array, and reading a missing body as empty would make a broken connector indistinguishable from
+     * one that genuinely reports nothing — for {@code listSupportedResources} that is a distinction
+     * Core acts on. REST rejects it identically via {@code BaseApiClient.requireBody}, and the
+     * single-DTO operations here already throw, so all three agree.
+     *
+     * <p>The list is a fresh {@link ArrayList} rather than an {@link Arrays#asList} view because REST
+     * hands back a mutable Jackson list: a caller that sorts or filters in place must behave the same
+     * on both transports.
+     */
+    private static <T> List<T> toMutableList(T[] result, String operation, ApiClientConnectorInfo connector)
+            throws ConnectorException {
+        return new ArrayList<>(Arrays.asList(requireBody(result, operation, connector)));
+    }
+
+    /**
+     * The MQ counterpart of {@code BaseApiClient.requireBody}: for an operation whose 2xx response
+     * must carry a payload, a bodiless response is a connector contract violation, so it fails here
+     * naming the operation instead of returning the proxy's {@code null}. Unlike the REST side's
+     * {@link IllegalStateException} this uses the declared {@link ConnectorException} channel and
+     * attributes the failure to the connector, so a caller can both catch it and tell which
+     * connector produced it.
+     */
+    private static <T> T requireBody(T body, String operation, ApiClientConnectorInfo connector) throws ConnectorException {
+        if (body == null) {
+            throw new ConnectorException("Connector returned an empty body for " + operation, connector);
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClient.java
@@ -46,8 +46,6 @@ import java.util.Objects;
 @SuppressWarnings("java:S1075") // contract paths, not configurable URIs
 public class DiscoveryApiClient implements DiscoverySyncApiClient {
 
-
-
     private static final String HTTP_METHOD_GET = "GET";
     private static final String HTTP_METHOD_POST = "POST";
 
@@ -171,7 +169,11 @@ public class DiscoveryApiClient implements DiscoverySyncApiClient {
         if (ex instanceof ConnectorEntityNotFoundException) {
             return true;
         }
+        // Status gates the code: a not-tracked code is only legitimate on a 404. Cancel's own 422
+        // (past the point of no return) must reach the caller, and REGISTRATION_NOT_FOUND, which the
+        // shared predicate accepts as authority's flavour of not-tracked, is itself declared 422.
         return ex instanceof ConnectorProblemException cpe
+                && HttpStatus.NOT_FOUND.equals(cpe.getHttpStatus())
                 && ConnectorOperationErrorCodes.isOperationNotTracked(cpe.getProblemDetail().getErrorCode());
     }
 

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
@@ -1,0 +1,52 @@
+package com.otilm.api.clients.mq.discovery.v2;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Per-operation MQ timeouts for {@link DiscoveryApiClient}. A discovery drain can legitimately
+ * take far longer than a status poll or a lifecycle control call, so each is sized independently
+ * rather than sharing one proxy-wide default.
+ *
+ * <ul>
+ *   <li>{@link #status()} — the {@code status} poll.</li>
+ *   <li>{@link #drain()} — the {@code results} drain; deployments raise this when their connectors
+ *       return large batches.</li>
+ *   <li>{@link #control()} — {@code initiate}, {@code stop}, {@code resume}, {@code cancel}, and the
+ *       three metadata list operations.</li>
+ * </ul>
+ *
+ * <p>Every component must be a positive duration. A zero or negative timeout is a configuration
+ * error that would otherwise surface as an immediate, puzzling timeout on the first connector call,
+ * so it is rejected at construction — the same rule
+ * {@link com.otilm.api.clients.ClientTuning} applies to its own durations.
+ */
+public record DiscoveryMqTimeouts(Duration status, Duration drain, Duration control) {
+
+    public DiscoveryMqTimeouts {
+        requirePositive(status, "status");
+        requirePositive(drain, "drain");
+        requirePositive(control, "control");
+    }
+
+    /**
+     * A missing component stays a {@link NullPointerException} (it is a wiring bug, not a value out
+     * of range); a zero or negative one is an {@link IllegalArgumentException} carrying the message
+     * shape {@link com.otilm.api.clients.ClientTuning} uses, so both validators read alike.
+     */
+    private static void requirePositive(Duration value, String name) {
+        Objects.requireNonNull(value, name + " is required");
+        if (value.isNegative() || value.isZero()) {
+            throw new IllegalArgumentException(name + " must be a positive duration, was " + value);
+        }
+    }
+
+    /**
+     * 30 seconds for every component; deployments raise {@link #drain()} when their connectors
+     * return large batches.
+     */
+    public static DiscoveryMqTimeouts defaults() {
+        Duration thirtySeconds = Duration.ofSeconds(30);
+        return new DiscoveryMqTimeouts(thirtySeconds, thirtySeconds, thirtySeconds);
+    }
+}

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
@@ -16,9 +16,8 @@ import java.util.Objects;
  *       three metadata list operations.</li>
  * </ul>
  *
- * <p>Every component must be a positive duration. A zero or negative timeout is a configuration
- * error that would otherwise surface as an immediate, puzzling timeout on the first connector call,
- * so it is rejected at construction — the same rule
+ * <p>Every component must be a positive duration, rejected at construction rather than surfacing as
+ * an immediate timeout on the first connector call — the same rule
  * {@link com.otilm.api.clients.ClientTuning} applies to its own durations.
  */
 public record DiscoveryMqTimeouts(Duration status, Duration drain, Duration control) {
@@ -30,9 +29,9 @@ public record DiscoveryMqTimeouts(Duration status, Duration drain, Duration cont
     }
 
     /**
-     * A missing component stays a {@link NullPointerException} (it is a wiring bug, not a value out
-     * of range); a zero or negative one is an {@link IllegalArgumentException} carrying the message
-     * shape {@link com.otilm.api.clients.ClientTuning} uses, so both validators read alike.
+     * A missing component stays a {@link NullPointerException} — a wiring bug, not a value out of
+     * range; a zero or negative one is an {@link IllegalArgumentException} carrying the message shape
+     * {@link com.otilm.api.clients.ClientTuning} uses.
      */
     private static void requirePositive(Duration value, String name) {
         Objects.requireNonNull(value, name + " is required");
@@ -41,10 +40,7 @@ public record DiscoveryMqTimeouts(Duration status, Duration drain, Duration cont
         }
     }
 
-    /**
-     * 30 seconds for every component; deployments raise {@link #drain()} when their connectors
-     * return large batches.
-     */
+    /** 30 seconds for every component. */
     public static DiscoveryMqTimeouts defaults() {
         Duration thirtySeconds = Duration.ofSeconds(30);
         return new DiscoveryMqTimeouts(thirtySeconds, thirtySeconds, thirtySeconds);

--- a/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
+++ b/src/main/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryMqTimeouts.java
@@ -4,21 +4,19 @@ import java.time.Duration;
 import java.util.Objects;
 
 /**
- * Per-operation MQ timeouts for {@link DiscoveryApiClient}. A discovery drain can legitimately
- * take far longer than a status poll or a lifecycle control call, so each is sized independently
- * rather than sharing one proxy-wide default.
+ * Per-operation MQ timeouts for {@link DiscoveryApiClient}, sized independently because a drain can
+ * legitimately run far longer than a status poll or a lifecycle control call.
  *
  * <ul>
  *   <li>{@link #status()} — the {@code status} poll.</li>
- *   <li>{@link #drain()} — the {@code results} drain; deployments raise this when their connectors
- *       return large batches.</li>
- *   <li>{@link #control()} — {@code initiate}, {@code stop}, {@code resume}, {@code cancel}, and the
- *       three metadata list operations.</li>
+ *   <li>{@link #drain()} — the {@code results} drain; raised where connectors return large batches.</li>
+ *   <li>{@link #control()} — {@code initiate}, {@code stop}, {@code resume}, {@code cancel} and the
+ *       three metadata reads.</li>
  * </ul>
  *
- * <p>Every component must be a positive duration, rejected at construction rather than surfacing as
- * an immediate timeout on the first connector call — the same rule
- * {@link com.otilm.api.clients.ClientTuning} applies to its own durations.
+ * <p>Components must be positive, rejected at construction rather than surfacing as an immediate
+ * timeout on the first connector call — the rule {@link com.otilm.api.clients.ClientTuning} applies to
+ * its own durations.
  */
 public record DiscoveryMqTimeouts(Duration status, Duration drain, Duration control) {
 

--- a/src/main/java/com/otilm/api/exception/ConnectorServerException.java
+++ b/src/main/java/com/otilm/api/exception/ConnectorServerException.java
@@ -12,6 +12,11 @@ public class ConnectorServerException extends ConnectorException {
         this.httpStatus = httpStatus;
     }
 
+    public ConnectorServerException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
     public ConnectorServerException(HttpStatus httpStatus, ConnectorDto connector) {
         super(connector);
         this.httpStatus = httpStatus;

--- a/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
+++ b/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
@@ -23,25 +23,25 @@ import java.util.List;
  * <p>Return-type convention:
  * <ul>
  *   <li>{@code ResponseEntity<Void>} for cancel — the caller reads {@code 204} (cancelled) versus
- *       {@code 404} (the connector no longer tracks the run, which is the terminal state cancel was
- *       asking for, so it counts as success). Every other failure is thrown, including the {@code 422}
- *       past-the-point-of-no-return refusal; see the throws note below.</li>
- *   <li>plain DTOs for initiate and resume — both are always {@code 202 Accepted}, so there is no
- *       sync-versus-async ambiguity to disambiguate (unlike the v3 certificate client).</li>
+ *       {@code 404} (the connector no longer tracks the run, the terminal state cancel asked for, so it
+ *       counts as success). Every other failure is thrown, including the {@code 422} refusal for a run
+ *       past the point of no return.</li>
+ *   <li>plain DTOs for initiate and resume — both always {@code 202 Accepted}, so there is no
+ *       sync-versus-async ambiguity to resolve (unlike the v3 certificate client).</li>
  *   <li>plain DTOs for all other operations — listing, status queries, results drainage, stop.</li>
  * </ul>
  *
  * <p><b>Thrown failures are transport-dependent.</b> Over REST a connector's RFC 9457 body becomes a
  * {@code ConnectorProblemException} carrying its {@code ErrorCode}, so a caller can distinguish
  * {@code CHECKPOINT_LOST} from any other 410. Over MQ the proxy classifies by HTTP status alone and
- * discards the problem body, so no {@code ErrorCode} is available and a {@code 422} arrives as
- * {@code ValidationException} — which is unchecked, and so is not covered by the declared
- * {@code ConnectorException}. Do not write logic that assumes an {@code ErrorCode} is always present.
+ * discards the problem body, so no {@code ErrorCode} is available and a {@code 422} arrives as the
+ * unchecked {@code ValidationException}, uncovered by the declared {@code ConnectorException}. Never
+ * assume an {@code ErrorCode} is present.
  *
- * <p>Note: no {@code stream} method exists here, and none exists on the REST client either — the
- * contract's {@code POST /v2/discoveryProvider/discoveries/stream} has no client yet. Streaming can
- * only ever be REST: a held-open NDJSON response cannot traverse the AMQP proxy tunnel, which carries
- * one message per call. That is why it stays outside this shared abstraction.
+ * <p>No {@code stream} method exists here or on the REST client — the contract's
+ * {@code POST /v2/discoveryProvider/discoveries/stream} has no client yet. Streaming can only ever be
+ * REST: a held-open NDJSON response cannot traverse the AMQP proxy tunnel, which carries one message
+ * per call.
  */
 public interface DiscoverySyncApiClient {
 

--- a/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
+++ b/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
@@ -1,0 +1,71 @@
+package com.otilm.api.interfaces.client.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryDrainRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryRunRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStopResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
+import com.otilm.api.model.core.auth.Resource;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+/**
+ * Sync interface for v2 Discovery API client operations.
+ * Implemented by both REST and MQ clients.
+ *
+ * <p>Return-type convention:
+ * <ul>
+ *   <li>{@code ResponseEntity<Void>} for cancel — the caller reads {@code 204} (cancelled) versus
+ *       {@code 404} (the connector no longer tracks the run, which is the terminal state cancel was
+ *       asking for, so it counts as success). Every other failure is thrown, including the {@code 422}
+ *       past-the-point-of-no-return refusal; see the throws note below.</li>
+ *   <li>plain DTOs for initiate and resume — both are always {@code 202 Accepted}, so there is no
+ *       sync-versus-async ambiguity to disambiguate (unlike the v3 certificate client).</li>
+ *   <li>plain DTOs for all other operations — listing, status queries, results drainage, stop.</li>
+ * </ul>
+ *
+ * <p><b>Thrown failures are transport-dependent.</b> Over REST a connector's RFC 9457 body becomes a
+ * {@code ConnectorProblemException} carrying its {@code ErrorCode}, so a caller can distinguish
+ * {@code CHECKPOINT_LOST} from any other 410. Over MQ the proxy classifies by HTTP status alone and
+ * discards the problem body, so no {@code ErrorCode} is available and a {@code 422} arrives as
+ * {@code ValidationException} — which is unchecked, and so is not covered by the declared
+ * {@code ConnectorException}. Do not write logic that assumes an {@code ErrorCode} is always present.
+ *
+ * <p>Note: no {@code stream} method exists here, and none exists on the REST client either — the
+ * contract's {@code POST /v2/discoveryProvider/discoveries/stream} has no client yet. Streaming can
+ * only ever be REST: a held-open NDJSON response cannot traverse the AMQP proxy tunnel, which carries
+ * one message per call. That is why it stays outside this shared abstraction.
+ */
+public interface DiscoverySyncApiClient {
+
+    List<DiscoverySupportedResourceDto> listSupportedResources(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    List<BaseAttribute> listRunAttributes(ApiClientConnectorInfo connector) throws ConnectorException;
+
+    /**
+     * @param resource must be discoverable — {@link Resource#CERTIFICATE} or
+     *                 {@link Resource#CRYPTOGRAPHIC_KEY}, the two the contract defines payloads for.
+     *                 Both transports reject anything else with {@link IllegalArgumentException}.
+     */
+    List<BaseAttribute> listResourceAttributes(ApiClientConnectorInfo connector, Resource resource) throws ConnectorException;
+
+    DiscoveryInitiateResponseDto initiate(ApiClientConnectorInfo connector, DiscoveryInitiateRequestDto request) throws ConnectorException;
+
+    DiscoveryStatusResponseDto status(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException;
+
+    DiscoveryResultsResponseDto results(ApiClientConnectorInfo connector, DiscoveryDrainRequestDto request) throws ConnectorException;
+
+    DiscoveryStopResponseDto stop(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException;
+
+    DiscoveryInitiateResponseDto resume(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException;
+
+    ResponseEntity<Void> cancel(ApiClientConnectorInfo connector, DiscoveryRunRequestDto request) throws ConnectorException;
+
+}

--- a/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
+++ b/src/main/java/com/otilm/api/interfaces/client/v2/DiscoverySyncApiClient.java
@@ -38,6 +38,15 @@ import java.util.List;
  * unchecked {@code ValidationException}, uncovered by the declared {@code ConnectorException}. Never
  * assume an {@code ErrorCode} is present.
  *
+ * <p>The list-returning operations hand back a mutable list on both transports, so a caller may sort
+ * or filter the result in place.
+ *
+ * <p>A 2xx carrying no body at all is non-conformant and both transports reject it, but not with the
+ * same type: MQ raises a connector-attributed {@code ConnectorException} while REST surfaces the
+ * shared client's {@code IllegalStateException}, which is unchecked and so outside the declared
+ * throws. Making that uniform means retyping {@code BaseApiClient.processRequest}'s functional
+ * parameter, which is public API every connector compiles against, so it is stated here instead.
+ *
  * <p>No {@code stream} method exists here or on the REST client — the contract's
  * {@code POST /v2/discoveryProvider/discoveries/stream} has no client yet. Streaming can only ever be
  * REST: a held-open NDJSON response cannot traverse the AMQP proxy tunnel, which carries one message

--- a/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
+++ b/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
@@ -4,11 +4,8 @@ package com.otilm.api.model.common.error;
  * Shared classification of connector error codes whose meaning is the same across provider
  * interfaces.
  *
- * <p>Lives beside {@link ErrorCode} so every consumer classifies a code the same way. Core's
- * authority adapter and async poll listener carry an equivalent copy in
- * {@code com.otilm.core.service.handler.authority.ConnectorOperationErrorCodes}; that copy should
- * be retired in favour of this one, so a newly introduced code is recognised everywhere at once
- * instead of in whichever consumer remembered to add it.
+ * <p>Lives beside {@link ErrorCode} so every consumer classifies a code the same way, and a newly
+ * introduced code is recognised everywhere at once.
  */
 public final class ConnectorOperationErrorCodes {
 

--- a/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
+++ b/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
@@ -1,0 +1,30 @@
+package com.otilm.api.model.common.error;
+
+/**
+ * Shared classification of connector error codes whose meaning is the same across provider
+ * interfaces.
+ *
+ * <p>Lives beside {@link ErrorCode} so every consumer classifies a code the same way. Core's
+ * authority adapter and async poll listener carry an equivalent copy in
+ * {@code com.otilm.core.service.handler.authority.ConnectorOperationErrorCodes}; that copy should
+ * be retired in favour of this one, so a newly introduced code is recognised everywhere at once
+ * instead of in whichever consumer remembered to add it.
+ */
+public final class ConnectorOperationErrorCodes {
+
+    private ConnectorOperationErrorCodes() {
+    }
+
+    /**
+     * True when the connector reports that it no longer tracks — or never tracked — the operation,
+     * meaning the upstream handle is gone.
+     *
+     * <p>Callers treat this as a soft success for cancel-style operations, since an operation the
+     * connector cannot find is already in the terminal state cancel was asking for, and as a
+     * terminal failure when polling, since no amount of retrying will make the handle reappear.
+     */
+    public static boolean isOperationNotTracked(ErrorCode code) {
+        return code == ErrorCode.OPERATION_NOT_TRACKED
+                || code == ErrorCode.REGISTRATION_NOT_FOUND;
+    }
+}

--- a/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
+++ b/src/main/java/com/otilm/api/model/common/error/ConnectorOperationErrorCodes.java
@@ -4,8 +4,12 @@ package com.otilm.api.model.common.error;
  * Shared classification of connector error codes whose meaning is the same across provider
  * interfaces.
  *
- * <p>Lives beside {@link ErrorCode} so every consumer classifies a code the same way, and a newly
- * introduced code is recognised everywhere at once.
+ * <p>Lives beside {@link ErrorCode} so a consumer classifies a code the same way wherever it runs. It
+ * is not yet the platform's only copy: Core still owns an equivalent in
+ * {@code com.otilm.core.service.handler.authority.ConnectorOperationErrorCodes}, used by its authority
+ * adapter and status-poll listener. Retiring that one in favour of this is tracked in
+ * OmniTrustILM/core#1990; until then a code added here reaches this library's clients, not those two
+ * Core consumers.
  */
 public final class ConnectorOperationErrorCodes {
 

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -403,6 +403,34 @@ class BaseApiClientTest {
      * synthesized 413 would assert an upstream status that never existed and send operators looking
      * for a request-size problem instead of at this client's read cap.
      */
+    @Test
+    void processRequest_oversizedResponse_mappedToConnectorServerException() {
+        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
+        int smallCap = 1024;
+        WebClient tuned = BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(10), 5, Duration.ofSeconds(1), smallCap));
+        TestApiClient tunedClient = new TestApiClient(tuned);
+        mockServer.stubFor(get(urlEqualTo("/oversized")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("a".repeat(smallCap * 4))));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> tunedClient.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/oversized")
+                                .retrieve()
+                                .toEntity(String.class)
+                                .block(),
+                        null,
+                        connector));
+
+        // The stub answered 200; that is what must be reported, and it must NOT be PAYLOAD_TOO_LARGE.
+        Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
     /**
      * A connector whose body does not match the expected type is a connector fault, not a transport
      * failure and not the caller's mistake. It must report 502: Core serves 422 for a caller's own
@@ -438,6 +466,32 @@ class BaseApiClientTest {
     }
 
     /**
+     * The wrapping is not always one layer deep: {@code WebClient.retrieve()} can surface a
+     * {@code WebClientResponseException} around the {@code DecodingException} that Jackson's decode
+     * failure arrives in. A one-level check misses that, and the miss is worse than a wrong label —
+     * it reaches {@code processRequest}'s catch-all, which logs the exception message, and a Jackson
+     * message quotes the connector's response body.
+     */
+    @Test
+    void processRequest_deeplyWrappedJacksonFailure_isStillClassifiedAndDoesNotReachTheCatchAll() {
+        String secret = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A-buried-two-levels-down";
+        JsonProcessingException jackson = new com.fasterxml.jackson.databind.exc.MismatchedInputException(
+                null, "Cannot deserialize value: " + secret) {
+        };
+        Throwable twoLevels = new DecodingException("outer", new DecodingException("inner", jackson));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:1", AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw reactor.core.Exceptions.propagate(twoLevels);
+                }, null, connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus());
+        Assertions.assertFalse(ex.getMessage().contains(secret),
+                "the outward message must not echo the body, however deeply the failure was wrapped");
+    }
+
+    /**
      * The branch order matters: {@code JsonProcessingException} extends {@code IOException}, so a bare
      * Jackson failure reaching the transport branch first would be reported as a communication failure
      * (503, retryable) rather than a contract violation (502).
@@ -454,34 +508,6 @@ class BaseApiClientTest {
                 }, null, connector));
 
         Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus());
-    }
-
-    @Test
-    void processRequest_oversizedResponse_mappedToConnectorServerException() {
-        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
-        int smallCap = 1024;
-        WebClient tuned = BaseApiClient.prepareWebClient(
-                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(10), 5, Duration.ofSeconds(1), smallCap));
-        TestApiClient tunedClient = new TestApiClient(tuned);
-        mockServer.stubFor(get(urlEqualTo("/oversized")).willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "text/plain")
-                .withBody("a".repeat(smallCap * 4))));
-        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
-
-        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
-                BaseApiClient.processRequest(
-                        req -> tunedClient.prepareRequest(HttpMethod.GET, connector, false)
-                                .uri("http://localhost:" + mockServer.port() + "/oversized")
-                                .retrieve()
-                                .toEntity(String.class)
-                                .block(),
-                        null,
-                        connector));
-
-        // The stub answered 200; that is what must be reported, and it must NOT be PAYLOAD_TOO_LARGE.
-        Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
-        Assertions.assertEquals(connector, ex.getConnector());
     }
 
     /**

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.common.attribute.common.content.data.SecretAttributeC
 import com.otilm.api.model.common.attribute.v2.content.FileAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.SecretAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
 import com.otilm.api.exception.ConnectorServerException;
@@ -402,6 +403,59 @@ class BaseApiClientTest {
      * synthesized 413 would assert an upstream status that never existed and send operators looking
      * for a request-size problem instead of at this client's read cap.
      */
+    /**
+     * A connector whose body does not match the expected type is a connector fault, not a transport
+     * failure and not the caller's mistake. It must report 502: Core serves 422 for a caller's own
+     * invalid input, so classifying this as 422 would blame the user and invert the retry signal.
+     *
+     * <p>The secret this pins is the message. Jackson's own message quotes fragments of the response
+     * body, and in discovery a malformed body can carry key material, so the outward exception message
+     * must stay generic while the cause keeps the detail for diagnostics.
+     */
+    @Test
+    void processRequest_unparseableResponse_reportsBadGatewayWithoutEchoingTheBody() {
+        String secret = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A-not-for-logs";
+        JsonProcessingException jackson = new com.fasterxml.jackson.databind.exc.MismatchedInputException(
+                null, "Cannot deserialize value: " + secret) {
+        };
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:1", AuthType.NONE, List.of());
+
+        // Thrown through Reactor's propagate so processRequest's Exceptions.unwrap yields the Jackson
+        // exception itself. That matters: unwrap strips only Reactor wrappers, so if the fixture nested
+        // the Jackson failure inside a DecodingException, the message being interpolated would be the
+        // wrapper's ("decode failed") and this test could not detect the leak it exists to catch.
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw reactor.core.Exceptions.propagate(jackson);
+                }, null, connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus(),
+                "an unparseable connector response is a 502 upstream fault, never a 422 blamed on the caller");
+        Assertions.assertEquals(connector, ex.getConnector(), "the fault must name the connector that caused it");
+        Assertions.assertFalse(ex.getMessage().contains(secret),
+                "the outward message must not echo the connector's response body; Jackson's message quotes it");
+        Assertions.assertSame(jackson, ex.getCause(), "the cause must be retained for diagnostics");
+    }
+
+    /**
+     * The branch order matters: {@code JsonProcessingException} extends {@code IOException}, so a bare
+     * Jackson failure reaching the transport branch first would be reported as a communication failure
+     * (503, retryable) rather than a contract violation (502).
+     */
+    @Test
+    void processRequest_bareJacksonFailure_isNotMisreadAsATransportFailure() {
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:1", AuthType.NONE, List.of());
+        JsonProcessingException bare = new com.fasterxml.jackson.core.JsonParseException(null, "bad token") {
+        };
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw new RuntimeException(bare);
+                }, null, connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus());
+    }
+
     @Test
     void processRequest_oversizedResponse_mappedToConnectorServerException() {
         BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -423,6 +423,65 @@ class BaseApiClientTest {
     }
 
     /**
+     * A 422 and a problem+json response are read as a typed body rather than a string, so each needed
+     * its own empty-body fallback: an empty source never runs {@code flatMap}, and the status would
+     * otherwise vanish into an unmapped {@code IllegalStateException} instead of the mapped
+     * {@code ConnectorException} the client promises.
+     */
+    @Test
+    void bodilessValidationResponseStillMapsToValidationException() {
+        mockServer.stubFor(get(urlEqualTo("/empty-422")).willReturn(aResponse().withStatus(422)));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        Assertions.assertThrows(ValidationException.class, () ->
+                BaseApiClient.processRequest(r -> r
+                                .uri("http://localhost:" + mockServer.port() + "/empty-422")
+                                .retrieve().toBodilessEntity().block(),
+                        client.prepareRequest(HttpMethod.GET, connector, false), connector));
+    }
+
+    @Test
+    void bodilessProblemJsonResponseMapsByStatusInsteadOfEscaping() {
+        mockServer.stubFor(get(urlEqualTo("/empty-problem")).willReturn(aResponse()
+                .withStatus(502)
+                .withHeader("Content-Type", "application/problem+json")));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(r -> r
+                                .uri("http://localhost:" + mockServer.port() + "/empty-problem")
+                                .retrieve().toBodilessEntity().block(),
+                        client.prepareRequest(HttpMethod.GET, connector, false), connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus(),
+                "with no problem body there is no ErrorCode to carry, so the status alone must classify it");
+    }
+
+    /**
+     * Core's {@code handleConnectorServerException} copies the exception message verbatim into its 502
+     * response body, and already appends the connector's name and uuid itself. So the connector URL in
+     * the message bought nothing for attribution while exposing internal topology — and any credentials
+     * carried in user-info or a query string — to whoever called the platform API.
+     */
+    @Test
+    void outwardConnectorFailureMessagesDoNotCarryTheConnectorUrl() {
+        String url = "https://svc-user:s3cret@internal-connector.svc.cluster.local:8443/api";
+        TestConnectorInfo connector = new TestConnectorInfo(url, AuthType.NONE, List.of());
+        JsonProcessingException jackson = new com.fasterxml.jackson.databind.exc.MismatchedInputException(
+                null, "bad shape") {
+        };
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw reactor.core.Exceptions.propagate(jackson);
+                }, null, connector));
+
+        Assertions.assertFalse(ex.getMessage().contains(url), "the outward message must not carry the URL");
+        Assertions.assertFalse(ex.getMessage().contains("s3cret"), "credentials in the URL must never reach a caller");
+        Assertions.assertEquals(connector, ex.getConnector(), "attribution stays on the exception, not in the message");
+    }
+
+    /**
      * A connector whose body does not match the expected type is a connector fault, not a transport
      * failure and not the caller's mistake. It must report 502: Core serves 422 for a caller's own
      * invalid input, so 422 here would blame the user and invert the retry signal.

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -11,7 +11,10 @@ import com.otilm.api.model.common.attribute.common.content.data.SecretAttributeC
 import com.otilm.api.model.common.attribute.v2.content.FileAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.SecretAttributeContentV2;
 import com.otilm.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
+import com.otilm.api.exception.ConnectorServerException;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.core.connector.AuthType;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.proxy.ProxyDto;
@@ -19,7 +22,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.ByteArrayInputStream;
@@ -53,6 +59,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class BaseApiClientTest {
 
+    /**
+     * The default in-memory response cap, read from {@link ClientTuning} rather than restated here:
+     * these cases only need "the cap this library ships with", and a literal copy would silently
+     * disagree with the record if the default ever moved.
+     */
+    private static final int DEFAULT_MAX_IN_MEMORY = ClientTuning.defaults().maxInMemorySize();
+
     private WireMockServer mockServer;
     private TestApiClient client;
 
@@ -75,6 +88,29 @@ class BaseApiClientTest {
         } finally {
             BaseApiClient.resetConnectorClientForTest();
         }
+    }
+
+    /**
+     * A zero-length body is the case {@code bodyToMono} completes empty for, so without
+     * {@code defaultIfEmpty} the {@code flatMap} never runs, the filter completes empty, and the
+     * failure escapes as an unmapped {@code IllegalStateException} instead of the mapped connector
+     * exception. Realistic from a reverse proxy that sets {@code text/html} and sends no body.
+     */
+    @Test
+    void unexpectedContentTypeWithEmptyBodyStillMapsToAConnectorException() {
+        mockServer.stubFor(get(urlEqualTo("/html-empty")).willReturn(aResponse()
+                .withStatus(502)
+                .withHeader("Content-Type", "text/html")));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        Assertions.assertThrows(ConnectorCommunicationException.class, () ->
+                BaseApiClient.processRequest(r -> r
+                                .uri("http://localhost:" + mockServer.port() + "/html-empty")
+                                .retrieve()
+                                .toBodilessEntity()
+                                .block(),
+                        client.prepareRequest(HttpMethod.GET, connector, false),
+                        connector));
     }
 
     @Test
@@ -294,7 +330,7 @@ class BaseApiClientTest {
     void prepareRequest_slowResponse_failsFastWithinResponseTimeout() {
         BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
         WebClient tuned = BaseApiClient.prepareWebClient(
-                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
+                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1), DEFAULT_MAX_IN_MEMORY));
         TestApiClient tunedClient = new TestApiClient(tuned);
         mockServer.stubFor(get(urlEqualTo("/slow")).willReturn(aResponse().withStatus(200).withFixedDelay(5000)));
         TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
@@ -334,7 +370,7 @@ class BaseApiClientTest {
     void processRequest_responseTimeout_mappedToConnectorCommunicationException() {
         BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
         WebClient tuned = BaseApiClient.prepareWebClient(
-                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1)));
+                new ClientTuning(Duration.ofSeconds(1), Duration.ofMillis(500), 5, Duration.ofSeconds(1), DEFAULT_MAX_IN_MEMORY));
         TestApiClient tunedClient = new TestApiClient(tuned);
         mockServer.stubFor(get(urlEqualTo("/slow")).willReturn(aResponse().withStatus(200).withFixedDelay(5000)));
         TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
@@ -345,6 +381,227 @@ class BaseApiClientTest {
                                 .uri("http://localhost:" + mockServer.port() + "/slow")
                                 .retrieve()
                                 .toBodilessEntity()
+                                .block(),
+                        null,
+                        connector));
+    }
+
+    /**
+     * A response exceeding the codec's {@code maxInMemorySize} (here: {@link ClientTuning}) must
+     * be classified as a connector fault ({@link ConnectorServerException}), not escape unmapped —
+     * {@code WebClient.retrieve()} wraps the codec's {@code DataBufferLimitException} into a
+     * {@link org.springframework.web.reactive.function.client.WebClientResponseException} while
+     * decoding the response body, which callers declaring {@code throws ConnectorException} could
+     * not otherwise catch, and which would never be attributed to a connector. Decoding to
+     * {@code String} (rather than a DTO) keeps this test's stubbed body trivially "valid" for any
+     * size, isolating the size gate from any parse-validity concern.
+     *
+     * <p>The mapped status must be the one the connector actually sent — {@code 200} here — not a
+     * synthesized {@code 413}. Core's {@code ExceptionHandlingAdvice.handleConnectorServerException}
+     * appends "Original response code &lt;status&gt;" to the operator-facing error verbatim, so a
+     * synthesized 413 would assert an upstream status that never existed and send operators looking
+     * for a request-size problem instead of at this client's read cap.
+     */
+    @Test
+    void processRequest_oversizedResponse_mappedToConnectorServerException() {
+        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
+        int smallCap = 1024;
+        WebClient tuned = BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(10), 5, Duration.ofSeconds(1), smallCap));
+        TestApiClient tunedClient = new TestApiClient(tuned);
+        mockServer.stubFor(get(urlEqualTo("/oversized")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("a".repeat(smallCap * 4))));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> tunedClient.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/oversized")
+                                .retrieve()
+                                .toEntity(String.class)
+                                .block(),
+                        null,
+                        connector));
+
+        // The stub answered 200; that is what must be reported, and it must NOT be PAYLOAD_TOO_LARGE.
+        Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * A read-limit breach that reaches {@code processRequest} without a
+     * {@link org.springframework.web.reactive.function.client.WebClientResponseException} around it
+     * carries no upstream status at all — there is nothing to report. {@link HttpStatus#BAD_GATEWAY}
+     * is the honest answer (the connector's response was unusable and it sits upstream of us), and
+     * again not a synthesized {@code 413}.
+     */
+    @Test
+    void processRequest_bareOversizedResponse_reportsBadGatewayRatherThanASynthesizedStatus() {
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw new DataBufferLimitException("Exceeded limit on max bytes to buffer : 1024");
+                }, null, connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY, ex.getHttpStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * The read-limit breach need not sit at the top of the chain or one level under it. Spring's
+     * {@code Jackson2JsonDecoder} raises a {@link DecodingException} around a decode failure — the
+     * same wrapping {@code isJsonTypeResolutionFailure} already has to see through — so a breach can
+     * arrive two or more levels down. Matching only the bare form and the immediate cause of a
+     * {@code WebClientResponseException} let that escape to {@code processRequest}'s catch-all and
+     * surface to the caller as a Spring-internal type, which is precisely the gap the
+     * oversized-response branch exists to close.
+     */
+    @Test
+    void processRequest_deeplyWrappedOversizedResponse_stillMappedToConnectorServerException() {
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+        DataBufferLimitException limitBreach = new DataBufferLimitException("Exceeded limit on max bytes to buffer : 1024");
+        // Two levels of wrapping: the decoder's DecodingException, itself wrapped once more.
+        DecodingException decodingFailure = new DecodingException("Could not read document", limitBreach);
+        IllegalStateException outer = new IllegalStateException("wrapped once more", decodingFailure);
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw outer;
+                }, null, connector));
+
+        Assertions.assertEquals(connector, ex.getConnector());
+        Assertions.assertSame(outer, ex.getCause());
+    }
+
+    /**
+     * The cause-chain walk runs inside an exception handler, so it must terminate on a cyclic chain —
+     * an infinite loop there would be far worse than the misclassification the walk prevents. The two
+     * exceptions below cause each other, which the walk's cheap self-cause check cannot detect: only
+     * its depth bound stops it. Preemptive timeout rather than a plain assertion because the failure
+     * mode being guarded is a hang, which no assertion would ever reach.
+     */
+    @Test
+    void processRequest_cyclicCauseChain_terminatesInsteadOfSpinning() {
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+        CyclicCauseException first = new CyclicCauseException("cycle head");
+        CyclicCauseException second = new CyclicCauseException("cycle tail");
+        first.causedBy(second);
+        second.causedBy(first);
+
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+                Assertions.assertThrows(ValidationException.class, () ->
+                        BaseApiClient.processRequest(req -> {
+                            throw first;
+                        }, null, connector)));
+    }
+
+    /**
+     * A cause cycle of length two. Deliberately not a self-cause: {@code a -> b -> a} is invisible to
+     * an {@code exception == exception.getCause()} check, so only a bounded walk survives it.
+     * {@link ValidationException} is the carrier so {@code processRequest} classifies it as a business
+     * error and logs the message alone — logging the throwable would hand the cycle to the logging
+     * framework's own stack-trace renderer, testing that instead of this class.
+     */
+    private static class CyclicCauseException extends ValidationException {
+        private transient Throwable partner;
+
+        CyclicCauseException(String message) {
+            super(message);
+        }
+
+        void causedBy(Throwable cause) {
+            this.partner = cause;
+        }
+
+        @Override
+        public synchronized Throwable getCause() {
+            return partner;
+        }
+    }
+
+    /**
+     * A connector answering an error status with a zero-length body must still produce the mapped
+     * {@link ConnectorClientException}. {@code bodyToMono(String.class)} completes empty for a bodiless
+     * response and an empty source never runs {@code flatMap}, so without a default the whole response
+     * filter completes empty: {@code requireResponse} then sees a null entity and throws
+     * {@link IllegalStateException}, which {@code processRequest} rethrows unmapped — past every caller
+     * catching {@code ConnectorException}, and losing the status entirely. A Go connector's
+     * {@code w.WriteHeader(400)} sends exactly this shape.
+     */
+    @Test
+    void processRequest_bodilessClientError_stillMappedToConnectorClientException() {
+        mockServer.stubFor(get(urlEqualTo("/bodiless-400")).willReturn(aResponse().withStatus(400)));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorClientException ex = Assertions.assertThrows(ConnectorClientException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> BaseApiClient.requireResponse(client.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/bodiless-400")
+                                .retrieve()
+                                .toEntity(String.class), "bodiless 400"),
+                        null,
+                        connector));
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /** The 5xx half of the bodiless-error mapping; see the 4xx case above for why it is needed. */
+    @Test
+    void processRequest_bodilessServerError_stillMappedToConnectorServerException() {
+        mockServer.stubFor(get(urlEqualTo("/bodiless-500")).willReturn(aResponse().withStatus(500)));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        ConnectorServerException ex = Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> BaseApiClient.requireResponse(client.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/bodiless-500")
+                                .retrieve()
+                                .toEntity(String.class), "bodiless 500"),
+                        null,
+                        connector));
+
+        Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getHttpStatus());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * Write-once tuning has two halves, and only the first was covered. A later caller asking for
+     * different tuning is warned and ignored — but it still receives a {@code WebClient}, and that
+     * client must enforce the tuning that <em>won</em>, not the tuning it asked for. Every other case
+     * in this class claims the tuning first, so the ignored-caller branch never ran: building the
+     * returned client from the caller's own tuning instead of the applied tuning would hand out a
+     * client whose read cap disagrees with the one live {@code HttpClient}, and the suite would stay
+     * green.
+     *
+     * <p>The stubbed body is sized between the two caps — over the cap that won, comfortably under the
+     * one the second caller asked for — so only the winning cap can produce a failure here.
+     */
+    @Test
+    void prepareWebClient_laterDifferingTuning_stillEnforcesTheWinningCap() {
+        BaseApiClient.resetConnectorClientForTest(); // claim write-once tuning for this test
+        int winningCap = 1024;
+        BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(10), 5, Duration.ofSeconds(1), winningCap));
+        WebClient later = BaseApiClient.prepareWebClient(
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(10), 5, Duration.ofSeconds(1), winningCap * 64));
+        TestApiClient laterClient = new TestApiClient(later);
+
+        mockServer.stubFor(get(urlEqualTo("/between-caps")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("a".repeat(winningCap * 4))));
+        TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
+
+        Assertions.assertThrows(ConnectorServerException.class, () ->
+                BaseApiClient.processRequest(
+                        req -> laterClient.prepareRequest(HttpMethod.GET, connector, false)
+                                .uri("http://localhost:" + mockServer.port() + "/between-caps")
+                                .retrieve()
+                                .toEntity(String.class)
                                 .block(),
                         null,
                         connector));

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -478,6 +478,29 @@ class BaseApiClientTest {
     }
 
     /**
+     * The URL was moved out of the outward messages and into the logs, which only relocated the risk:
+     * a configured connector URL can carry {@code user:password@} or a token in its query string, and a
+     * log outlives the request that wrote it. Host, port and path stay — internal topology is fine
+     * server-side and is what places a failure — while user-info and query never appear.
+     */
+    @Test
+    void safeLocation_keepsTheEndpointAndDropsAnythingSecret() {
+        Assertions.assertEquals("https://connector.svc:8443/api",
+                BaseApiClient.safeLocation(new TestConnectorInfo(
+                        "https://svc-user:s3cret@connector.svc:8443/api?token=abc123",
+                        AuthType.NONE, List.of())));
+
+        Assertions.assertEquals("http://plain.local",
+                BaseApiClient.safeLocation(new TestConnectorInfo("http://plain.local", AuthType.NONE, List.of())));
+
+        Assertions.assertEquals("<no url>",
+                BaseApiClient.safeLocation(new TestConnectorInfo(null, AuthType.NONE, List.of())));
+
+        Assertions.assertEquals("<unparseable url>",
+                BaseApiClient.safeLocation(new TestConnectorInfo("not a url", AuthType.NONE, List.of())));
+    }
+
+    /**
      * Core's {@code handleConnectorServerException} copies the exception message verbatim into its 502
      * response body, and already appends the connector's name and uuid itself. So the connector URL in
      * the message bought nothing for attribution while exposing internal topology — and any credentials

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -60,11 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class BaseApiClientTest {
 
-    /**
-     * The default in-memory response cap, read from {@link ClientTuning} rather than restated here:
-     * these cases only need "the cap this library ships with", and a literal copy would silently
-     * disagree with the record if the default ever moved.
-     */
+    /** Read from {@link ClientTuning} so a literal copy cannot drift from the record's default. */
     private static final int DEFAULT_MAX_IN_MEMORY = ClientTuning.defaults().maxInMemorySize();
 
     private WireMockServer mockServer;
@@ -92,10 +88,10 @@ class BaseApiClientTest {
     }
 
     /**
-     * A zero-length body is the case {@code bodyToMono} completes empty for, so without
-     * {@code defaultIfEmpty} the {@code flatMap} never runs, the filter completes empty, and the
-     * failure escapes as an unmapped {@code IllegalStateException} instead of the mapped connector
-     * exception. Realistic from a reverse proxy that sets {@code text/html} and sends no body.
+     * {@code bodyToMono} completes empty for a zero-length body, so without {@code defaultIfEmpty} the
+     * {@code flatMap} never runs and the failure escapes as an unmapped
+     * {@code IllegalStateException}. Realistic from a reverse proxy that sets {@code text/html} and
+     * sends no body.
      */
     @Test
     void unexpectedContentTypeWithEmptyBodyStillMapsToAConnectorException() {
@@ -388,20 +384,15 @@ class BaseApiClientTest {
     }
 
     /**
-     * A response exceeding the codec's {@code maxInMemorySize} (here: {@link ClientTuning}) must
-     * be classified as a connector fault ({@link ConnectorServerException}), not escape unmapped —
-     * {@code WebClient.retrieve()} wraps the codec's {@code DataBufferLimitException} into a
-     * {@link org.springframework.web.reactive.function.client.WebClientResponseException} while
-     * decoding the response body, which callers declaring {@code throws ConnectorException} could
-     * not otherwise catch, and which would never be attributed to a connector. Decoding to
-     * {@code String} (rather than a DTO) keeps this test's stubbed body trivially "valid" for any
-     * size, isolating the size gate from any parse-validity concern.
+     * A response exceeding the codec's {@code maxInMemorySize} must be classified as a connector fault
+     * ({@link ConnectorServerException}), not escape unmapped as the
+     * {@link org.springframework.web.reactive.function.client.WebClientResponseException} that
+     * {@code retrieve()} wraps it in. Decoding to {@code String} rather than a DTO keeps the stubbed
+     * body trivially valid at any size, isolating the size gate from parse validity.
      *
-     * <p>The mapped status must be the one the connector actually sent — {@code 200} here — not a
-     * synthesized {@code 413}. Core's {@code ExceptionHandlingAdvice.handleConnectorServerException}
-     * appends "Original response code &lt;status&gt;" to the operator-facing error verbatim, so a
-     * synthesized 413 would assert an upstream status that never existed and send operators looking
-     * for a request-size problem instead of at this client's read cap.
+     * <p>The mapped status must be the one the connector actually sent ({@code 200} here), never a
+     * synthesized {@code 413}: Core's {@code ExceptionHandlingAdvice} appends "Original response code
+     * &lt;status&gt;" to the operator-facing error verbatim.
      */
     @Test
     void processRequest_oversizedResponse_mappedToConnectorServerException() {
@@ -434,11 +425,11 @@ class BaseApiClientTest {
     /**
      * A connector whose body does not match the expected type is a connector fault, not a transport
      * failure and not the caller's mistake. It must report 502: Core serves 422 for a caller's own
-     * invalid input, so classifying this as 422 would blame the user and invert the retry signal.
+     * invalid input, so 422 here would blame the user and invert the retry signal.
      *
-     * <p>The secret this pins is the message. Jackson's own message quotes fragments of the response
-     * body, and in discovery a malformed body can carry key material, so the outward exception message
-     * must stay generic while the cause keeps the detail for diagnostics.
+     * <p>The message is the other half. Jackson's own message quotes fragments of the response body,
+     * and in discovery that can carry key material, so the outward exception message must stay generic
+     * while the cause keeps the detail.
      */
     @Test
     void processRequest_unparseableResponse_reportsBadGatewayWithoutEchoingTheBody() {
@@ -466,11 +457,10 @@ class BaseApiClientTest {
     }
 
     /**
-     * The wrapping is not always one layer deep: {@code WebClient.retrieve()} can surface a
-     * {@code WebClientResponseException} around the {@code DecodingException} that Jackson's decode
-     * failure arrives in. A one-level check misses that, and the miss is worse than a wrong label —
-     * it reaches {@code processRequest}'s catch-all, which logs the exception message, and a Jackson
-     * message quotes the connector's response body.
+     * The wrapping is not always one layer deep: {@code retrieve()} can surface a
+     * {@code WebClientResponseException} around the {@code DecodingException} the Jackson failure
+     * arrives in. A one-level check misses that, and the miss reaches {@code processRequest}'s
+     * catch-all, which logs the exception message — which quotes the connector's response body.
      */
     @Test
     void processRequest_deeplyWrappedJacksonFailure_isStillClassifiedAndDoesNotReachTheCatchAll() {
@@ -511,11 +501,10 @@ class BaseApiClientTest {
     }
 
     /**
-     * A read-limit breach that reaches {@code processRequest} without a
+     * A read-limit breach reaching {@code processRequest} without a
      * {@link org.springframework.web.reactive.function.client.WebClientResponseException} around it
-     * carries no upstream status at all — there is nothing to report. {@link HttpStatus#BAD_GATEWAY}
-     * is the honest answer (the connector's response was unusable and it sits upstream of us), and
-     * again not a synthesized {@code 413}.
+     * carries no upstream status to report, so {@link HttpStatus#BAD_GATEWAY} is the answer — again
+     * not a synthesized {@code 413}.
      */
     @Test
     void processRequest_bareOversizedResponse_reportsBadGatewayRatherThanASynthesizedStatus() {
@@ -531,19 +520,15 @@ class BaseApiClientTest {
     }
 
     /**
-     * The read-limit breach need not sit at the top of the chain or one level under it. Spring's
-     * {@code Jackson2JsonDecoder} raises a {@link DecodingException} around a decode failure — the
-     * same wrapping {@code isJsonTypeResolutionFailure} already has to see through — so a breach can
-     * arrive two or more levels down. Matching only the bare form and the immediate cause of a
-     * {@code WebClientResponseException} let that escape to {@code processRequest}'s catch-all and
-     * surface to the caller as a Spring-internal type, which is precisely the gap the
-     * oversized-response branch exists to close.
+     * The read-limit breach need not sit at the top of the chain or one level under it: Spring's
+     * {@code Jackson2JsonDecoder} raises a {@link DecodingException} around a decode failure, so a
+     * breach can arrive two or more levels down. Matching only the bare form and one level of wrapping
+     * lets that escape to {@code processRequest}'s catch-all and surface as a Spring-internal type.
      */
     @Test
     void processRequest_deeplyWrappedOversizedResponse_stillMappedToConnectorServerException() {
         TestConnectorInfo connector = new TestConnectorInfo("http://localhost:" + mockServer.port(), AuthType.NONE, List.of());
         DataBufferLimitException limitBreach = new DataBufferLimitException("Exceeded limit on max bytes to buffer : 1024");
-        // Two levels of wrapping: the decoder's DecodingException, itself wrapped once more.
         DecodingException decodingFailure = new DecodingException("Could not read document", limitBreach);
         IllegalStateException outer = new IllegalStateException("wrapped once more", decodingFailure);
 
@@ -557,11 +542,10 @@ class BaseApiClientTest {
     }
 
     /**
-     * The cause-chain walk runs inside an exception handler, so it must terminate on a cyclic chain —
-     * an infinite loop there would be far worse than the misclassification the walk prevents. The two
-     * exceptions below cause each other, which the walk's cheap self-cause check cannot detect: only
-     * its depth bound stops it. Preemptive timeout rather than a plain assertion because the failure
-     * mode being guarded is a hang, which no assertion would ever reach.
+     * The cause-chain walk runs inside an exception handler, so it must terminate on a cyclic chain.
+     * The two exceptions below cause each other, which the walk's cheap self-cause check cannot
+     * detect: only its depth bound stops it. Preemptive timeout because the failure mode guarded
+     * against is a hang, which no assertion would ever reach.
      */
     @Test
     void processRequest_cyclicCauseChain_terminatesInsteadOfSpinning() {
@@ -581,9 +565,9 @@ class BaseApiClientTest {
     /**
      * A cause cycle of length two. Deliberately not a self-cause: {@code a -> b -> a} is invisible to
      * an {@code exception == exception.getCause()} check, so only a bounded walk survives it.
-     * {@link ValidationException} is the carrier so {@code processRequest} classifies it as a business
-     * error and logs the message alone — logging the throwable would hand the cycle to the logging
-     * framework's own stack-trace renderer, testing that instead of this class.
+     * {@link ValidationException} is the carrier so {@code processRequest} logs the message alone —
+     * logging the throwable would hand the cycle to the logging framework's stack-trace renderer,
+     * testing that instead of this class.
      */
     private static class CyclicCauseException extends ValidationException {
         private transient Throwable partner;
@@ -605,11 +589,9 @@ class BaseApiClientTest {
     /**
      * A connector answering an error status with a zero-length body must still produce the mapped
      * {@link ConnectorClientException}. {@code bodyToMono(String.class)} completes empty for a bodiless
-     * response and an empty source never runs {@code flatMap}, so without a default the whole response
-     * filter completes empty: {@code requireResponse} then sees a null entity and throws
-     * {@link IllegalStateException}, which {@code processRequest} rethrows unmapped — past every caller
-     * catching {@code ConnectorException}, and losing the status entirely. A Go connector's
-     * {@code w.WriteHeader(400)} sends exactly this shape.
+     * response and an empty source never runs {@code flatMap}, so without a default the response filter
+     * completes empty, {@code requireResponse} sees a null entity, and the status is lost to an unmapped
+     * {@link IllegalStateException}. A Go connector's {@code w.WriteHeader(400)} sends this shape.
      */
     @Test
     void processRequest_bodilessClientError_stillMappedToConnectorClientException() {
@@ -649,16 +631,13 @@ class BaseApiClientTest {
     }
 
     /**
-     * Write-once tuning has two halves, and only the first was covered. A later caller asking for
-     * different tuning is warned and ignored — but it still receives a {@code WebClient}, and that
-     * client must enforce the tuning that <em>won</em>, not the tuning it asked for. Every other case
-     * in this class claims the tuning first, so the ignored-caller branch never ran: building the
-     * returned client from the caller's own tuning instead of the applied tuning would hand out a
-     * client whose read cap disagrees with the one live {@code HttpClient}, and the suite would stay
-     * green.
+     * A later caller asking for different tuning is warned and ignored, but it still receives a
+     * {@code WebClient}, and that client must enforce the tuning that <em>won</em>, not the tuning it
+     * asked for. Building it from the caller's own tuning would hand out a client whose read cap
+     * disagrees with the one live {@code HttpClient}.
      *
-     * <p>The stubbed body is sized between the two caps — over the cap that won, comfortably under the
-     * one the second caller asked for — so only the winning cap can produce a failure here.
+     * <p>The stubbed body is sized between the two caps — over the winning cap, well under the one the
+     * second caller asked for — so only the winning cap can fail here.
      */
     @Test
     void prepareWebClient_laterDifferingTuning_stillEnforcesTheWinningCap() {

--- a/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/BaseApiClientTest.java
@@ -458,6 +458,26 @@ class BaseApiClientTest {
     }
 
     /**
+     * The same rule for the communication failure. Its handler maps to 503 and copies the message the
+     * same way, so a URL here reached callers identically — this one predated the discovery work, which
+     * is the only reason it survived two rounds of cleaning the neighbouring messages.
+     */
+    @Test
+    void communicationFailureMessageDoesNotCarryTheConnectorUrl() {
+        String url = "https://svc-user:s3cret@internal-connector.svc.cluster.local:9999/api";
+        TestConnectorInfo connector = new TestConnectorInfo(url, AuthType.NONE, List.of());
+
+        ConnectorCommunicationException ex = Assertions.assertThrows(ConnectorCommunicationException.class, () ->
+                BaseApiClient.processRequest(req -> {
+                    throw reactor.core.Exceptions.propagate(new java.net.ConnectException("refused"));
+                }, null, connector));
+
+        Assertions.assertFalse(ex.getMessage().contains(url), "the outward message must not carry the URL");
+        Assertions.assertFalse(ex.getMessage().contains("s3cret"), "credentials in the URL must never reach a caller");
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
      * Core's {@code handleConnectorServerException} copies the exception message verbatim into its 502
      * response body, and already appends the connector's name and uuid itself. So the connector URL in
      * the message bought nothing for attribution while exposing internal topology — and any credentials

--- a/src/test/java/com/otilm/api/clients/ClientTuningTest.java
+++ b/src/test/java/com/otilm/api/clients/ClientTuningTest.java
@@ -8,11 +8,8 @@ import java.time.Duration;
 class ClientTuningTest {
 
     /**
-     * Regression guard for the four-argument, source-compatible constructor kept for callers built
-     * against this record before {@code maxInMemorySize} existed (e.g. Core's
-     * {@code ApplicationConfig}). If this overload is ever "tidied away" or its delegation stops
-     * applying the 16 MiB default, this fails — a compile error alone would not catch a wrong
-     * default silently taking its place.
+     * Regression guard for the four-argument, source-compatible constructor. A compile error alone
+     * would not catch a wrong default silently taking the 16 MiB one's place.
      */
     @Test
     void fourArgConstructor_usesDefaultMaxInMemorySize() {
@@ -22,12 +19,10 @@ class ClientTuningTest {
     }
 
     /**
-     * The canonical constructor's {@code maxInMemorySize} guard, which nothing else covered — the
-     * four-argument overload can never reach it, since it always supplies the positive default. A
-     * non-positive cap is not a harmless value to wave through: Spring's codec treats it as the byte
-     * limit, so it would fail every response rather than none, and the failure would surface as an
-     * oversized-response error on every single connector call sharing the WebClient. Without this
-     * case the guard could be deleted outright with the suite still green.
+     * The canonical constructor's {@code maxInMemorySize} guard; the four-argument overload can never
+     * reach it, since it always supplies the positive default. A non-positive cap is not harmless:
+     * Spring's codec treats it as the byte limit, so it would fail every response on every connector
+     * call sharing the WebClient.
      */
     @Test
     void canonicalConstructor_rejectsNonPositiveMaxInMemorySize() {

--- a/src/test/java/com/otilm/api/clients/ClientTuningTest.java
+++ b/src/test/java/com/otilm/api/clients/ClientTuningTest.java
@@ -1,0 +1,40 @@
+package com.otilm.api.clients;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+class ClientTuningTest {
+
+    /**
+     * Regression guard for the four-argument, source-compatible constructor kept for callers built
+     * against this record before {@code maxInMemorySize} existed (e.g. Core's
+     * {@code ApplicationConfig}). If this overload is ever "tidied away" or its delegation stops
+     * applying the 16 MiB default, this fails — a compile error alone would not catch a wrong
+     * default silently taking its place.
+     */
+    @Test
+    void fourArgConstructor_usesDefaultMaxInMemorySize() {
+        ClientTuning tuning = new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10));
+
+        Assertions.assertEquals(16 * 1024 * 1024, tuning.maxInMemorySize());
+    }
+
+    /**
+     * The canonical constructor's {@code maxInMemorySize} guard, which nothing else covered — the
+     * four-argument overload can never reach it, since it always supplies the positive default. A
+     * non-positive cap is not a harmless value to wave through: Spring's codec treats it as the byte
+     * limit, so it would fail every response rather than none, and the failure would surface as an
+     * oversized-response error on every single connector call sharing the WebClient. Without this
+     * case the guard could be deleted outright with the suite still green.
+     */
+    @Test
+    void canonicalConstructor_rejectsNonPositiveMaxInMemorySize() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10), 0));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10), -1));
+    }
+}

--- a/src/test/java/com/otilm/api/clients/ClientTuningTest.java
+++ b/src/test/java/com/otilm/api/clients/ClientTuningTest.java
@@ -26,10 +26,17 @@ class ClientTuningTest {
      */
     @Test
     void canonicalConstructor_rejectsNonPositiveMaxInMemorySize() {
-        Assertions.assertThrows(IllegalArgumentException.class, () ->
-                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10), 0));
+        // Built outside the lambdas so the constructor is the only call inside one: with the Duration
+        // factories in there too, the assertion would also pass if one of those threw, which is not
+        // what is under test.
+        Duration connect = Duration.ofSeconds(3);
+        Duration response = Duration.ofSeconds(35);
+        Duration pendingAcquire = Duration.ofSeconds(10);
 
         Assertions.assertThrows(IllegalArgumentException.class, () ->
-                new ClientTuning(Duration.ofSeconds(3), Duration.ofSeconds(35), 20, Duration.ofSeconds(10), -1));
+                new ClientTuning(connect, response, 20, pendingAcquire, 0));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new ClientTuning(connect, response, 20, pendingAcquire, -1));
     }
 }

--- a/src/test/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClientTest.java
@@ -93,9 +93,8 @@ class DiscoveryApiClientTest {
         Assertions.assertEquals(2, result.size());
         Assertions.assertEquals(Resource.CERTIFICATE, result.get(0).getResource());
         Assertions.assertEquals(Resource.CRYPTOGRAPHIC_KEY, result.get(1).getResource());
-        // Absent (entry 0) vs empty (entry 1) capabilities are contractually distinct — see
-        // DiscoverySupportedResourceDto's javadoc — and a client round-trip is exactly where a
-        // careless deserializer would normalize one into the other.
+        // Absent (entry 0) vs empty (entry 1) capabilities are contractually distinct, and a client
+        // round-trip is where a careless deserializer would normalize one into the other.
         Assertions.assertNull(result.get(0).getCapabilities());
         Assertions.assertNotNull(result.get(1).getCapabilities());
         Assertions.assertTrue(result.get(1).getCapabilities().isEmpty());
@@ -103,9 +102,7 @@ class DiscoveryApiClientTest {
 
     /**
      * The list operations decode an array and wrap it, so the wrapper — not Jackson or Reactor —
-     * decides mutability. Both transports must hand back a list a caller can sort or filter in place;
-     * the MQ client documents the same contract, and a caller that works on one transport must not
-     * break on the other.
+     * decides mutability. Both transports must hand back a list a caller can sort or filter in place.
      */
     @Test
     void listSupportedResources_returnsMutableList() throws ConnectorException {
@@ -166,9 +163,8 @@ class DiscoveryApiClientTest {
     /**
      * Body matchers, not just path and method: without them a client that dropped {@code .body(...)},
      * sent the wrong DTO, or lost {@code runId} would still match the stub and pass. The
-     * {@code resources} entry is pinned to the wire code {@code "certificates"}, never the Java enum
-     * name {@code CERTIFICATE} — the request body is the other half of the wire-code contract already
-     * pinned on the path side by {@code listResourceAttributes_usesResourceWireCodeInPath}.
+     * {@code resources} entry pins the wire code {@code "certificates"} — the request-body half of the
+     * wire-code contract {@code listResourceAttributes_usesResourceWireCodeInPath} pins on the path.
      */
     @Test
     void initiate_returnsMeta() throws ConnectorException {
@@ -283,9 +279,9 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * A 404 on cancel means the run is already terminal — Core treats this as success, so the
-     * client MUST surface it via the returned {@code ResponseEntity}'s status, never as a thrown
-     * exception. This is the entire reason {@code cancel} returns {@code ResponseEntity<Void>}.
+     * A 404 on cancel means the run is already terminal, i.e. success, so the client must surface it
+     * via the returned {@code ResponseEntity}'s status, never as a thrown exception. That is the reason
+     * {@code cancel} returns {@code ResponseEntity<Void>}.
      */
     @Test
     void cancel_404IsReturnedAsStatusNotException() throws ConnectorException {
@@ -305,10 +301,9 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * A conformant not-tracked 404 needs no operator attention — the connector said in so many words
-     * that it does not track the run — so it must NOT produce the diagnostic WARN reserved for the
-     * ambiguous bare-404 fallback. Without this, the WARN would fire on every routine cancel of an
-     * already-finished run and train operators to ignore it.
+     * A conformant not-tracked 404 needs no operator attention, so it must not produce the diagnostic
+     * WARN reserved for the ambiguous bare-404 fallback — which would otherwise fire on every routine
+     * cancel of an already-finished run and train operators to ignore it.
      */
     @Test
     void cancel_conformantNotTracked404DoesNotWarn() throws ConnectorException {
@@ -336,11 +331,11 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * The not-tracked rule is {@link com.otilm.api.model.common.error.ConnectorOperationErrorCodes},
-     * the single shared definition beside {@code ErrorCode}, not a local one-code comparison — it
-     * recognises {@code REGISTRATION_NOT_FOUND} as well as {@code OPERATION_NOT_TRACKED}. Pinning the
-     * second code keeps this client, the MQ client and Core classifying a connector's answer
-     * identically instead of each remembering a different subset of the codes.
+     * The not-tracked rule is the shared
+     * {@link com.otilm.api.model.common.error.ConnectorOperationErrorCodes}, not a local one-code
+     * comparison, so it recognises {@code REGISTRATION_NOT_FOUND} as well as
+     * {@code OPERATION_NOT_TRACKED}. Pinning the second code keeps every consumer classifying a
+     * connector's answer identically.
      */
     @Test
     void cancel_registrationNotFoundIsSwallowedViaSharedRule() throws ConnectorException {
@@ -360,9 +355,9 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * Regression guard on the 404-swallowing branch added for cancel: a 422 refusal (run past the
-     * point of no return) is a real failure and MUST still throw, proving the special-case only
-     * intercepts a not-tracked answer, not every {@link ConnectorProblemException}.
+     * A 422 refusal (run past the point of no return) is a real failure and must still throw, so the
+     * 404-swallowing branch intercepts only a not-tracked answer, not every
+     * {@link ConnectorProblemException}.
      */
     @Test
     void cancel_422StillThrows() {
@@ -396,11 +391,11 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * A terse-but-conformant connector can answer 404 without an {@code application/problem+json}
-     * body (a framework-default error page, for instance). {@code BaseApiClient}'s legacy fallback
-     * maps that shape to {@link com.otilm.api.exception.ConnectorEntityNotFoundException} rather
-     * than {@link ConnectorProblemException} — cancel must still swallow it into a
-     * {@code ResponseEntity} status, or a legitimately-terminal run would be reported as a failure.
+     * A terse-but-conformant connector can answer 404 without an {@code application/problem+json} body.
+     * {@code BaseApiClient}'s legacy fallback maps that shape to
+     * {@link com.otilm.api.exception.ConnectorEntityNotFoundException} rather than
+     * {@link ConnectorProblemException}, and cancel must accept it too, or a legitimately-terminal run
+     * would be reported as a failure.
      */
     @Test
     void cancel_legacyNotFoundIsReturnedAsStatusNotException() throws ConnectorException {
@@ -423,15 +418,12 @@ class DiscoveryApiClientTest {
      * {@code w.WriteHeader(404)} sends exactly that, and cancel is the likeliest place to meet it since
      * the route is declared bodiless even on success.
      *
-     * <p>That shape used to escape the mapping entirely. {@code BaseApiClient}'s legacy 404 branch reads
-     * the body for the exception message with {@code bodyToMono(String.class).flatMap(...)}, which never
-     * runs for a zero-length body — so the response filter completed empty, no connector exception was
-     * ever raised, and an {@link IllegalStateException} escaped instead ("The underlying HTTP client
-     * completed without emitting a response" on this bodiless route, {@code requireResponse}'s own
-     * message on routes that decode a body). {@code processRequest}'s final {@code else} rethrows that
-     * unmapped, so {@code cancel}'s {@code onErrorResume} never saw a
-     * {@code ConnectorEntityNotFoundException} and a legitimately-terminal run reached Core as a hard
-     * failure of an unrelated, uncatchable type.
+     * <p>{@code BaseApiClient}'s legacy 404 branch reads the body for the exception message with
+     * {@code bodyToMono(String.class).flatMap(...)}, which never runs for a zero-length body. Without
+     * a {@code defaultIfEmpty} the response filter completes empty, no connector exception is raised,
+     * and an unmapped {@link IllegalStateException} escapes instead — so {@code cancel}'s
+     * {@code onErrorResume} never sees a {@code ConnectorEntityNotFoundException} and a
+     * legitimately-terminal run reaches Core as a hard failure of an uncatchable type.
      */
     @Test
     void cancel_bodiless404IsReturnedAsStatusNotIllegalState() throws ConnectorException {
@@ -447,13 +439,11 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * The lenient bare-404 fallback above is kept because a terse 404 genuinely is ambiguous, but it
-     * must be diagnosable: the shared connector contract documents 404 as "endpoint not found or not
-     * implemented" too (see {@code AuthProtectedConnectorController}), and the body stubbed here is
-     * exactly Spring's unmapped-route error page. A connector that never implemented
-     * {@code /discoveries/cancel}, or one reached through a stale base URL, is otherwise reported to
-     * Core as an already-terminal cancellation — a silently failed abort. So the swallow must log at
-     * WARN, and the line must name both the connector and the path an operator has to go check.
+     * The lenient bare-404 fallback must stay diagnosable: the shared connector contract also documents
+     * 404 as "endpoint not found or not implemented", and the body stubbed here is Spring's
+     * unmapped-route error page. A connector that never implemented {@code /discoveries/cancel}, or one
+     * reached through a stale base URL, would otherwise be reported as an already-terminal cancellation
+     * — a silently failed abort. So the WARN must name both the connector and the path to go check.
      */
     @Test
     void cancel_bare404IsSwallowedButWarnsNamingConnectorAndPath() throws ConnectorException {
@@ -487,9 +477,8 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * Every other lifecycle call (here: status) keeps the standard mapping — a 404 surfaces as
-     * {@link ConnectorProblemException} with {@code errorCode=OPERATION_NOT_TRACKED} — unlike
-     * cancel, which is special-cased.
+     * Every other lifecycle call keeps the standard mapping — a 404 surfaces as
+     * {@link ConnectorProblemException} with {@code errorCode=OPERATION_NOT_TRACKED} — unlike cancel.
      */
     @Test
     void status_404MapsToOperationNotTracked() {
@@ -586,39 +575,28 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * A {@code results} page larger than the configured read cap must fail fast — never buffer
-     * an unbounded/malicious response into memory.
+     * A {@code results} page larger than the configured read cap must fail fast rather than buffer an
+     * unbounded response into memory.
      *
-     * <p>The read cap is {@code ClientTuning.maxInMemorySize} on the shared {@code WebClient} —
-     * see {@code DiscoveryApiClient}'s class javadoc — so it can't be dialed down for just
-     * this test via the shared, process-wide {@code BaseApiClient.prepareWebClient()} singleton
-     * without either being ignored (if another test already claimed the default tuning first) or
-     * permanently shrinking the cap for every other test in the same JVM run. Instead this test
-     * builds its own throwaway {@code WebClient} with a small cap, proving the exact contract this
-     * client depends on: whatever cap the injected {@code WebClient} enforces, {@code results}
-     * surfaces the resulting failure through the standard error path rather than swallowing it.
+     * <p>The cap lives on the shared {@code WebClient}, so it cannot be dialed down through the
+     * process-wide {@code BaseApiClient.prepareWebClient()} singleton without either being ignored
+     * (another test may have claimed the tuning first) or shrinking the cap for every other test in the
+     * JVM run. Hence the throwaway small-cap client.
      *
-     * <p>The stubbed body is genuine, syntactically valid JSON — a real {@code DiscoveryResultsResponseDto}
-     * shape plus one padding field — sized comfortably over the cap, so the failure demonstrably
-     * comes from the size gate tripping before parsing, not from malformed input coincidentally
-     * failing around the same size.
+     * <p>The stubbed body is syntactically valid JSON — a real {@code DiscoveryResultsResponseDto} shape
+     * plus one padding field — so the failure comes from the size gate tripping before parsing, not
+     * from malformed input failing around the same size.
      *
-     * <p>The cap is enforced by the codec while decoding the (2xx) response body, a step that
-     * runs inside {@code WebClient.retrieve()} itself. Spring's {@code retrieve()} wraps any
-     * body-decode failure — including a codec limit breach — into a {@link WebClientResponseException}
-     * so the failure still carries the response's status/headers; the original
-     * {@link DataBufferLimitException} survives as its cause. {@code BaseApiClient.processRequest}
-     * now maps that (either shape) to {@code ConnectorServerException} (see {@code BaseApiClientTest}
-     * for that mapping's own direct coverage) — asserted here via the class this client's caller
-     * actually sees.
+     * <p>The codec enforces the cap while decoding the 2xx body, inside {@code retrieve()}, which wraps
+     * the breach in a {@link WebClientResponseException} carrying the response status and keeping the
+     * original {@link DataBufferLimitException} as its cause. Asserted here through the exception class
+     * this client's caller actually sees.
      */
     @Test
     void results_oversizedResponse_failsInsteadOfBuffering() {
         int smallCap = 8 * 1024;
         DiscoveryApiClient smallCapClient = smallCapClient(smallCap);
 
-        // Genuinely valid JSON — a real DiscoveryResultsResponseDto shape with one oversized
-        // padding string — at 4x the cap (32 KB body against an 8 KB cap).
         String oversizedBody = "{\"items\":[],\"highestSequence\":0,\"more\":false,\"padding\":\""
                 + "a".repeat(smallCap * 4) + "\"}";
         mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/results")
@@ -634,8 +612,7 @@ class DiscoveryApiClientTest {
                 ConnectorServerException.class,
                 () -> smallCapClient.results(connector, request));
 
-        // The status carried is the one the connector really sent (200), not a synthesized 413 — see
-        // BaseApiClient.upstreamStatus and BaseApiClientTest for that mapping's own coverage.
+        // The status is the one the connector really sent (200), not a synthesized 413.
         Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
         Assertions.assertInstanceOf(WebClientResponseException.class, ex.getCause());
         Assertions.assertInstanceOf(DataBufferLimitException.class, ex.getCause().getCause());
@@ -644,23 +621,20 @@ class DiscoveryApiClientTest {
     /**
      * The read cap must bound a whole list response, not each of its elements.
      *
-     * <p>This is the case the cap silently failed to cover: {@code toEntityList(X.class)} streams the
-     * array through Spring's {@code Jackson2Tokenizer}, whose {@code assertInMemorySize} resets its
-     * byte counter every time a top-level element completes, so the cap degrades into a per-element
-     * cap and the {@code collectList} that assembles the result is unbounded. Every element below is
-     * a couple of dozen bytes — far under the cap — while the array as a whole is several times over
-     * it, which is exactly the shape a connector returning a million tiny objects would produce, and
-     * exactly the shape an element-wise cap waves through. Decoding an array type instead routes
-     * through the codec's bounded {@code decodeToMono}, so the whole response is measured and the
-     * call fails rather than assembling.
+     * <p>{@code toEntityList(X.class)} streams the array through Spring's {@code Jackson2Tokenizer},
+     * whose {@code assertInMemorySize} resets its byte counter every time a top-level element
+     * completes, so the cap degrades into a per-element cap and the {@code collectList} assembling the
+     * result is unbounded. Every element below is a couple of dozen bytes while the array as a whole is
+     * several times over the cap — the shape a connector returning a million tiny objects produces, and
+     * the shape an element-wise cap waves through. Decoding an array type instead routes through the
+     * codec's bounded {@code decodeToMono}, so the whole response is measured.
      */
     @Test
     void listSupportedResources_oversizedArrayOfSmallElements_failsInsteadOfAssembling() {
         int smallCap = 8 * 1024;
         DiscoveryApiClient smallCapClient = smallCapClient(smallCap);
 
-        // ~27 bytes per element, 1000 elements: no single element is anywhere near the cap, the array
-        // is roughly 3.5x over it.
+        // ~27 bytes per element, 1000 elements: no element is near the cap, the array is ~3.5x over it.
         String oversizedArray = "[" + String.join(",",
                 Collections.nCopies(1000, "{\"resource\":\"certificates\"}")) + "]";
         Assertions.assertTrue(oversizedArray.length() > smallCap * 3,
@@ -680,10 +654,9 @@ class DiscoveryApiClientTest {
     }
 
     /**
-     * A throwaway {@code WebClient} with its own small read cap. The shared
+     * A throwaway {@code WebClient} with its own small read cap, because the shared
      * {@code BaseApiClient.prepareWebClient()} singleton cannot be re-tuned per test — see
-     * {@code results_oversizedResponse_failsInsteadOfBuffering} for why — so cap-sensitive cases
-     * build their own.
+     * {@code results_oversizedResponse_failsInsteadOfBuffering}.
      */
     private DiscoveryApiClient smallCapClient(int maxInMemorySize) {
         WebClient smallCapWebClient = WebClient.builder()
@@ -712,7 +685,7 @@ class DiscoveryApiClientTest {
 
     /**
      * Spring's default unmapped-route error page: a 404 with no {@code application/problem+json} body,
-     * which is what a connector that never implemented the endpoint actually returns.
+     * what a connector that never implemented the endpoint returns.
      */
     private static String springDefaultErrorPage() {
         return "{\"timestamp\":\"2026-08-06T10:00:00Z\",\"status\":404,\"error\":\"Not Found\","
@@ -722,11 +695,11 @@ class DiscoveryApiClientTest {
     /**
      * Attach a recorder to this client's own logger so a test can assert on the events it emits.
      *
-     * <p>logback-classic is this module's SLF4J provider (slf4j-simple is on the test classpath too
-     * but loses provider selection), so the SLF4J logger really is a logback one; asserting the type
-     * makes a provider change fail loudly instead of silently skipping the log assertions. The level
-     * is pinned so the assertions do not depend on the ambient root level, and restored to inherited
-     * afterwards — the module ships no logback configuration, so inherited is the original state.
+     * <p>logback-classic is this module's SLF4J provider (slf4j-simple is on the test classpath too but
+     * loses provider selection), so asserting the type makes a provider change fail loudly instead of
+     * silently skipping the log assertions. The level is pinned so the assertions do not depend on the
+     * ambient root level, and restored to inherited — the module ships no logback configuration, so
+     * inherited is the original state.
      */
     private static ListAppender<ILoggingEvent> attachClientLogRecorder() {
         Logger clientLogger = Assertions.assertInstanceOf(Logger.class,

--- a/src/test/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClientTest.java
+++ b/src/test/java/com/otilm/api/clients/discovery/v2/DiscoveryApiClientTest.java
@@ -1,0 +1,755 @@
+package com.otilm.api.clients.discovery.v2;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.clients.BaseApiClient;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.exception.ConnectorServerException;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryDrainRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryRunRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStopResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.connector.ConnectorDto;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.buffer.DataBufferLimitException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+class DiscoveryApiClientTest {
+
+    private static final UUID RUN_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+    /** Named so the swallowed-404 WARN can be asserted to identify the connector it came from. */
+    private static final String CONNECTOR_NAME = "discovery-connector-under-test";
+
+    private static final String CANCEL_PATH = "/v2/discoveryProvider/discoveries/cancel";
+
+    private DiscoveryApiClient client;
+    private ConnectorDto connector;
+    private WireMockServer mockServer;
+
+    @BeforeEach
+    void setUp() {
+        client = new DiscoveryApiClient(BaseApiClient.prepareWebClient(), null);
+
+        mockServer = new WireMockServer(options().dynamicPort());
+        mockServer.start();
+        WireMock.configureFor("localhost", mockServer.port());
+
+        connector = new ConnectorDto();
+        connector.setName(CONNECTOR_NAME);
+        connector.setUrl("http://localhost:" + mockServer.port());
+        connector.setStatus(ConnectorStatus.CONNECTED);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+    }
+
+    @Test
+    void listSupportedResources_returnsResources() throws ConnectorException {
+        String json = """
+                [
+                  { "resource": "certificates" },
+                  { "resource": "keys", "capabilities": [] }
+                ]
+                """;
+        mockServer.stubFor(WireMock.get("/v2/discoveryProvider/resources")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(json)));
+
+        List<DiscoverySupportedResourceDto> result = client.listSupportedResources(connector);
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(Resource.CERTIFICATE, result.get(0).getResource());
+        Assertions.assertEquals(Resource.CRYPTOGRAPHIC_KEY, result.get(1).getResource());
+        // Absent (entry 0) vs empty (entry 1) capabilities are contractually distinct — see
+        // DiscoverySupportedResourceDto's javadoc — and a client round-trip is exactly where a
+        // careless deserializer would normalize one into the other.
+        Assertions.assertNull(result.get(0).getCapabilities());
+        Assertions.assertNotNull(result.get(1).getCapabilities());
+        Assertions.assertTrue(result.get(1).getCapabilities().isEmpty());
+    }
+
+    /**
+     * The list operations decode an array and wrap it, so the wrapper — not Jackson or Reactor —
+     * decides mutability. Both transports must hand back a list a caller can sort or filter in place;
+     * the MQ client documents the same contract, and a caller that works on one transport must not
+     * break on the other.
+     */
+    @Test
+    void listSupportedResources_returnsMutableList() throws ConnectorException {
+        mockServer.stubFor(WireMock.get("/v2/discoveryProvider/resources")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"resource\":\"certificates\"}]")));
+
+        List<DiscoverySupportedResourceDto> result = client.listSupportedResources(connector);
+
+        Assertions.assertDoesNotThrow(() -> result.add(new DiscoverySupportedResourceDto()));
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    void listRunAttributes_returnsAttributes() throws ConnectorException {
+        String json = """
+                [
+                  { "uuid": "11111111-1111-1111-1111-111111111111", "name": "targetAddress", "type": "data", "contentType": "string", "version": 2 }
+                ]
+                """;
+        mockServer.stubFor(WireMock.get("/v2/discoveryProvider/attributes")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(json)));
+
+        List<BaseAttribute> result = client.listRunAttributes(connector);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("targetAddress", result.get(0).getName());
+    }
+
+    /**
+     * The path segment is the resource's wire code ({@code "keys"}), never the Java enum name
+     * ({@code CRYPTOGRAPHIC_KEY}) — verified by pinning the stub to the literal path.
+     */
+    @Test
+    void listResourceAttributes_usesResourceWireCodeInPath() throws ConnectorException {
+        String json = """
+                [
+                  { "uuid": "22222222-2222-2222-2222-222222222222", "name": "keySize", "type": "data", "contentType": "integer", "version": 2 }
+                ]
+                """;
+        mockServer.stubFor(WireMock.get("/v2/discoveryProvider/keys/attributes")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(json)));
+
+        List<BaseAttribute> result = client.listResourceAttributes(connector, Resource.CRYPTOGRAPHIC_KEY);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("keySize", result.get(0).getName());
+    }
+
+    /**
+     * Body matchers, not just path and method: without them a client that dropped {@code .body(...)},
+     * sent the wrong DTO, or lost {@code runId} would still match the stub and pass. The
+     * {@code resources} entry is pinned to the wire code {@code "certificates"}, never the Java enum
+     * name {@code CERTIFICATE} — the request body is the other half of the wire-code contract already
+     * pinned on the path side by {@code listResourceAttributes_usesResourceWireCodeInPath}.
+     */
+    @Test
+    void initiate_returnsMeta() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/initiate")
+                .withRequestBody(WireMock.matchingJsonPath("$.runId", WireMock.equalTo(RUN_ID.toString())))
+                .withRequestBody(WireMock.matchingJsonPath("$.resources[0]", WireMock.equalTo("certificates")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(202)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"meta\":[]}")));
+
+        DiscoveryInitiateRequestDto request = new DiscoveryInitiateRequestDto();
+        request.setRunId(RUN_ID);
+        request.setResources(List.of(Resource.CERTIFICATE));
+
+        DiscoveryInitiateResponseDto response = client.initiate(connector, request);
+
+        Assertions.assertNotNull(response.getMeta());
+        Assertions.assertTrue(response.getMeta().isEmpty());
+    }
+
+    /** Pins the run-request body shape (the DTO shared by status, stop, resume and cancel). */
+    @Test
+    void status_returnsRunState() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/status")
+                .withRequestBody(WireMock.matchingJsonPath("$.runId", WireMock.equalTo(RUN_ID.toString())))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"state\":\"running\",\"highestSequence\":42}")));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        DiscoveryStatusResponseDto response = client.status(connector, request);
+
+        Assertions.assertEquals("running", response.getState().getCode());
+        Assertions.assertEquals(42L, response.getHighestSequence());
+    }
+
+    /**
+     * Pins the drain body shape, including the {@code afterSequence} cursor — a drain that silently
+     * lost its cursor would re-read the run from the start on every poll, which no response assertion
+     * would notice.
+     */
+    @Test
+    void results_returnsPage() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/results")
+                .withRequestBody(WireMock.matchingJsonPath("$.runId", WireMock.equalTo(RUN_ID.toString())))
+                .withRequestBody(WireMock.matchingJsonPath("$.afterSequence", WireMock.equalTo("12")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"items\":[],\"highestSequence\":7,\"more\":false}")));
+
+        DiscoveryDrainRequestDto request = new DiscoveryDrainRequestDto();
+        request.setRunId(RUN_ID);
+        request.setAfterSequence(12L);
+
+        DiscoveryResultsResponseDto response = client.results(connector, request);
+
+        Assertions.assertTrue(response.getItems().isEmpty());
+        Assertions.assertEquals(7L, response.getHighestSequence());
+        Assertions.assertEquals(Boolean.FALSE, response.getMore());
+    }
+
+    @Test
+    void stop_returnsMeta() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/stop")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"meta\":[]}")));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        DiscoveryStopResponseDto response = client.stop(connector, request);
+
+        Assertions.assertNotNull(response.getMeta());
+        Assertions.assertTrue(response.getMeta().isEmpty());
+    }
+
+    @Test
+    void resume_returnsMeta() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/resume")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(202)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("{\"meta\":[]}")));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        DiscoveryInitiateResponseDto response = client.resume(connector, request);
+
+        Assertions.assertNotNull(response.getMeta());
+        Assertions.assertTrue(response.getMeta().isEmpty());
+    }
+
+    @Test
+    void cancel_204OnSuccess() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse().withStatus(204)));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ResponseEntity<Void> response = client.cancel(connector, request);
+
+        Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    /**
+     * A 404 on cancel means the run is already terminal — Core treats this as success, so the
+     * client MUST surface it via the returned {@code ResponseEntity}'s status, never as a thrown
+     * exception. This is the entire reason {@code cancel} returns {@code ResponseEntity<Void>}.
+     */
+    @Test
+    void cancel_404IsReturnedAsStatusNotException() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(notTrackedProblemJson("OPERATION_NOT_TRACKED",
+                                "https://docs.otilm.com/problems/connector/discovery/OPERATION_NOT_TRACKED"))));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ResponseEntity<Void> response = client.cancel(connector, request);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    /**
+     * A conformant not-tracked 404 needs no operator attention — the connector said in so many words
+     * that it does not track the run — so it must NOT produce the diagnostic WARN reserved for the
+     * ambiguous bare-404 fallback. Without this, the WARN would fire on every routine cancel of an
+     * already-finished run and train operators to ignore it.
+     */
+    @Test
+    void cancel_conformantNotTracked404DoesNotWarn() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(notTrackedProblemJson("OPERATION_NOT_TRACKED",
+                                "https://docs.otilm.com/problems/connector/discovery/OPERATION_NOT_TRACKED"))));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ListAppender<ILoggingEvent> recorder = attachClientLogRecorder();
+        ResponseEntity<Void> response;
+        try {
+            response = client.cancel(connector, request);
+        } finally {
+            detachClientLogRecorder(recorder);
+        }
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assertions.assertTrue(warnings(recorder).isEmpty(),
+                () -> "a conformant not-tracked 404 must not warn, got " + recorder.list);
+    }
+
+    /**
+     * The not-tracked rule is {@link com.otilm.api.model.common.error.ConnectorOperationErrorCodes},
+     * the single shared definition beside {@code ErrorCode}, not a local one-code comparison — it
+     * recognises {@code REGISTRATION_NOT_FOUND} as well as {@code OPERATION_NOT_TRACKED}. Pinning the
+     * second code keeps this client, the MQ client and Core classifying a connector's answer
+     * identically instead of each remembering a different subset of the codes.
+     */
+    @Test
+    void cancel_registrationNotFoundIsSwallowedViaSharedRule() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(notTrackedProblemJson("REGISTRATION_NOT_FOUND",
+                                "https://docs.otilm.com/problems/connector/authority/REGISTRATION_NOT_FOUND"))));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ResponseEntity<Void> response = client.cancel(connector, request);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    /**
+     * Regression guard on the 404-swallowing branch added for cancel: a 422 refusal (run past the
+     * point of no return) is a real failure and MUST still throw, proving the special-case only
+     * intercepts a not-tracked answer, not every {@link ConnectorProblemException}.
+     */
+    @Test
+    void cancel_422StillThrows() {
+        String problemJson = """
+                {
+                  "type": "https://docs.otilm.com/problems/connector/OPERATION_PAST_POINT_OF_NO_RETURN",
+                  "title": "Cancel refused — operation past point of no return",
+                  "status": 422,
+                  "detail": "runId 33333333-3333-3333-3333-333333333333 already committed upstream",
+                  "errorCode": "OPERATION_PAST_POINT_OF_NO_RETURN",
+                  "timestamp": "2026-08-04T10:00:00Z",
+                  "correlationId": "test-corr-cancel-422",
+                  "retryable": false
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(422)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(problemJson)));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ConnectorProblemException ex = Assertions.assertThrows(
+                ConnectorProblemException.class,
+                () -> client.cancel(connector, request));
+
+        Assertions.assertEquals(ErrorCode.OPERATION_PAST_POINT_OF_NO_RETURN, ex.getProblemDetail().getErrorCode());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * A terse-but-conformant connector can answer 404 without an {@code application/problem+json}
+     * body (a framework-default error page, for instance). {@code BaseApiClient}'s legacy fallback
+     * maps that shape to {@link com.otilm.api.exception.ConnectorEntityNotFoundException} rather
+     * than {@link ConnectorProblemException} — cancel must still swallow it into a
+     * {@code ResponseEntity} status, or a legitimately-terminal run would be reported as a failure.
+     */
+    @Test
+    void cancel_legacyNotFoundIsReturnedAsStatusNotException() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(springDefaultErrorPage())));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ResponseEntity<Void> response = client.cancel(connector, request);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    /**
+     * The terse 404 can be terser still: no body at all, and no {@code Content-Type}. A Go connector's
+     * {@code w.WriteHeader(404)} sends exactly that, and cancel is the likeliest place to meet it since
+     * the route is declared bodiless even on success.
+     *
+     * <p>That shape used to escape the mapping entirely. {@code BaseApiClient}'s legacy 404 branch reads
+     * the body for the exception message with {@code bodyToMono(String.class).flatMap(...)}, which never
+     * runs for a zero-length body — so the response filter completed empty, no connector exception was
+     * ever raised, and an {@link IllegalStateException} escaped instead ("The underlying HTTP client
+     * completed without emitting a response" on this bodiless route, {@code requireResponse}'s own
+     * message on routes that decode a body). {@code processRequest}'s final {@code else} rethrows that
+     * unmapped, so {@code cancel}'s {@code onErrorResume} never saw a
+     * {@code ConnectorEntityNotFoundException} and a legitimately-terminal run reached Core as a hard
+     * failure of an unrelated, uncatchable type.
+     */
+    @Test
+    void cancel_bodiless404IsReturnedAsStatusNotIllegalState() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse().withStatus(404)));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ResponseEntity<Void> response = client.cancel(connector, request);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    /**
+     * The lenient bare-404 fallback above is kept because a terse 404 genuinely is ambiguous, but it
+     * must be diagnosable: the shared connector contract documents 404 as "endpoint not found or not
+     * implemented" too (see {@code AuthProtectedConnectorController}), and the body stubbed here is
+     * exactly Spring's unmapped-route error page. A connector that never implemented
+     * {@code /discoveries/cancel}, or one reached through a stale base URL, is otherwise reported to
+     * Core as an already-terminal cancellation — a silently failed abort. So the swallow must log at
+     * WARN, and the line must name both the connector and the path an operator has to go check.
+     */
+    @Test
+    void cancel_bare404IsSwallowedButWarnsNamingConnectorAndPath() throws ConnectorException {
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/cancel")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(springDefaultErrorPage())));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ListAppender<ILoggingEvent> recorder = attachClientLogRecorder();
+        ResponseEntity<Void> response;
+        try {
+            response = client.cancel(connector, request);
+        } finally {
+            detachClientLogRecorder(recorder);
+        }
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        List<ILoggingEvent> warnings = warnings(recorder);
+        Assertions.assertEquals(1, warnings.size(),
+                () -> "expected exactly one WARN for the swallowed bare 404, got " + recorder.list);
+        String message = warnings.get(0).getFormattedMessage();
+        Assertions.assertTrue(message.contains(CONNECTOR_NAME),
+                () -> "the WARN must name the connector: " + message);
+        Assertions.assertTrue(message.contains(CANCEL_PATH),
+                () -> "the WARN must name the path: " + message);
+    }
+
+    /**
+     * Every other lifecycle call (here: status) keeps the standard mapping — a 404 surfaces as
+     * {@link ConnectorProblemException} with {@code errorCode=OPERATION_NOT_TRACKED} — unlike
+     * cancel, which is special-cased.
+     */
+    @Test
+    void status_404MapsToOperationNotTracked() {
+        String problemJson = """
+                {
+                  "type": "https://docs.otilm.com/problems/connector/discovery/OPERATION_NOT_TRACKED",
+                  "title": "Async operation no longer tracked by connector",
+                  "status": 404,
+                  "detail": "runId 33333333-3333-3333-3333-333333333333 not tracked",
+                  "errorCode": "OPERATION_NOT_TRACKED",
+                  "timestamp": "2026-08-04T10:00:00Z",
+                  "correlationId": "test-corr-status-404",
+                  "retryable": false
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/status")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(problemJson)));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ConnectorProblemException ex = Assertions.assertThrows(
+                ConnectorProblemException.class,
+                () -> client.status(connector, request));
+
+        Assertions.assertEquals(ErrorCode.OPERATION_NOT_TRACKED, ex.getProblemDetail().getErrorCode());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    @Test
+    void initiate_422MapsToValidationFailed() {
+        String problemJson = """
+                {
+                  "type": "https://docs.otilm.com/problems/common/VALIDATION_FAILED",
+                  "title": "Validation failed",
+                  "status": 422,
+                  "detail": "resource type 'oids' is not supported",
+                  "errorCode": "VALIDATION_FAILED",
+                  "timestamp": "2026-08-04T10:00:00Z",
+                  "correlationId": "test-corr-initiate-422",
+                  "retryable": false
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/initiate")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(422)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(problemJson)));
+
+        DiscoveryInitiateRequestDto request = new DiscoveryInitiateRequestDto();
+        request.setRunId(RUN_ID);
+        request.setResources(List.of(Resource.CERTIFICATE));
+
+        ConnectorProblemException ex = Assertions.assertThrows(
+                ConnectorProblemException.class,
+                () -> client.initiate(connector, request));
+
+        Assertions.assertEquals(ErrorCode.VALIDATION_FAILED, ex.getProblemDetail().getErrorCode());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    @Test
+    void resume_410MapsToCheckpointLost() {
+        String problemJson = """
+                {
+                  "type": "https://docs.otilm.com/problems/connector/discovery/CHECKPOINT_LOST",
+                  "title": "Discovery checkpoint lost — run cannot be resumed",
+                  "status": 410,
+                  "detail": "checkpoint for runId 33333333-3333-3333-3333-333333333333 expired",
+                  "errorCode": "CHECKPOINT_LOST",
+                  "timestamp": "2026-08-04T10:00:00Z",
+                  "correlationId": "test-corr-resume-410",
+                  "retryable": false
+                }
+                """;
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/resume")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(410)
+                        .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                        .withBody(problemJson)));
+
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        request.setRunId(RUN_ID);
+
+        ConnectorProblemException ex = Assertions.assertThrows(
+                ConnectorProblemException.class,
+                () -> client.resume(connector, request));
+
+        Assertions.assertEquals(ErrorCode.CHECKPOINT_LOST, ex.getProblemDetail().getErrorCode());
+        Assertions.assertEquals(connector, ex.getConnector());
+    }
+
+    /**
+     * A {@code results} page larger than the configured read cap must fail fast — never buffer
+     * an unbounded/malicious response into memory.
+     *
+     * <p>The read cap is {@code ClientTuning.maxInMemorySize} on the shared {@code WebClient} —
+     * see {@code DiscoveryApiClient}'s class javadoc — so it can't be dialed down for just
+     * this test via the shared, process-wide {@code BaseApiClient.prepareWebClient()} singleton
+     * without either being ignored (if another test already claimed the default tuning first) or
+     * permanently shrinking the cap for every other test in the same JVM run. Instead this test
+     * builds its own throwaway {@code WebClient} with a small cap, proving the exact contract this
+     * client depends on: whatever cap the injected {@code WebClient} enforces, {@code results}
+     * surfaces the resulting failure through the standard error path rather than swallowing it.
+     *
+     * <p>The stubbed body is genuine, syntactically valid JSON — a real {@code DiscoveryResultsResponseDto}
+     * shape plus one padding field — sized comfortably over the cap, so the failure demonstrably
+     * comes from the size gate tripping before parsing, not from malformed input coincidentally
+     * failing around the same size.
+     *
+     * <p>The cap is enforced by the codec while decoding the (2xx) response body, a step that
+     * runs inside {@code WebClient.retrieve()} itself. Spring's {@code retrieve()} wraps any
+     * body-decode failure — including a codec limit breach — into a {@link WebClientResponseException}
+     * so the failure still carries the response's status/headers; the original
+     * {@link DataBufferLimitException} survives as its cause. {@code BaseApiClient.processRequest}
+     * now maps that (either shape) to {@code ConnectorServerException} (see {@code BaseApiClientTest}
+     * for that mapping's own direct coverage) — asserted here via the class this client's caller
+     * actually sees.
+     */
+    @Test
+    void results_oversizedResponse_failsInsteadOfBuffering() {
+        int smallCap = 8 * 1024;
+        DiscoveryApiClient smallCapClient = smallCapClient(smallCap);
+
+        // Genuinely valid JSON — a real DiscoveryResultsResponseDto shape with one oversized
+        // padding string — at 4x the cap (32 KB body against an 8 KB cap).
+        String oversizedBody = "{\"items\":[],\"highestSequence\":0,\"more\":false,\"padding\":\""
+                + "a".repeat(smallCap * 4) + "\"}";
+        mockServer.stubFor(WireMock.post("/v2/discoveryProvider/discoveries/results")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(oversizedBody)));
+
+        DiscoveryDrainRequestDto request = new DiscoveryDrainRequestDto();
+        request.setRunId(RUN_ID);
+
+        ConnectorServerException ex = Assertions.assertThrows(
+                ConnectorServerException.class,
+                () -> smallCapClient.results(connector, request));
+
+        // The status carried is the one the connector really sent (200), not a synthesized 413 — see
+        // BaseApiClient.upstreamStatus and BaseApiClientTest for that mapping's own coverage.
+        Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
+        Assertions.assertInstanceOf(WebClientResponseException.class, ex.getCause());
+        Assertions.assertInstanceOf(DataBufferLimitException.class, ex.getCause().getCause());
+    }
+
+    /**
+     * The read cap must bound a whole list response, not each of its elements.
+     *
+     * <p>This is the case the cap silently failed to cover: {@code toEntityList(X.class)} streams the
+     * array through Spring's {@code Jackson2Tokenizer}, whose {@code assertInMemorySize} resets its
+     * byte counter every time a top-level element completes, so the cap degrades into a per-element
+     * cap and the {@code collectList} that assembles the result is unbounded. Every element below is
+     * a couple of dozen bytes — far under the cap — while the array as a whole is several times over
+     * it, which is exactly the shape a connector returning a million tiny objects would produce, and
+     * exactly the shape an element-wise cap waves through. Decoding an array type instead routes
+     * through the codec's bounded {@code decodeToMono}, so the whole response is measured and the
+     * call fails rather than assembling.
+     */
+    @Test
+    void listSupportedResources_oversizedArrayOfSmallElements_failsInsteadOfAssembling() {
+        int smallCap = 8 * 1024;
+        DiscoveryApiClient smallCapClient = smallCapClient(smallCap);
+
+        // ~27 bytes per element, 1000 elements: no single element is anywhere near the cap, the array
+        // is roughly 3.5x over it.
+        String oversizedArray = "[" + String.join(",",
+                Collections.nCopies(1000, "{\"resource\":\"certificates\"}")) + "]";
+        Assertions.assertTrue(oversizedArray.length() > smallCap * 3,
+                "the stubbed array must be comfortably over the cap");
+        mockServer.stubFor(WireMock.get("/v2/discoveryProvider/resources")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(oversizedArray)));
+
+        ConnectorServerException ex = Assertions.assertThrows(
+                ConnectorServerException.class,
+                () -> smallCapClient.listSupportedResources(connector));
+
+        // As above: the connector's own status (200), never a synthesized 413.
+        Assertions.assertEquals(HttpStatus.OK, ex.getHttpStatus());
+    }
+
+    /**
+     * A throwaway {@code WebClient} with its own small read cap. The shared
+     * {@code BaseApiClient.prepareWebClient()} singleton cannot be re-tuned per test — see
+     * {@code results_oversizedResponse_failsInsteadOfBuffering} for why — so cap-sensitive cases
+     * build their own.
+     */
+    private DiscoveryApiClient smallCapClient(int maxInMemorySize) {
+        WebClient smallCapWebClient = WebClient.builder()
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(c -> c.defaultCodecs().maxInMemorySize(maxInMemorySize))
+                        .build())
+                .build();
+        return new DiscoveryApiClient(smallCapWebClient, null);
+    }
+
+    /** An RFC 9457 body whose {@code errorCode} the shared not-tracked rule must recognise. */
+    private static String notTrackedProblemJson(String errorCode, String type) {
+        return """
+                {
+                  "type": "%s",
+                  "title": "Async operation no longer tracked by connector",
+                  "status": 404,
+                  "detail": "runId 33333333-3333-3333-3333-333333333333 not tracked",
+                  "errorCode": "%s",
+                  "timestamp": "2026-08-04T10:00:00Z",
+                  "correlationId": "test-corr-cancel-404",
+                  "retryable": false
+                }
+                """.formatted(type, errorCode);
+    }
+
+    /**
+     * Spring's default unmapped-route error page: a 404 with no {@code application/problem+json} body,
+     * which is what a connector that never implemented the endpoint actually returns.
+     */
+    private static String springDefaultErrorPage() {
+        return "{\"timestamp\":\"2026-08-06T10:00:00Z\",\"status\":404,\"error\":\"Not Found\","
+                + "\"path\":\"" + CANCEL_PATH + "\"}";
+    }
+
+    /**
+     * Attach a recorder to this client's own logger so a test can assert on the events it emits.
+     *
+     * <p>logback-classic is this module's SLF4J provider (slf4j-simple is on the test classpath too
+     * but loses provider selection), so the SLF4J logger really is a logback one; asserting the type
+     * makes a provider change fail loudly instead of silently skipping the log assertions. The level
+     * is pinned so the assertions do not depend on the ambient root level, and restored to inherited
+     * afterwards — the module ships no logback configuration, so inherited is the original state.
+     */
+    private static ListAppender<ILoggingEvent> attachClientLogRecorder() {
+        Logger clientLogger = Assertions.assertInstanceOf(Logger.class,
+                LoggerFactory.getLogger(DiscoveryApiClient.class),
+                "expected logback-classic to be the active SLF4J provider");
+        ListAppender<ILoggingEvent> recorder = new ListAppender<>();
+        recorder.setContext(clientLogger.getLoggerContext());
+        recorder.start();
+        clientLogger.setLevel(Level.WARN);
+        clientLogger.addAppender(recorder);
+        return recorder;
+    }
+
+    private static void detachClientLogRecorder(ListAppender<ILoggingEvent> recorder) {
+        Logger clientLogger = (Logger) LoggerFactory.getLogger(DiscoveryApiClient.class);
+        clientLogger.detachAppender(recorder);
+        clientLogger.setLevel(null);
+        recorder.stop();
+    }
+
+    private static List<ILoggingEvent> warnings(ListAppender<ILoggingEvent> recorder) {
+        return recorder.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .toList();
+    }
+}

--- a/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
@@ -1,0 +1,579 @@
+package com.otilm.api.clients.mq.discovery.v2;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.discovery.v2.DiscoveryPaths;
+import com.otilm.api.clients.mq.ProxyClient;
+import com.otilm.api.exception.ConnectorEntityNotFoundException;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.v3.InfoAttributeV3;
+import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.common.error.ProblemDetailExtended;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryDrainRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryInitiateResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryRunRequestDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryStopResponseDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.connector.ConnectorDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Delegation tests for the MQ-based Discovery v2 client. Verifies each method reaches
+ * {@link ProxyClient} with the right connector, path, HTTP method, body, response type, and — the
+ * point of this class — the right per-operation {@code Duration}, and that what comes back is what
+ * the connector contract promises the caller.
+ *
+ * <p>No mocking framework is on this project's test classpath — only JUnit Jupiter and WireMock — so
+ * the proxy is a hand-written recording fake, matching
+ * {@code com.otilm.api.clients.mq.v2.AttributesApiClientMqTest}.
+ *
+ * <p>This class asserts against {@link DiscoveryPaths} constants while the REST suite hardcodes the
+ * same routes as literals. That split is deliberate: the literals are the independent pin, so a wrong
+ * constant fails there, and this class verifies only that both transports resolve the same constant.
+ * Do not convert the REST literals to constants — that would leave nothing checking the constants
+ * themselves.
+ *
+ * <p>The fake throws {@link AssertionError} from every {@code ProxyClient} overload that takes no
+ * {@code Duration}. That makes the constraint structural rather than per-test: any future call to a
+ * timeout-less overload fails at the call site, in whichever test provokes it, without needing to be
+ * asserted anywhere.
+ *
+ * <p>The three timeouts (11s/22s/33s) are deliberately distinguishable from one another and from
+ * {@link DiscoveryMqTimeouts#defaults()}, so a mis-mapped component — {@code results} wired to
+ * {@code control()} instead of {@code drain()}, say — fails rather than passing by coincidence.
+ *
+ * <p>Behavioural cases here never assert "the fake was reached" in place of an outcome: cancel's
+ * cases drive the fake into each shape the proxy can produce (a thrown not-tracked failure, a
+ * successful entity) and assert the {@code ResponseEntity} the caller actually receives.
+ */
+class DiscoveryApiClientMqTest {
+
+
+    private static final Duration STATUS_TIMEOUT = Duration.ofSeconds(11);
+    private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(22);
+    private static final Duration CONTROL_TIMEOUT = Duration.ofSeconds(33);
+
+    private RecordingProxyClient proxyClient;
+    private ConnectorDto connector;
+    private DiscoveryApiClient client;
+
+    @BeforeEach
+    void setUp() {
+        proxyClient = new RecordingProxyClient();
+        connector = new ConnectorDto();
+        connector.setUrl("http://localhost");
+        client = new DiscoveryApiClient(proxyClient, timeouts());
+    }
+
+    private static DiscoveryMqTimeouts timeouts() {
+        return new DiscoveryMqTimeouts(STATUS_TIMEOUT, DRAIN_TIMEOUT, CONTROL_TIMEOUT);
+    }
+
+    // ---- Metadata reads (GET, control timeout) ----
+
+    @Test
+    void listSupportedResources_delegatesGetWithControlTimeout() throws ConnectorException {
+        DiscoverySupportedResourceDto item = new DiscoverySupportedResourceDto();
+        proxyClient.syncResponse = new DiscoverySupportedResourceDto[]{item};
+
+        List<DiscoverySupportedResourceDto> result = client.listSupportedResources(connector);
+
+        Assertions.assertEquals(List.of(item), result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.RESOURCES, "GET", null, DiscoverySupportedResourceDto[].class, CONTROL_TIMEOUT);
+    }
+
+    @Test
+    void listRunAttributes_delegatesGetWithControlTimeout() throws ConnectorException {
+        BaseAttribute attribute = new InfoAttributeV3();
+        proxyClient.syncResponse = new BaseAttribute[]{attribute};
+
+        List<BaseAttribute> result = client.listRunAttributes(connector);
+
+        Assertions.assertEquals(List.of(attribute), result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.ATTRIBUTES, "GET", null, BaseAttribute[].class, CONTROL_TIMEOUT);
+    }
+
+    @Test
+    void listResourceAttributes_bindsResourceWireCodeIntoPath() throws ConnectorException {
+        BaseAttribute attribute = new InfoAttributeV3();
+        proxyClient.syncResponse = new BaseAttribute[]{attribute};
+
+        List<BaseAttribute> result = client.listResourceAttributes(connector, Resource.CERTIFICATE);
+
+        Assertions.assertEquals(List.of(attribute), result);
+        // The wire code, never the Java enum name: "certificates", not "CERTIFICATE".
+        proxyClient.assertCalled(connector, DiscoveryPaths.BASE + "/certificates/attributes", "GET", null, BaseAttribute[].class, CONTROL_TIMEOUT);
+    }
+
+    @Test
+    void listResourceAttributes_bindsKeyResourceWireCode() throws ConnectorException {
+        proxyClient.syncResponse = new BaseAttribute[0];
+
+        client.listResourceAttributes(connector, Resource.CRYPTOGRAPHIC_KEY);
+
+        proxyClient.assertCalled(connector, DiscoveryPaths.BASE + "/keys/attributes", "GET", null, BaseAttribute[].class, CONTROL_TIMEOUT);
+    }
+
+    // ---- Lifecycle (POST) ----
+
+    @Test
+    void initiate_delegatesPostWithControlTimeout() throws ConnectorException {
+        DiscoveryInitiateRequestDto request = new DiscoveryInitiateRequestDto();
+        DiscoveryInitiateResponseDto expected = new DiscoveryInitiateResponseDto();
+        proxyClient.syncResponse = expected;
+
+        DiscoveryInitiateResponseDto result = client.initiate(connector, request);
+
+        Assertions.assertSame(expected, result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.INITIATE, "POST", request, DiscoveryInitiateResponseDto.class, CONTROL_TIMEOUT);
+    }
+
+    @Test
+    void status_delegatesPostWithStatusTimeout() throws ConnectorException {
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        DiscoveryStatusResponseDto expected = new DiscoveryStatusResponseDto();
+        proxyClient.syncResponse = expected;
+
+        DiscoveryStatusResponseDto result = client.status(connector, request);
+
+        Assertions.assertSame(expected, result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.STATUS, "POST", request, DiscoveryStatusResponseDto.class, STATUS_TIMEOUT);
+    }
+
+    @Test
+    void results_delegatesPostWithDrainTimeout() throws ConnectorException {
+        DiscoveryDrainRequestDto request = new DiscoveryDrainRequestDto();
+        DiscoveryResultsResponseDto expected = new DiscoveryResultsResponseDto();
+        proxyClient.syncResponse = expected;
+
+        DiscoveryResultsResponseDto result = client.results(connector, request);
+
+        Assertions.assertSame(expected, result);
+        // The drain is the one operation allowed a longer budget than the rest.
+        proxyClient.assertCalled(connector, DiscoveryPaths.RESULTS, "POST", request, DiscoveryResultsResponseDto.class, DRAIN_TIMEOUT);
+    }
+
+    @Test
+    void stop_delegatesPostWithControlTimeout() throws ConnectorException {
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        DiscoveryStopResponseDto expected = new DiscoveryStopResponseDto();
+        proxyClient.syncResponse = expected;
+
+        DiscoveryStopResponseDto result = client.stop(connector, request);
+
+        Assertions.assertSame(expected, result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.STOP, "POST", request, DiscoveryStopResponseDto.class, CONTROL_TIMEOUT);
+    }
+
+    @Test
+    void resume_delegatesPostWithControlTimeout() throws ConnectorException {
+        DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+        DiscoveryInitiateResponseDto expected = new DiscoveryInitiateResponseDto();
+        proxyClient.syncResponse = expected;
+
+        DiscoveryInitiateResponseDto result = client.resume(connector, request);
+
+        Assertions.assertSame(expected, result);
+        proxyClient.assertCalled(connector, DiscoveryPaths.RESUME, "POST", request, DiscoveryInitiateResponseDto.class, CONTROL_TIMEOUT);
+    }
+
+    // ---- cancel: the one operation whose status is part of its contract ----
+
+    /**
+     * 204 is cancel's only contract success status, so whatever successful status the proxy reports —
+     * including the {@code 200} the interface default produces — must reach the caller as 204.
+     */
+    @Test
+    void cancel_normalizesEverySuccessfulProxyStatusToNoContent() throws ConnectorException {
+        for (HttpStatus proxyStatus : List.of(HttpStatus.NO_CONTENT, HttpStatus.OK, HttpStatus.ACCEPTED)) {
+            DiscoveryRunRequestDto request = new DiscoveryRunRequestDto();
+            proxyClient.syncResponse = ResponseEntity.status(proxyStatus).<Void>build();
+
+            ResponseEntity<Void> result = client.cancel(connector, request);
+
+            Assertions.assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode(),
+                    "cancel must answer 204 regardless of the successful status the proxy reported (" + proxyStatus + ")");
+            Assertions.assertNull(result.getBody());
+            proxyClient.assertCalled(connector, DiscoveryPaths.CANCEL, "POST", request, Void.class, CONTROL_TIMEOUT);
+            Assertions.assertTrue(proxyClient.viaSendRequestForEntity,
+                    "cancel must use sendRequestForEntity - its ResponseEntity<Void> return exists to carry the upstream status");
+        }
+    }
+
+    /**
+     * The composed case, with no override in the way: a proxy that leaves the {@code Duration}
+     * overload of {@code sendRequestForEntity} to the interface default — as {@code ProxyClientImpl}
+     * does today — still yields 204, because the client normalizes what the default wrapped in
+     * {@code ResponseEntity.ok}.
+     */
+    @Test
+    void cancel_yieldsNoContentEvenWhenTheProxyLeavesTheOverloadToTheInterfaceDefault() throws ConnectorException {
+        TimeoutCapturingProxyClient proxy = new TimeoutCapturingProxyClient(null);
+
+        ResponseEntity<Void> result = new DiscoveryApiClient(proxy, timeouts())
+                .cancel(connector, new DiscoveryRunRequestDto());
+
+        Assertions.assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        Assertions.assertEquals(CONTROL_TIMEOUT, proxy.seenTimeout);
+    }
+
+    /**
+     * The 404 the proxy classifies into {@link ConnectorEntityNotFoundException} is the run being
+     * untracked — already the terminal state cancel asked for. REST reports it as a 404 response, so
+     * MQ must too, or the identical call succeeds on one transport and hard-fails on the other.
+     */
+    @Test
+    void cancel_reportsANotTrackedRunAsNotFoundInsteadOfThrowing() throws ConnectorException {
+        proxyClient.failure = new ConnectorEntityNotFoundException("run 33333333 is not tracked");
+
+        ResponseEntity<Void> result = client.cancel(connector, new DiscoveryRunRequestDto());
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+    }
+
+    /**
+     * The same case in its problem+json shape, for when the proxy learns to relay a connector's
+     * {@code application/problem+json} body: classified by error code, not by transport status.
+     */
+    @Test
+    void cancel_reportsANotTrackedProblemAsNotFoundInsteadOfThrowing() throws ConnectorException {
+        proxyClient.failure = problem(ErrorCode.OPERATION_NOT_TRACKED);
+
+        ResponseEntity<Void> result = client.cancel(connector, new DiscoveryRunRequestDto());
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+    }
+
+    /**
+     * The not-tracked catch must stay narrow: the 422 past-the-point-of-no-return refusal is a real
+     * failure and may not be laundered into a 404 response.
+     */
+    @Test
+    void cancel_rethrowsAProblemThatIsNotAboutAnUntrackedRun() {
+        ConnectorProblemException refusal = problem(ErrorCode.OPERATION_PAST_POINT_OF_NO_RETURN);
+        proxyClient.failure = refusal;
+
+        ConnectorProblemException thrown = Assertions.assertThrows(ConnectorProblemException.class,
+                () -> client.cancel(connector, new DiscoveryRunRequestDto()));
+
+        Assertions.assertSame(refusal, thrown, "a refusal must reach the caller unchanged");
+    }
+
+    private static ConnectorProblemException problem(ErrorCode code) {
+        return new ConnectorProblemException(
+                ProblemDetailExtended.fromErrorCode(code, "simulated " + code, null, "test-corr-mq-cancel"));
+    }
+
+    // ---- Error propagation: this client adds no mapping of its own ----
+
+    @Test
+    void connectorExceptionPropagatesUnchangedFromEveryOperation() {
+        ConnectorException failure = new ConnectorException("simulated connector failure");
+        proxyClient.failure = failure;
+
+        assertPropagates(failure, () -> client.listSupportedResources(connector));
+        assertPropagates(failure, () -> client.listRunAttributes(connector));
+        assertPropagates(failure, () -> client.listResourceAttributes(connector, Resource.CERTIFICATE));
+        assertPropagates(failure, () -> client.initiate(connector, new DiscoveryInitiateRequestDto()));
+        assertPropagates(failure, () -> client.status(connector, new DiscoveryRunRequestDto()));
+        assertPropagates(failure, () -> client.results(connector, new DiscoveryDrainRequestDto()));
+        assertPropagates(failure, () -> client.stop(connector, new DiscoveryRunRequestDto()));
+        assertPropagates(failure, () -> client.resume(connector, new DiscoveryRunRequestDto()));
+        assertPropagates(failure, () -> client.cancel(connector, new DiscoveryRunRequestDto()));
+    }
+
+    private static void assertPropagates(ConnectorException expected, Executable call) {
+        ConnectorException thrown = Assertions.assertThrows(ConnectorException.class, call);
+        Assertions.assertSame(expected, thrown, "the MQ client must not wrap or re-map connector failures");
+    }
+
+    // ---- Bodiless responses: the proxy returns null when the relayed response had no body ----
+
+    /**
+     * A list route answering with no body at all is non-conformant, not empty — it must return a JSON
+     * array. Reading it as empty would make a broken connector indistinguishable from one that
+     * genuinely reports nothing, which for {@code listSupportedResources} is a distinction Core acts
+     * on. REST rejects it identically through {@code BaseApiClient.requireBody}, so this is the case
+     * that keeps the two transports from disagreeing.
+     */
+    @Test
+    void listOperationsFailNamingTheOperationOnABodilessResponse() {
+        proxyClient.syncResponse = null;
+
+        assertFailsNaming("listSupportedResources", () -> client.listSupportedResources(connector));
+        assertFailsNaming("listRunAttributes", () -> client.listRunAttributes(connector));
+        assertFailsNaming("listResourceAttributes", () -> client.listResourceAttributes(connector, Resource.CERTIFICATE));
+    }
+
+    @Test
+    void listOperationsReturnAMutableListWhenTheProxyHasABody() throws ConnectorException {
+        proxyClient.syncResponse = new BaseAttribute[]{new InfoAttributeV3()};
+
+        List<BaseAttribute> result = client.listRunAttributes(connector);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertDoesNotThrow(() -> result.add(new InfoAttributeV3()),
+                "the returned list must be mutable on both transports, not an Arrays.asList view");
+    }
+
+    /**
+     * The operations whose 2xx response must carry a payload fail loudly instead of handing
+     * {@code null} to Core, where it would resurface as an NPE attributed to no connector.
+     */
+    @Test
+    void singleValueOperationsFailNamingTheOperationOnABodilessResponse() {
+        proxyClient.syncResponse = null;
+
+        assertFailsNaming("initiate", () -> client.initiate(connector, new DiscoveryInitiateRequestDto()));
+        assertFailsNaming("status", () -> client.status(connector, new DiscoveryRunRequestDto()));
+        assertFailsNaming("results", () -> client.results(connector, new DiscoveryDrainRequestDto()));
+        assertFailsNaming("stop", () -> client.stop(connector, new DiscoveryRunRequestDto()));
+        assertFailsNaming("resume", () -> client.resume(connector, new DiscoveryRunRequestDto()));
+        // cancel has no body by contract, but it does need an entity to read the status from.
+        assertFailsNaming("cancel", () -> client.cancel(connector, new DiscoveryRunRequestDto()));
+    }
+
+    private void assertFailsNaming(String operation, Executable call) {
+        ConnectorException thrown = Assertions.assertThrows(ConnectorException.class, call);
+        Assertions.assertTrue(thrown.getMessage().contains(operation),
+                "the failure must name the operation, was: " + thrown.getMessage());
+        Assertions.assertSame(connector, thrown.getConnector(),
+                "the failure must be attributed to the connector that produced it");
+    }
+
+    // ---- Eager validation ----
+
+    @Test
+    void constructorsRejectNullCollaborators() {
+        DiscoveryMqTimeouts timeouts = timeouts();
+        ProxyClient noProxy = null;
+        Assertions.assertThrows(NullPointerException.class, () -> new DiscoveryApiClient(null, timeouts));
+        Assertions.assertThrows(NullPointerException.class, () -> new DiscoveryApiClient(proxyClient, null));
+        Assertions.assertThrows(NullPointerException.class, () -> new DiscoveryApiClient(noProxy));
+    }
+
+    // ---- DiscoveryMqTimeouts ----
+
+    @Test
+    void timeoutDefaultsAreThirtySecondsForEveryComponent() {
+        DiscoveryMqTimeouts defaults = DiscoveryMqTimeouts.defaults();
+
+        Assertions.assertEquals(Duration.ofSeconds(30), defaults.status());
+        Assertions.assertEquals(Duration.ofSeconds(30), defaults.drain());
+        Assertions.assertEquals(Duration.ofSeconds(30), defaults.control());
+    }
+
+    @Test
+    void timeoutsRejectNullComponents() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new DiscoveryMqTimeouts(null, DRAIN_TIMEOUT, CONTROL_TIMEOUT));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, null, CONTROL_TIMEOUT));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, DRAIN_TIMEOUT, null));
+    }
+
+    /**
+     * A 0ms or negative timeout must fail at construction, not as an immediate, puzzling timeout on
+     * the first connector call.
+     */
+    @Test
+    void timeoutsRejectNonPositiveComponents() {
+        Duration negative = Duration.ofSeconds(-1);
+
+        assertNotPositive("status", () -> new DiscoveryMqTimeouts(Duration.ZERO, DRAIN_TIMEOUT, CONTROL_TIMEOUT));
+        assertNotPositive("status", () -> new DiscoveryMqTimeouts(negative, DRAIN_TIMEOUT, CONTROL_TIMEOUT));
+        assertNotPositive("drain", () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, Duration.ZERO, CONTROL_TIMEOUT));
+        assertNotPositive("drain", () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, negative, CONTROL_TIMEOUT));
+        assertNotPositive("control", () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, DRAIN_TIMEOUT, Duration.ZERO));
+        assertNotPositive("control", () -> new DiscoveryMqTimeouts(STATUS_TIMEOUT, DRAIN_TIMEOUT, negative));
+    }
+
+    private static void assertNotPositive(String component, Executable construction) {
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, construction);
+        Assertions.assertTrue(thrown.getMessage().startsWith(component + " must be a positive duration"),
+                "the message must name the component and match the ClientTuning shape, was: " + thrown.getMessage());
+    }
+
+    @Test
+    void singleArgConstructorUsesTheDefaults() throws ConnectorException {
+        RecordingProxyClient fake = new RecordingProxyClient();
+        fake.syncResponse = new DiscoveryStatusResponseDto();
+
+        new DiscoveryApiClient(fake).status(connector, new DiscoveryRunRequestDto());
+
+        Assertions.assertEquals(Duration.ofSeconds(30), fake.timeout);
+    }
+
+    // ---- The ProxyClient default this task added ----
+
+    /**
+     * The new {@code sendRequestForEntity(…, Duration)} is a {@code default} method, so
+     * {@link RecordingProxyClient} overrides it and never exercises it. This covers the default body
+     * itself: it must forward the caller's timeout to {@code sendRequest} rather than drop it. The
+     * status the default produces is deliberately not asserted here — it is not the contract status,
+     * and {@code cancel} normalizes it; see
+     * {@link #cancel_yieldsNoContentEvenWhenTheProxyLeavesTheOverloadToTheInterfaceDefault()}.
+     */
+    @Test
+    void sendRequestForEntityDefaultForwardsTheCallersTimeout() throws ConnectorException {
+        DiscoveryStopResponseDto body = new DiscoveryStopResponseDto();
+        TimeoutCapturingProxyClient proxy = new TimeoutCapturingProxyClient(body);
+
+        ResponseEntity<DiscoveryStopResponseDto> response = proxy.sendRequestForEntity(
+                connector, DiscoveryPaths.STOP, "POST", null, DiscoveryStopResponseDto.class, DRAIN_TIMEOUT);
+
+        Assertions.assertEquals(DRAIN_TIMEOUT, proxy.seenTimeout);
+        Assertions.assertSame(body, response.getBody());
+    }
+
+    /**
+     * Implements only the abstract {@link ProxyClient} methods, so the interface's {@code default}
+     * {@code sendRequestForEntity} runs for real.
+     */
+    private static final class TimeoutCapturingProxyClient extends UnsupportedProxyClient {
+        private final Object response;
+        private Duration seenTimeout;
+
+        private TimeoutCapturingProxyClient(Object response) {
+            this.response = response;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body,
+                                 Class<T> responseType, Duration timeout) {
+            this.seenTimeout = timeout;
+            return (T) response;
+        }
+    }
+
+    /**
+     * Records the one call the client under test makes. Every overload without a {@code Duration}
+     * throws, so the "explicit timeout on every call" rule holds structurally.
+     *
+     * <p>The recorded connector is {@code seenConnector}, not {@code connector}: while it shared the
+     * enclosing test's field name, {@code assertCalled} compared the field with itself and could
+     * never fail, so nothing checked that the client forwards the caller's connector at all.
+     */
+    private static final class RecordingProxyClient extends UnsupportedProxyClient {
+        private ApiClientConnectorInfo seenConnector;
+        private String path;
+        private String method;
+        private Object body;
+        private Class<?> responseType;
+        private Duration timeout;
+        private boolean viaSendRequestForEntity;
+
+        private Object syncResponse;
+        private ConnectorException failure;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body,
+                                 Class<T> responseType, Duration timeout) throws ConnectorException {
+            record(connector, path, method, body, responseType, timeout, false);
+            return (T) syncResponse;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> ResponseEntity<T> sendRequestForEntity(ApiClientConnectorInfo connector, String path, String method,
+                                                         Object body, Class<T> responseType, Duration timeout) throws ConnectorException {
+            record(connector, path, method, body, responseType, timeout, true);
+            return (ResponseEntity<T>) syncResponse;
+        }
+
+        private void record(ApiClientConnectorInfo connector, String path, String method, Object body,
+                            Class<?> responseType, Duration timeout, boolean forEntity) throws ConnectorException {
+            this.seenConnector = connector;
+            this.path = path;
+            this.method = method;
+            this.body = body;
+            this.responseType = responseType;
+            this.timeout = timeout;
+            this.viaSendRequestForEntity = forEntity;
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        private void assertCalled(ApiClientConnectorInfo expectedConnector, String expectedPath, String expectedMethod,
+                                  Object expectedBody, Class<?> expectedResponseType, Duration expectedTimeout) {
+            Assertions.assertSame(expectedConnector, seenConnector, "the caller's connector must be forwarded unchanged");
+            Assertions.assertEquals(expectedPath, path);
+            Assertions.assertEquals(expectedMethod, method);
+            Assertions.assertSame(expectedBody, body);
+            Assertions.assertEquals(expectedResponseType, responseType);
+            Assertions.assertEquals(expectedTimeout, timeout, "wrong DiscoveryMqTimeouts component for this operation");
+        }
+    }
+
+    /**
+     * Base fake: every {@link ProxyClient} member the discovery client must not touch. The
+     * timeout-less overloads are the ones that matter — reaching one means an operation silently
+     * readopted the proxy's shared default timeout, which is exactly what this client exists to avoid.
+     */
+    private abstract static class UnsupportedProxyClient implements ProxyClient {
+
+        private static final String NO_TIMEOUT = "the discovery v2 MQ client must pass an explicit Duration on every call";
+
+        @Override
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType) {
+            throw new AssertionError(NO_TIMEOUT + " - timeout-less sendRequest was called for " + path);
+        }
+
+        @Override
+        public <T> ResponseEntity<T> sendRequestForEntity(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType) {
+            throw new AssertionError(NO_TIMEOUT + " - timeout-less sendRequestForEntity was called for " + path);
+        }
+
+        // sendRequest(…, Duration) is deliberately left abstract — it is the one overload the
+        // discovery client is allowed to call, so each concrete fake below supplies it.
+
+        @Override
+        public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Map<String, String> pathVariables, Object body, Class<T> responseType) {
+            throw new AssertionError(NO_TIMEOUT + " - the path-variable sendRequest overload takes no timeout");
+        }
+
+        @Override
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Object body, Class<T> responseType, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<T> sendRequestAsync(ApiClientConnectorInfo connector, String path, String method, Map<String, String> pathVariables, Object body, Class<T> responseType, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendFireAndForget(ApiClientConnectorInfo connector, String path, String method, Object body) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendFireAndForget(ApiClientConnectorInfo connector, String path, String method, Object body, String messageType) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
@@ -487,7 +487,7 @@ class DiscoveryApiClientMqTest {
         @SuppressWarnings("unchecked")
         public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Object body,
                                  Class<T> responseType, Duration timeout) throws ConnectorException {
-            record(connector, path, method, body, responseType, timeout, false);
+            capture(connector, path, method, body, responseType, timeout, false);
             return (T) syncResponse;
         }
 
@@ -495,11 +495,11 @@ class DiscoveryApiClientMqTest {
         @SuppressWarnings("unchecked")
         public <T> ResponseEntity<T> sendRequestForEntity(ApiClientConnectorInfo connector, String path, String method,
                                                          Object body, Class<T> responseType, Duration timeout) throws ConnectorException {
-            record(connector, path, method, body, responseType, timeout, true);
+            capture(connector, path, method, body, responseType, timeout, true);
             return (ResponseEntity<T>) syncResponse;
         }
 
-        private void record(ApiClientConnectorInfo connector, String path, String method, Object body,
+        private void capture(ApiClientConnectorInfo connector, String path, String method, Object body,
                             Class<?> responseType, Duration timeout, boolean forEntity) throws ConnectorException {
             this.seenConnector = connector;
             this.path = path;

--- a/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
@@ -49,17 +49,12 @@ import java.util.concurrent.CompletableFuture;
  * themselves.
  *
  * <p>The fake throws {@link AssertionError} from every {@code ProxyClient} overload that takes no
- * {@code Duration}. That makes the constraint structural rather than per-test: any future call to a
- * timeout-less overload fails at the call site, in whichever test provokes it, without needing to be
- * asserted anywhere.
+ * {@code Duration}, making the constraint structural: any future call to a timeout-less overload fails
+ * at the call site without needing to be asserted anywhere.
  *
- * <p>The three timeouts (11s/22s/33s) are deliberately distinguishable from one another and from
+ * <p>The three timeouts (11s/22s/33s) are distinguishable from one another and from
  * {@link DiscoveryMqTimeouts#defaults()}, so a mis-mapped component — {@code results} wired to
  * {@code control()} instead of {@code drain()}, say — fails rather than passing by coincidence.
- *
- * <p>Behavioural cases here never assert "the fake was reached" in place of an outcome: cancel's
- * cases drive the fake into each shape the proxy can produce (a thrown not-tracked failure, a
- * successful entity) and assert the {@code ResponseEntity} the caller actually receives.
  */
 class DiscoveryApiClientMqTest {
 
@@ -216,10 +211,9 @@ class DiscoveryApiClientMqTest {
     }
 
     /**
-     * The composed case, with no override in the way: a proxy that leaves the {@code Duration}
-     * overload of {@code sendRequestForEntity} to the interface default — as {@code ProxyClientImpl}
-     * does today — still yields 204, because the client normalizes what the default wrapped in
-     * {@code ResponseEntity.ok}.
+     * The composed case, with no override in the way: a proxy that leaves the {@code Duration} overload
+     * of {@code sendRequestForEntity} to the interface default still yields 204, because the client
+     * normalizes what the default wrapped in {@code ResponseEntity.ok}.
      */
     @Test
     void cancel_yieldsNoContentEvenWhenTheProxyLeavesTheOverloadToTheInterfaceDefault() throws ConnectorException {
@@ -234,8 +228,8 @@ class DiscoveryApiClientMqTest {
 
     /**
      * The 404 the proxy classifies into {@link ConnectorEntityNotFoundException} is the run being
-     * untracked — already the terminal state cancel asked for. REST reports it as a 404 response, so
-     * MQ must too, or the identical call succeeds on one transport and hard-fails on the other.
+     * untracked — already the terminal state cancel asked for. REST reports it as a 404 response, so MQ
+     * must too, or the identical call succeeds on one transport and hard-fails on the other.
      */
     @Test
     void cancel_reportsANotTrackedRunAsNotFoundInsteadOfThrowing() throws ConnectorException {
@@ -306,10 +300,9 @@ class DiscoveryApiClientMqTest {
 
     /**
      * A list route answering with no body at all is non-conformant, not empty — it must return a JSON
-     * array. Reading it as empty would make a broken connector indistinguishable from one that
-     * genuinely reports nothing, which for {@code listSupportedResources} is a distinction Core acts
-     * on. REST rejects it identically through {@code BaseApiClient.requireBody}, so this is the case
-     * that keeps the two transports from disagreeing.
+     * array. Reading it as empty would make a broken connector indistinguishable from one that genuinely
+     * reports nothing, which for {@code listSupportedResources} is a distinction Core acts on. REST
+     * rejects it identically through {@code BaseApiClient.requireBody}.
      */
     @Test
     void listOperationsFailNamingTheOperationOnABodilessResponse() {
@@ -423,11 +416,10 @@ class DiscoveryApiClientMqTest {
     // ---- The ProxyClient default this task added ----
 
     /**
-     * The new {@code sendRequestForEntity(…, Duration)} is a {@code default} method, so
-     * {@link RecordingProxyClient} overrides it and never exercises it. This covers the default body
-     * itself: it must forward the caller's timeout to {@code sendRequest} rather than drop it. The
-     * status the default produces is deliberately not asserted here — it is not the contract status,
-     * and {@code cancel} normalizes it; see
+     * {@code sendRequestForEntity(…, Duration)} is a {@code default} method that
+     * {@link RecordingProxyClient} overrides, so this covers the default body itself: it must forward
+     * the caller's timeout to {@code sendRequest} rather than drop it. The status it produces is not
+     * asserted — it is not the contract status, and {@code cancel} normalizes it; see
      * {@link #cancel_yieldsNoContentEvenWhenTheProxyLeavesTheOverloadToTheInterfaceDefault()}.
      */
     @Test
@@ -464,12 +456,11 @@ class DiscoveryApiClientMqTest {
     }
 
     /**
-     * Records the one call the client under test makes. Every overload without a {@code Duration}
-     * throws, so the "explicit timeout on every call" rule holds structurally.
+     * Records the one call the client under test makes.
      *
-     * <p>The recorded connector is {@code seenConnector}, not {@code connector}: while it shared the
-     * enclosing test's field name, {@code assertCalled} compared the field with itself and could
-     * never fail, so nothing checked that the client forwards the caller's connector at all.
+     * <p>The recorded connector must stay named {@code seenConnector}, not {@code connector}: sharing
+     * the enclosing test's field name makes {@code assertCalled} compare the field with itself, so it
+     * could never fail and nothing would check that the client forwards the caller's connector.
      */
     private static final class RecordingProxyClient extends UnsupportedProxyClient {
         private ApiClientConnectorInfo seenConnector;
@@ -525,9 +516,8 @@ class DiscoveryApiClientMqTest {
     }
 
     /**
-     * Base fake: every {@link ProxyClient} member the discovery client must not touch. The
-     * timeout-less overloads are the ones that matter — reaching one means an operation silently
-     * readopted the proxy's shared default timeout, which is exactly what this client exists to avoid.
+     * Base fake: every {@link ProxyClient} member the discovery client must not touch. Reaching a
+     * timeout-less overload means an operation silently readopted the proxy's shared default timeout.
      */
     private abstract static class UnsupportedProxyClient implements ProxyClient {
 
@@ -543,8 +533,8 @@ class DiscoveryApiClientMqTest {
             throw new AssertionError(NO_TIMEOUT + " - timeout-less sendRequestForEntity was called for " + path);
         }
 
-        // sendRequest(…, Duration) is deliberately left abstract — it is the one overload the
-        // discovery client is allowed to call, so each concrete fake below supplies it.
+        // sendRequest(…, Duration) is left abstract: it is the one overload the discovery client may
+        // call, so each concrete fake supplies it.
 
         @Override
         public <T> T sendRequest(ApiClientConnectorInfo connector, String path, String method, Map<String, String> pathVariables, Object body, Class<T> responseType) {

--- a/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
@@ -52,7 +52,6 @@ import java.util.concurrent.CompletableFuture;
  */
 class DiscoveryApiClientMqTest {
 
-
     private static final Duration STATUS_TIMEOUT = Duration.ofSeconds(11);
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(22);
     private static final Duration CONTROL_TIMEOUT = Duration.ofSeconds(33);
@@ -267,6 +266,26 @@ class DiscoveryApiClientMqTest {
                 ProblemDetailExtended.fromErrorCode(code, "simulated " + code, null, "test-corr-mq-cancel"));
     }
 
+    /**
+     * A not-tracked error code is only ever legitimate on a 404. {@code REGISTRATION_NOT_FOUND} is
+     * authority's flavour of not-tracked and is declared 422, and cancel's own 422 means the run is past
+     * the point of no return — so honouring the code without checking the status would answer a refused
+     * cancel, or a non-conformant authority code on a discovery route, as a successful cancellation.
+     */
+    @Test
+    void cancel_notTrackedCodeOnANon404_isNotSwallowedAsSuccess() {
+        ProblemDetailExtended problem = new ProblemDetailExtended();
+        problem.setStatus(HttpStatus.UNPROCESSABLE_ENTITY.value());
+        problem.setErrorCode(ErrorCode.REGISTRATION_NOT_FOUND);
+        proxyClient.failure = new ConnectorProblemException(problem);
+
+        ConnectorException thrown = Assertions.assertThrows(ConnectorException.class,
+                () -> client.cancel(connector, new DiscoveryRunRequestDto()));
+
+        Assertions.assertSame(proxyClient.failure, thrown,
+                "a 422 must reach the caller, whatever error code it carries");
+    }
+
     // ---- Error propagation: this client adds no mapping of its own ----
 
     @Test
@@ -407,7 +426,7 @@ class DiscoveryApiClientMqTest {
         Assertions.assertEquals(Duration.ofSeconds(30), fake.timeout);
     }
 
-    // ---- The ProxyClient default this task added ----
+    // ---- ProxyClient default overload ----
 
     /**
      * {@code sendRequestForEntity(…, Duration)} is a {@code default} method that

--- a/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
+++ b/src/test/java/com/otilm/api/clients/mq/discovery/v2/DiscoveryApiClientMqTest.java
@@ -33,28 +33,22 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Delegation tests for the MQ-based Discovery v2 client. Verifies each method reaches
- * {@link ProxyClient} with the right connector, path, HTTP method, body, response type, and — the
- * point of this class — the right per-operation {@code Duration}, and that what comes back is what
- * the connector contract promises the caller.
+ * Delegation tests for the MQ Discovery v2 client: each method must reach {@link ProxyClient} with the
+ * right connector, path, method, body and response type, with the right per-operation {@code Duration},
+ * and must return what the contract promises the caller.
  *
- * <p>No mocking framework is on this project's test classpath — only JUnit Jupiter and WireMock — so
- * the proxy is a hand-written recording fake, matching
- * {@code com.otilm.api.clients.mq.v2.AttributesApiClientMqTest}.
+ * <p>The proxy is a hand-written recording fake because no mocking framework is on this project's test
+ * classpath, matching {@code com.otilm.api.clients.mq.v2.AttributesApiClientMqTest}. It throws
+ * {@link AssertionError} from every {@code ProxyClient} overload lacking a {@code Duration}, which makes
+ * the explicit-timeout rule structural — a future call to one fails at the call site, unasserted.
  *
- * <p>This class asserts against {@link DiscoveryPaths} constants while the REST suite hardcodes the
- * same routes as literals. That split is deliberate: the literals are the independent pin, so a wrong
- * constant fails there, and this class verifies only that both transports resolve the same constant.
- * Do not convert the REST literals to constants — that would leave nothing checking the constants
- * themselves.
+ * <p>The three timeouts (11s/22s/33s) differ from each other and from
+ * {@link DiscoveryMqTimeouts#defaults()}, so a mis-mapped component fails rather than passing by
+ * coincidence.
  *
- * <p>The fake throws {@link AssertionError} from every {@code ProxyClient} overload that takes no
- * {@code Duration}, making the constraint structural: any future call to a timeout-less overload fails
- * at the call site without needing to be asserted anywhere.
- *
- * <p>The three timeouts (11s/22s/33s) are distinguishable from one another and from
- * {@link DiscoveryMqTimeouts#defaults()}, so a mis-mapped component — {@code results} wired to
- * {@code control()} instead of {@code drain()}, say — fails rather than passing by coincidence.
+ * <p>This class asserts against {@link DiscoveryPaths} constants while the REST suite hardcodes the same
+ * routes as literals. Keep it that way: the literals are the independent pin on the constants, and
+ * converting them would leave nothing checking the constants at all.
  */
 class DiscoveryApiClientMqTest {
 


### PR DESCRIPTION
Closes #815. Stacked on the discovery v2 contract (#825, merged), now rebased onto `main`.

The clients Core calls to drive a discovery v2 run: one transport-agnostic interface, two implementations, and the shared-client changes both of them need.

## What this adds

- **`interfaces/client/v2/DiscoverySyncApiClient`** — the surface both transports implement. Named to match every other transport pair in this library: one simple name, the package carrying the transport, as `clients/DiscoveryApiClient` and `clients/mq/DiscoveryApiClient` already do for v1.
- **`clients/discovery/v2/DiscoveryApiClient`** — REST.
- **`clients/mq/discovery/v2/DiscoveryApiClient`** + `DiscoveryMqTimeouts` — MQ, where every call passes an explicit `Duration` rather than inheriting the proxy's single default, because a drain can legitimately run far longer than a status poll.
- **`DiscoveryPaths`** — the eleven routes defined once, imported by both clients.
- **`ProxyClient`** gains a `Duration`-taking `sendRequestForEntity`, as a `default` method. `cancel` needs the upstream status and no timeout-aware overload existed, so the two requirements were previously unsatisfiable together. Default rather than abstract because `ProxyClient` is implemented outside this repository.
- **Shared client changes** in `BaseApiClient`/`ClientTuning`, kept as their own commit because that class is used by every connector client in the library, not just discovery.

## Decisions worth reviewing

**No `stream` method anywhere.** NDJSON streaming cannot cross the AMQP proxy, which carries one message per call, so it can only ever be REST — and no client implements it yet. Both javadocs say so rather than implying one exists.

**The two transports are held to identical behaviour, deliberately.** Three defects found in review were all the same shape — the same logical call behaving differently depending on which transport served it:
- `cancel` reported a not-tracked run as a hard failure over MQ while REST returned it as a 404 the contract calls an already-terminal cancellation. Core's `ProxyClientImpl` maps any 404 to a thrown exception, so the `ResponseEntity<Void>` return existed for nothing on that path.
- `cancel` returned 200 over MQ where the contract declares 204. Core's v3 authority adapter branches on exact status values and throws on anything unexpected, so it is normalized here rather than waiting on the Core override.
- A bodiless list response read as an empty list over MQ and was rejected over REST. A list route answering with no body is non-conformant, not empty: reading it as empty makes a broken connector indistinguishable from one that genuinely reports nothing, which for `listSupportedResources` is a distinction Core acts on.

**The read cap now actually bounds list responses.** `toEntityList` streams through `Jackson2Tokenizer`, which resets its byte count per completed element, so `collectList()` had no whole-response bound — a connector returning a million small objects was unbounded regardless of `maxInMemorySize`. Verified against spring-web 6.2.19 sources. The list operations decode arrays through `toEntity`, which routes via `DataBufferUtils.join` and is bounded.

**An unparseable connector response reports 502, not 422.** This branch was removed from #825 during review — it had no consumer there — and it lands here reclassified. `ValidationException` maps to 422 through the same handler and body Core serves for a caller's *own* invalid input, so the old classification blamed the user for a connector fault and inverted the retry signal. Being checked, it also leaves the roughly 36 `catch (ConnectorException)` sites in Core behaving as they did.

**The type-resolution log no longer carries Jackson's message**, which quotes fragments of the response body — for discovery, potentially key material. Type and connector are logged; the cause rides on the thrown exception.

## For Core to know before bumping

A bodiless 4xx or 5xx from a connector now arrives as a mapped `ConnectorException` where it previously escaped as `IllegalStateException`. `bodyToMono` completes empty for a zero-length body, so the mapping never ran — realistic in practice, since a Go connector's `w.WriteHeader(404)` sends no body. Existing `catch (ConnectorException)` handlers will start seeing a case they never have; `CertificateStatusPollListener` sits on the JMS retry/DLQ boundary and is called out in OmniTrustILM/core#1961.

Also owed in Core, both tracked: `ProxyClientImpl` must override the new `sendRequestForEntity` overload to preserve the real upstream status (core#1961), and relaying `problem+json` across the proxy hop so `ErrorCode` survives it (core#1990 — that one fixes two live authority defects and is not specific to discovery).

## Verification

`mvn -B verify javadoc:jar` green: **685 tests, 0 failures**. Beyond coverage:

- The MQ test proxy throws `AssertionError` from every `ProxyClient` overload lacking a `Duration`, which makes "explicit timeout on every call" structural rather than per-test — a future call to one fails at the call site, in whichever test provokes it.
- The REST suite pins serialized request bodies, not just paths and verbs, so a client that dropped `.body()` or lost `runId` cannot pass.
- Every behavioural fix was mutation-tested: reverted alone against a green tree to confirm a test actually fails. Two tests were found vacuous that way and rewritten — the `meta` `toString` assertion and the message-leak guard, the latter because nesting the Jackson failure in a `DecodingException` meant the interpolated message was the wrapper's and the secret could never have appeared.

One coverage limit worth stating: the log line's argument list is not tested. slf4j-simple binds its stream at initialization so swapping `System.err` does not capture it, and no mocking framework is on this classpath. The outward exception message is guarded; the log rests on review.
