### PR TITLE
Add a cause-taking constructor to SchedulerException

### DIFF
--- a/src/main/java/com/otilm/api/exception/SchedulerException.java
+++ b/src/main/java/com/otilm/api/exception/SchedulerException.java
@@ -5,4 +5,8 @@ public class SchedulerException extends Exception implements PlatformException {
     public SchedulerException(String message) {
         super(message);
     }
+
+    public SchedulerException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
**Adds `SchedulerException(String message, Throwable cause)`.** Purely additive — the existing `(String)` constructor is untouched, so nothing that compiles today stops compiling.

### Why

`SchedulerException` is the only platform exception in its family that cannot carry a cause. Callers that wrap a lower-level failure are forced to discard it:

```java
} catch (org.quartz.SchedulerException e) {
    logger.error("Unable to schedule job {}", schedulerDetail.getJobName(), e);
    throw new SchedulerException(e.getMessage());   // cause dropped
}
```

The message survives, the exception does not. In the scheduler service that pattern repeats at **five** call sites. Downstream, `SchedulerException` has no dedicated `@ExceptionHandler`, so it falls through to the generic `handleException(Exception)` → HTTP 500, which logs a stack trace rooted in the service method with **no `Caused by:` section**. The frames identifying the actual Quartz failure are absent from that line.

### Why a constructor rather than `initCause`

`initCause(e)` does work here — `super(message)` leaves the `cause` field at its uninitialised sentinel, so it does not throw `IllegalStateException`. But it costs three lines at every call site:

```java
final SchedulerException wrapped = new SchedulerException(e.getMessage());
wrapped.initCause(e);
throw wrapped;
```

That is boilerplate whose only purpose is to route around a missing constructor, repeated five times in one file. Fixing it once here removes the need everywhere.

### Consistency

`(String, Throwable)` is the standard `Throwable` shape and is already present on **nine** sibling exceptions in `com.otilm.api.exception`: `CbomRepositoryException`, `CertificateRequestException`, `ConnectorClientException`, `ConnectorCommunicationException`, `ConnectorException`, `ConnectorServerException`, `DiscoveryException`, `MessageHandlingException` and `ScepException`. This brings `SchedulerException` in line with them; the implementation matches their form exactly.

### Verification

`mvn verify` passes on this branch — **627 tests, 0 failures**.

### Follow-up

Consumed by OmniTrustILM/scheduler#112, which currently carries a private `initCause` helper as a stopgap. Once this is released, that helper is deleted and the five call sites become `throw new SchedulerException(e.getMessage(), e);`.